### PR TITLE
ci(docs): use digest-pinned mkdocs container image

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,15 +17,10 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: squidfunk/mkdocs-material:9.7.1@sha256:3bba0a99bc6e635bb8e53f379d32ab9cecb554adee9cc8f59a347f93ecf82f3b
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
-        with:
-          python-version: "3.12"
-      - name: Install docs toolchain (hash pinned)
-        run: >
-          python -m pip install --disable-pip-version-check
-          "https://files.pythonhosted.org/packages/3e/32/ed071cb721aca8c227718cffcf7bd539620e9799bbf2619e90c757bfd030/mkdocs_material-9.7.1-py3-none-any.whl#sha256=3f6100937d7d731f87f1e3e3b021c97f7239666b9ba1151ab476cabb96c60d5c"
       - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:


### PR DESCRIPTION
## Summary
- run docs build inside digest-pinned squidfunk/mkdocs-material container
- remove runtime pip install from docs workflow

## Why
- improves Scorecard Pinned-Dependencies by avoiding unpinned pipCommand detection in docs.yml
- keeps docs build deterministic with pinned container digest