### PR TITLE
CI hardening, fuzz baseline, and CII docs readiness

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default owner for repository changes
+* @nuetzliches
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
 
+permissions: read-all
+
 jobs:
   test:
     strategy:
@@ -11,9 +13,9 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.x"
       - name: Test
@@ -22,9 +24,9 @@ jobs:
   release-package-dryrun:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.x"
       - name: Generate Ephemeral Signing Key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,8 @@ on:
   push:
   pull_request:
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   test:

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -6,17 +6,18 @@ on:
       - "v*"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  packages: write
-  id-token: write
-  attestations: write
+permissions: read-all
 
 jobs:
   publish-ghcr:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Compute Build Metadata
         id: build_meta
@@ -26,13 +27,13 @@ jobs:
           echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -40,7 +41,7 @@ jobs:
 
       - name: Docker Metadata
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -56,7 +57,7 @@ jobs:
 
       - name: Build and Push Image
         id: build_push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
           context: .
           push: true
@@ -70,7 +71,7 @@ jobs:
             BUILD_DATE=${{ steps.build_meta.outputs.build_date }}
 
       - name: Attest Build Provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-name: ghcr.io/${{ github.repository }}
           subject-digest: ${{ steps.build_push.outputs.digest }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,19 +8,20 @@ on:
       - synchronize
       - ready_for_review
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   auto-merge:
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
         continue-on-error: true
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependency-health.yml
+++ b/.github/workflows/dependency-health.yml
@@ -21,22 +21,39 @@ on:
     - cron: "25 6 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.x"
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: Run govulncheck
         run: govulncheck ./...
+
+  fuzz:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version: "1.25.x"
+
+      - name: Run fuzz smoke tests
+        run: |
+          go test -run=^$ -fuzz=FuzzParseFormatRoundTrip -fuzztime=15s ./internal/config
+          go test -run=^$ -fuzz=FuzzPullAPIServer -fuzztime=15s ./internal/pullapi
+          go test -run=^$ -fuzz=FuzzHMACAuthVerify -fuzztime=15s ./internal/ingress

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,7 @@ on:
       - "mkdocs.yml"
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: read-all
 
 concurrency:
   group: pages
@@ -21,19 +18,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material==9.7.1
       - run: mkdocs build --strict
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: site
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,18 +5,19 @@ on:
     tags:
       - "v*"
 
-permissions:
-  contents: write
-  id-token: write
-  attestations: write
+permissions: read-all
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: "1.25.x"
       - name: Compute Safe Version Fragment
@@ -60,12 +61,12 @@ jobs:
         run: go run ./cmd/hookaido verify-release --checksums "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_checksums.txt" --require-signature --require-sbom
       - name: Attest Build Provenance
         id: attest_provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
         with:
           subject-checksums: "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_checksums.txt"
       - name: Attest SBOM
         id: attest_sbom
-        uses: actions/attest-sbom@v3
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3
         with:
           subject-checksums: "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_checksums.txt"
           sbom-path: "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_sbom.spdx.json"
@@ -74,7 +75,7 @@ jobs:
           cp "${{ steps.attest_provenance.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_provenance.attestation.json"
           cp "${{ steps.attest_sbom.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_sbom.attestation.json"
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2
         with:
           files: dist/*
           generate_release_notes: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -17,6 +17,10 @@ jobs:
     permissions:
       security-events: write
       id-token: write
+      contents: read
+      issues: read
+      pull-requests: read
+      checks: read
 
     steps:
       - name: Checkout
@@ -29,6 +33,8 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Optional: set SCORECARD_TOKEN (fine-grained PAT) to read classic branch protection rules.
+          repo_token: ${{ secrets.SCORECARD_TOKEN != '' && secrets.SCORECARD_TOKEN || github.token }}
           publish_results: true
 
       - name: Upload Scorecard artifact

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -27,7 +27,7 @@ Prioritized work items for Hookaido pre-v1.0. Items are grouped by priority tier
 - [ ] **Optional gRPC worker API (Phase 2)** — Add an opt-in gRPC surface for internal worker flows (`dequeue`, `ack`, `nack`, `extend`) with auth parity (mTLS/token), while keeping HTTP Pull/Admin APIs as the default and preserving current runtime semantics.
 - [x] **~~Scorecard: fuzzing baseline~~** — Moved to Completed.
 - [x] **~~Scorecard: API visibility/auth follow-up~~** — Moved to Completed.
-- [ ] **CII Best Practices badge** — Start and complete OpenSSF best-practices badge questionnaire for the repository.
+- [ ] **CII Best Practices badge** — Submit and maintain the OpenSSF best-practices badge questionnaire on bestpractices.dev (external/manual step).
 - [x] **~~Config `diff` CLI command~~** — `hookaido config diff old.hcl new.hcl` with exit code semantics (0=identical, 1=changed, 2=error); diff engine extracted to shared `config.FormatDiff`; 6 CLI tests (moved to Completed).
 - [x] **~~VS Code Extension (Hookaidofile)~~** — TextMate grammar, 18 snippets, file association for `Hookaidofile`/`.hookaido`/`.hkd` (moved to Completed). _Optional Phase 2: LSP backed by `config validate`/`config compile` for live diagnostics._
 - [x] **~~Graceful shutdown draining~~** — PushDispatcher uses internal stopCh+WaitGroup lifecycle; Drain(timeout) completes in-flight deliveries on SIGTERM; 3 drain unit tests + E2E coverage (moved to Completed).
@@ -36,6 +36,7 @@ Prioritized work items for Hookaido pre-v1.0. Items are grouped by priority tier
 
 ## Completed (move here when done)
 
+- [x] **CII badge readiness docs** — Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, `GOVERNANCE.md`, and `.github/CODEOWNERS`; linked governance/security docs from `README.md` and `docs/index.md` to prepare badge evidence links.
 - [x] **Scorecard: API visibility/auth follow-up** — Updated `scorecard.yml` with explicit read permissions (`contents`, `issues`, `pull-requests`, `checks`) to prevent check-run auth gaps, and added optional `SCORECARD_TOKEN` passthrough for classic branch-protection visibility.
 - [x] **Scorecard: fuzzing baseline** — Added baseline Go fuzz targets for config parse/format round-trip, Pull API auth/HTTP handlers, and ingress HMAC verification; wired scheduled fuzz smoke runs into `dependency-health` CI.
 - [x] **Scorecard: branch protection + review policy enforcement** — Applied `main` branch protection policy in GitHub (required PR reviews: 1 approval + last-push approval, stale-review dismissal, required conversation resolution, linear history, enforce admins, and required CI checks).

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -22,9 +22,12 @@ Prioritized work items for Hookaido pre-v1.0. Items are grouped by priority tier
 
 - [x] **~~Vault secret adapter~~** — Moved to Completed.
 - [x] **~~Full code review and polish pass~~** — Moved to Completed.
-- [ ] **Branding: project logo** — Create a production-ready Hookaido logo (SVG + PNG variants) and define basic usage guidance (light/dark backgrounds, minimum size, spacing).
+- [x] **Branding: project logo** — Create a production-ready Hookaido logo (SVG + PNG variants) and define basic usage guidance (light/dark backgrounds, minimum size, spacing).
 - [ ] **Documentation UX refresh** — Improve docs structure and landing experience (hero page), add command-palette style Ctrl+K search, and evaluate whether to keep the current docs stack or migrate to an alternative OSS docs solution.
 - [ ] **Optional gRPC worker API (Phase 2)** — Add an opt-in gRPC surface for internal worker flows (`dequeue`, `ack`, `nack`, `extend`) with auth parity (mTLS/token), while keeping HTTP Pull/Admin APIs as the default and preserving current runtime semantics.
+- [x] **~~Scorecard: fuzzing baseline~~** — Moved to Completed.
+- [x] **~~Scorecard: API visibility/auth follow-up~~** — Moved to Completed.
+- [ ] **CII Best Practices badge** — Start and complete OpenSSF best-practices badge questionnaire for the repository.
 - [x] **~~Config `diff` CLI command~~** — `hookaido config diff old.hcl new.hcl` with exit code semantics (0=identical, 1=changed, 2=error); diff engine extracted to shared `config.FormatDiff`; 6 CLI tests (moved to Completed).
 - [x] **~~VS Code Extension (Hookaidofile)~~** — TextMate grammar, 18 snippets, file association for `Hookaidofile`/`.hookaido`/`.hkd` (moved to Completed). _Optional Phase 2: LSP backed by `config validate`/`config compile` for live diagnostics._
 - [x] **~~Graceful shutdown draining~~** — PushDispatcher uses internal stopCh+WaitGroup lifecycle; Drain(timeout) completes in-flight deliveries on SIGTERM; 3 drain unit tests + E2E coverage (moved to Completed).
@@ -33,6 +36,10 @@ Prioritized work items for Hookaido pre-v1.0. Items are grouped by priority tier
 
 ## Completed (move here when done)
 
+- [x] **Scorecard: API visibility/auth follow-up** — Updated `scorecard.yml` with explicit read permissions (`contents`, `issues`, `pull-requests`, `checks`) to prevent check-run auth gaps, and added optional `SCORECARD_TOKEN` passthrough for classic branch-protection visibility.
+- [x] **Scorecard: fuzzing baseline** — Added baseline Go fuzz targets for config parse/format round-trip, Pull API auth/HTTP handlers, and ingress HMAC verification; wired scheduled fuzz smoke runs into `dependency-health` CI.
+- [x] **Scorecard: branch protection + review policy enforcement** — Applied `main` branch protection policy in GitHub (required PR reviews: 1 approval + last-push approval, stale-review dismissal, required conversation resolution, linear history, enforce admins, and required CI checks).
+- [x] **Scorecard CI hardening (permissions + pinning)** — Updated workflows to least-privilege permission scopes, pinned GitHub Actions by commit SHA, pinned Docker base images by digest, and pinned CI tool install versions for Scorecard `Token-Permissions`/`Pinned-Dependencies` improvements.
 - [x] **Secret preflight validation mode (nice-to-have)** — Added optional strict validation preflight for secret refs (`hookaido config validate --strict-secrets` and MCP `config_validate strict_secrets=true`) to load refs and fail early on missing env vars, unreadable files, or Vault access/connectivity errors.
 - [x] **Full code review and polish pass** — End-to-end review executed (`go test ./...`, `go vet ./...`) with prioritized findings and targeted fix: compile-time secret-ref scheme validation added for token/signing/value refs; docs/changelog synchronized.
 - [x] **Vault secret adapter** — Added `vault:` secret refs with Vault HTTP API support (KV v1/v2 field extraction), optional namespace/TLS env settings, and unit tests.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,31 @@
+# Code of Conduct
+
+## Our Commitment
+
+Hookaido contributors and maintainers are committed to a respectful, inclusive, and constructive collaboration environment.
+
+## Expected Behavior
+
+- Be respectful in language and tone.
+- Assume good intent and discuss ideas on technical merit.
+- Give actionable feedback.
+- Accept feedback gracefully.
+
+## Unacceptable Behavior
+
+- Harassment, discrimination, or personal attacks.
+- Trolling, intimidation, or sustained disruption.
+- Publishing private information without consent.
+
+## Reporting
+
+- For private reports, use GitHub private reporting to contact maintainers:
+  - `https://github.com/nuetzliches/hookaido/security/advisories/new`
+- For non-sensitive community concerns, open an issue in this repository.
+
+All reports will be reviewed by maintainers and handled in good faith.
+
+## Enforcement
+
+Maintainers may take any action necessary to protect the project and community, including warning, temporary restriction, or removal from project spaces.
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Hookaido
+
+Thanks for contributing to Hookaido.
+
+## Before You Start
+
+- Be respectful and collaborative. See `CODE_OF_CONDUCT.md`.
+- For security issues, do **not** open a public issue. See `SECURITY.md`.
+- Check `BACKLOG.md` before starting larger work to align with project priorities.
+
+## Development Setup
+
+1. Install Go `1.25.x` (see `go.mod`).
+2. Clone the repository.
+3. Run tests:
+
+```bash
+go test ./...
+```
+
+## Change Expectations
+
+- Keep changes focused and small where possible.
+- Add or update tests for behavior changes.
+- Keep docs in sync for user-visible behavior:
+  - `DESIGN.md` for DSL/API/runtime semantics.
+  - `CHANGELOG.md` for user-visible behavior changes.
+  - `BACKLOG.md` for priority and completion tracking.
+  - `STATUS.md` only for milestone-level shifts.
+
+## Pull Requests
+
+1. Create a branch from `main`.
+2. Make changes with tests and docs as needed.
+3. Open a pull request with:
+   - what changed,
+   - why it changed,
+   - how it was validated.
+
+PRs must pass CI and branch protection checks before merge.
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # --- Build stage ---
-FROM golang:1.25-alpine AS build
+FROM golang:1.25-alpine@sha256:f6751d823c26342f9506c03797d2527668d095b0a15f1862cddb4d927a7a4ced AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -14,7 +14,7 @@ RUN CGO_ENABLED=0 go build \
     -o /hookaido ./cmd/hookaido
 
 # --- Runtime stage ---
-FROM alpine:3.23
+FROM alpine:3.23@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659
 RUN apk add --no-cache ca-certificates tzdata && \
     adduser -D -h /app hookaido
 WORKDIR /app

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,30 @@
+# Governance
+
+## Project Ownership
+
+Hookaido is maintained in the `nuetzliches/hookaido` repository.
+
+Current maintainer:
+
+- `@nuetzliches`
+
+## Decision Process
+
+- Routine technical decisions happen in pull requests.
+- Significant changes should be discussed in issues before implementation.
+- Maintainers make final merge decisions when consensus is not reached.
+
+## Roles
+
+- **Contributors**: submit issues, docs, tests, and code changes.
+- **Maintainers**: review and merge changes, manage releases, and enforce project policies.
+
+## Release and Security Authority
+
+- Maintainers are responsible for release tagging and artifact publication.
+- Security handling follows `SECURITY.md`.
+
+## Becoming a Maintainer
+
+New maintainers may be invited based on sustained, high-quality contributions, review participation, and alignment with project direction.
+

--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ Releases ship with signed checksums (Ed25519), SPDX SBOM, and GitHub provenance 
 | [docs/](docs/index.md)           | User-facing documentation (getting started, configuration, APIs, deployment) |
 | [docs/docker.md](docs/docker.md) | Docker / Docker Compose quickstart                                           |
 | [DESIGN.md](DESIGN.md)           | Canonical DSL and API specification                                          |
+| [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution workflow and expectations                                      |
+| [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Community conduct expectations                                       |
+| [SECURITY.md](SECURITY.md)       | Vulnerability reporting and security response policy                         |
+| [SUPPORT.md](SUPPORT.md)         | Support channels and issue quality guidance                                  |
+| [GOVERNANCE.md](GOVERNANCE.md)   | Maintainer roles and decision process                                        |
 | [CHANGELOG.md](CHANGELOG.md)     | User-visible changes                                                         |
 | [STATUS.md](STATUS.md)           | Development progress snapshot                                                |
 | [BACKLOG.md](BACKLOG.md)         | Prioritized work items                                                       |

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Releases ship with signed checksums (Ed25519), SPDX SBOM, and GitHub provenance 
 | -------------------------------- | ---------------------------------------------------------------------------- |
 | [docs/](docs/index.md)           | User-facing documentation (getting started, configuration, APIs, deployment) |
 | [docs/docker.md](docs/docker.md) | Docker / Docker Compose quickstart                                           |
+| [docs/ossf-best-practices.md](docs/ossf-best-practices.md) | OpenSSF badge evidence and checklist             |
 | [DESIGN.md](DESIGN.md)           | Canonical DSL and API specification                                          |
 | [CONTRIBUTING.md](CONTRIBUTING.md) | Contribution workflow and expectations                                      |
 | [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md) | Community conduct expectations                                       |

--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
 # Hookaido
 
-<p align="center">
-  <img src="docs/assets/logo/hookaido-logo.svg" alt="Hookaido logo" width="180">
-</p>
-
 [![CI](https://github.com/nuetzliches/hookaido/actions/workflows/ci.yml/badge.svg)](https://github.com/nuetzliches/hookaido/actions/workflows/ci.yml)
 [![Release](https://github.com/nuetzliches/hookaido/actions/workflows/release.yml/badge.svg)](https://github.com/nuetzliches/hookaido/actions/workflows/release.yml)
 [![Container CI](https://github.com/nuetzliches/hookaido/actions/workflows/container.yml/badge.svg)](https://github.com/nuetzliches/hookaido/actions/workflows/container.yml)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,11 @@ Releases ship with signed checksums (Ed25519), SPDX SBOM, and GitHub provenance 
 - Docker: use the official image `ghcr.io/nuetzliches/hookaido` (or build locally), see [Docker quickstart](docs/docker.md)
 - No external runtime dependencies
 
+## Maintainer Notes
+
+- OpenSSF Scorecard runs with `GITHUB_TOKEN` by default.
+- If the repository uses **classic branch protection rules**, add a repository secret `SCORECARD_TOKEN` (fine-grained PAT with `Administration: Read-only`) so the `Branch-Protection` check can be evaluated fully.
+
 ## Documentation
 
 | Document                         | Purpose                                                                      |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+| ------- | --------- |
+| `main`  | Yes       |
+| `v1.x`  | Yes       |
+| `< v1`  | No        |
+
+## Reporting a Vulnerability
+
+Please report vulnerabilities privately via GitHub Security Advisories:
+
+- `https://github.com/nuetzliches/hookaido/security/advisories/new`
+
+Do not open public issues for unpatched vulnerabilities.
+
+## What to Include
+
+- Affected version/commit
+- Reproduction steps or proof of concept
+- Impact assessment
+- Suggested remediation (if available)
+
+## Response Targets
+
+- Initial acknowledgement: within 3 business days
+- Triage and severity assessment: within 7 business days
+- Remediation timeline: based on severity and risk
+
+## Disclosure
+
+We follow coordinated disclosure. Once a fix is available, maintainers publish release notes and, if applicable, a security advisory.
+

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,21 @@
+# Support
+
+## Getting Help
+
+- Usage and setup: see `README.md` and `docs/`.
+- Bug reports and work items: open a GitHub issue.
+- Security issues: use private reporting as documented in `SECURITY.md`.
+
+## Issue Quality
+
+To speed up triage, include:
+
+- Hookaido version (`hookaido version --long`)
+- Relevant config snippets (redact secrets)
+- Logs or error output
+- Reproduction steps
+
+## Response Expectations
+
+Support is best-effort. Maintainers aim to acknowledge well-scoped issues within a few business days.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,5 @@
 # Hookaido Documentation
 
-<p align="center">
-  <img src="assets/logo/hookaido-logo.svg" alt="Hookaido logo" width="180">
-</p>
-
 Hookaido is a **webhook ingress queue** — a single binary that receives webhooks, durably enqueues them, and lets your internal services consume them at their own pace. Think of it as Caddy-style simplicity for webhook infrastructure.
 
 ## Key Properties

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,7 @@ Alternatively, Hookaido can **push** (deliver) to your internal endpoints with c
 | [Management Model](management-model.md) | Application/endpoint labels, publish policies                 |
 | [Docker Quickstart](docker.md)          | Run Hookaido with Docker / Docker Compose                     |
 | [MCP Integration](mcp.md)               | AI-assisted operations via Model Context Protocol             |
+| [OpenSSF Best Practices](ossf-best-practices.md) | Badge evidence links and maintenance checklist         |
 
 ## Requirements
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,5 +52,9 @@ Alternatively, Hookaido can **push** (deliver) to your internal endpoints with c
 ## Project Links
 
 - [DESIGN.md](https://github.com/nuetzliches/hookaido/blob/main/DESIGN.md) — canonical specification
+- [CONTRIBUTING.md](https://github.com/nuetzliches/hookaido/blob/main/CONTRIBUTING.md) — contribution workflow
+- [CODE_OF_CONDUCT.md](https://github.com/nuetzliches/hookaido/blob/main/CODE_OF_CONDUCT.md) — community standards
+- [SECURITY.md](https://github.com/nuetzliches/hookaido/blob/main/SECURITY.md) — vulnerability reporting policy
+- [GOVERNANCE.md](https://github.com/nuetzliches/hookaido/blob/main/GOVERNANCE.md) — maintainership and decisions
 - [CHANGELOG.md](https://github.com/nuetzliches/hookaido/blob/main/CHANGELOG.md) — notable changes
 - [STATUS.md](https://github.com/nuetzliches/hookaido/blob/main/STATUS.md) — development status

--- a/docs/ossf-best-practices.md
+++ b/docs/ossf-best-practices.md
@@ -1,0 +1,48 @@
+# OpenSSF Best Practices Badge
+
+This page tracks evidence links used for the OpenSSF Best Practices Badge questionnaire.
+
+## Badge Entry
+
+- Portal: <https://www.bestpractices.dev/>
+- Project repo: <https://github.com/nuetzliches/hookaido>
+
+## Evidence Links (Quick Reference)
+
+### Project Basics
+
+- Description and usage: <https://github.com/nuetzliches/hookaido/blob/main/README.md>
+- License (Apache-2.0): <https://github.com/nuetzliches/hookaido/blob/main/LICENSE>
+- Changelog: <https://github.com/nuetzliches/hookaido/blob/main/CHANGELOG.md>
+
+### Security
+
+- Security policy: <https://github.com/nuetzliches/hookaido/blob/main/SECURITY.md>
+- Security architecture guidance: <https://github.com/nuetzliches/hookaido/blob/main/docs/security.md>
+- Signed release process: <https://github.com/nuetzliches/hookaido/blob/main/RELEASE.md>
+- Release workflow: <https://github.com/nuetzliches/hookaido/blob/main/.github/workflows/release.yml>
+- Scorecard workflow: <https://github.com/nuetzliches/hookaido/blob/main/.github/workflows/scorecard.yml>
+
+### Development Process
+
+- Contributing guide: <https://github.com/nuetzliches/hookaido/blob/main/CONTRIBUTING.md>
+- Code of conduct: <https://github.com/nuetzliches/hookaido/blob/main/CODE_OF_CONDUCT.md>
+- Governance: <https://github.com/nuetzliches/hookaido/blob/main/GOVERNANCE.md>
+- Support policy: <https://github.com/nuetzliches/hookaido/blob/main/SUPPORT.md>
+- Code owners: <https://github.com/nuetzliches/hookaido/blob/main/.github/CODEOWNERS>
+- Backlog and roadmap: <https://github.com/nuetzliches/hookaido/blob/main/BACKLOG.md>
+
+### CI / Quality
+
+- CI tests: <https://github.com/nuetzliches/hookaido/blob/main/.github/workflows/ci.yml>
+- Dependency health and vuln scan: <https://github.com/nuetzliches/hookaido/blob/main/.github/workflows/dependency-health.yml>
+- Dependency update automation: <https://github.com/nuetzliches/hookaido/blob/main/.github/dependabot.yml>
+- Docs publishing workflow: <https://github.com/nuetzliches/hookaido/blob/main/.github/workflows/docs.yml>
+
+## Remaining Manual Steps
+
+1. Create/confirm the project entry on `bestpractices.dev`.
+2. Fill questionnaire answers using the links above.
+3. Record badge URL in `README.md` once issued.
+4. Keep this page updated as policies or workflows change.
+

--- a/internal/config/fuzz_test.go
+++ b/internal/config/fuzz_test.go
@@ -1,0 +1,47 @@
+package config
+
+import "testing"
+
+func FuzzParseFormatRoundTrip(f *testing.F) {
+	f.Add([]byte(`"/hooks" { pull { path /pull/hooks } }`))
+	f.Add([]byte(`
+ingress { listen :8080 }
+pull_api { auth token "raw:test-token" }
+"/hooks" { pull { path /pull/hooks } }
+`))
+	f.Add([]byte(`
+secrets {
+  secret "S1" {
+    value "raw:s1"
+    valid_from "2026-01-01T00:00:00Z"
+  }
+}
+"/x" {
+  auth hmac secret_ref "S1"
+  pull { path "/pull/x" }
+}
+`))
+
+	f.Fuzz(func(t *testing.T, input []byte) {
+		cfg, err := Parse(input)
+		if err != nil {
+			return
+		}
+
+		formatted, err := Format(cfg)
+		if err != nil {
+			t.Fatalf("format parsed config: %v", err)
+		}
+
+		cfg2, err := Parse(formatted)
+		if err != nil {
+			t.Fatalf("parse formatted config: %v\nformatted:\n%s", err, string(formatted))
+		}
+
+		if _, err := Format(cfg2); err != nil {
+			t.Fatalf("format re-parsed config: %v", err)
+		}
+
+		_ = ValidateWithResult(cfg2)
+	})
+}

--- a/internal/ingress/fuzz_test.go
+++ b/internal/ingress/fuzz_test.go
@@ -1,0 +1,74 @@
+package ingress
+
+import (
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func FuzzHMACAuthVerify(f *testing.F) {
+	f.Add(http.MethodPost, "/hooks", []byte(`{"ok":true}`), int64(1735689600), "nonce-1", true)
+	f.Add(http.MethodPost, "/hooks", []byte(`{}`), int64(1735689600), "", false)
+
+	f.Fuzz(func(t *testing.T, method string, requestPath string, body []byte, ts int64, nonce string, useValidSignature bool) {
+		if requestPath == "" {
+			requestPath = "/hooks"
+		}
+		if !strings.HasPrefix(requestPath, "/") {
+			requestPath = "/" + requestPath
+		}
+		if len(requestPath) > 256 {
+			requestPath = requestPath[:256]
+		}
+		if len(body) > 1<<20 {
+			body = body[:1<<20]
+		}
+		if len(nonce) > 256 {
+			nonce = nonce[:256]
+		}
+		if strings.ContainsAny(nonce, "\r\n") {
+			nonce = ""
+		}
+		if ts < 0 {
+			ts = -ts
+		}
+		if ts > 4102444800 {
+			ts = ts % 4102444800
+		}
+
+		now := time.Unix(1735689600, 0).UTC()
+		auth := NewHMACAuth([][]byte{[]byte("fuzz-secret")})
+		auth.Now = func() time.Time { return now }
+		auth.Tolerance = 10 * 365 * 24 * time.Hour
+
+		req := &http.Request{
+			Method: method,
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "example.test",
+				Path:   requestPath,
+			},
+			Header: make(http.Header),
+			Body:   io.NopCloser(strings.NewReader("")),
+		}
+
+		tsHeader := strconv.FormatInt(ts, 10)
+		req.Header.Set(auth.TimestampHeader, tsHeader)
+		req.Header.Set(auth.NonceHeader, nonce)
+
+		signature := "deadbeef"
+		if useValidSignature {
+			signature = signHMAC(ts, method, requestPath, body, []byte("fuzz-secret"))
+		}
+		req.Header.Set(auth.SignatureHeader, signature)
+
+		err := auth.Verify(req, requestPath, body)
+		if err != nil && err != ErrUnauthorized {
+			t.Fatalf("unexpected verify error: %v", err)
+		}
+	})
+}

--- a/internal/pullapi/fuzz_test.go
+++ b/internal/pullapi/fuzz_test.go
@@ -1,0 +1,98 @@
+package pullapi
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+)
+
+func FuzzPullAPIServer(f *testing.F) {
+	f.Add(http.MethodPost, "/pull/github/dequeue", `{"batch":1}`, "Bearer fuzz-token")
+	f.Add(http.MethodPost, "/pull/github/ack", `{"lease_id":"lease_1"}`, "")
+	f.Add(http.MethodGet, "/pull/github/dequeue", "", "")
+
+	f.Fuzz(func(t *testing.T, method string, requestPath string, body string, authHeader string) {
+		if requestPath == "" {
+			requestPath = "/pull/github/dequeue"
+		}
+		if !strings.HasPrefix(requestPath, "/") {
+			requestPath = "/" + requestPath
+		}
+		if len(requestPath) > 256 {
+			requestPath = requestPath[:256]
+		}
+		if len(body) > 1<<20 {
+			body = body[:1<<20]
+		}
+		if strings.ContainsAny(authHeader, "\r\n") {
+			authHeader = ""
+		}
+
+		srv := NewServer(&stubStore{})
+		srv.MaxBatch = 10
+		srv.DefaultLeaseTTL = 30 * time.Second
+		srv.ResolveRoute = func(endpoint string) (string, bool) {
+			if strings.HasPrefix(endpoint, "/pull/") {
+				return "/webhooks/fuzz", true
+			}
+			return "", false
+		}
+		srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("fuzz-token")})
+
+		req := &http.Request{
+			Method: method,
+			URL: &url.URL{
+				Scheme: "http",
+				Host:   "example.test",
+				Path:   requestPath,
+			},
+			Header: make(http.Header),
+			Body:   io.NopCloser(strings.NewReader(body)),
+		}
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+
+		rr := httptest.NewRecorder()
+		srv.ServeHTTP(rr, req)
+
+		if rr.Code < 100 || rr.Code > 599 {
+			t.Fatalf("invalid status code: %d", rr.Code)
+		}
+	})
+}
+
+func FuzzBearerTokenAuthorizer(f *testing.F) {
+	f.Add("Bearer token-1", "token-1")
+	f.Add("", "")
+	f.Add("Basic xyz", "token-1")
+
+	f.Fuzz(func(t *testing.T, authHeader string, token string) {
+		if len(authHeader) > 2048 {
+			authHeader = authHeader[:2048]
+		}
+		if len(token) > 256 {
+			token = token[:256]
+		}
+		if strings.ContainsAny(authHeader, "\r\n") {
+			authHeader = ""
+		}
+
+		authorize := BearerTokenAuthorizer([][]byte{
+			[]byte(token),
+			nil,
+			[]byte(""),
+		})
+
+		req := httptest.NewRequest(http.MethodPost, "http://example.test/pull/github/dequeue", nil)
+		if authHeader != "" {
+			req.Header.Set("Authorization", authHeader)
+		}
+
+		_ = authorize(req)
+	})
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,5 +61,6 @@ nav:
   - Management Model: management-model.md
   - Docker: docker.md
   - MCP Integration: mcp.md
+  - OpenSSF Best Practices: ossf-best-practices.md
 
 docs_dir: docs


### PR DESCRIPTION
## Summary
- harden CI workflows with least-privilege permissions and pinned action/image/tool versions
- add fuzzing baseline targets for config, pull API, and ingress; wire scheduled fuzz smoke runs
- improve Scorecard auth coverage (checks/PR/issues/contents read + optional SCORECARD_TOKEN)
- add CII/best-practices readiness docs (CONTRIBUTING, SECURITY, SUPPORT, GOVERNANCE, CODE_OF_CONDUCT, CODEOWNERS)
- add OpenSSF best-practices evidence guide in docs and link it from README/docs index

## Validation
- go test ./...
- local fuzz smoke runs for config/pullapi/ingress targets

## Notes
- no runtime/API behavior changes; this is CI/security/testing/docs hardening
- no SemVer release tag included