### PR TITLE
docs(security): make private advisory reporting link direct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -4,6 +4,13 @@ title: "[bug] "
 labels:
   - bug
 body:
+  - type: markdown
+    attributes:
+      value: |
+        **Do not report security vulnerabilities in public issues.**
+        Use private advisory reporting instead:
+        https://github.com/nuetzliches/hookaido/security/advisories/new
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability Report
-    url: https://github.com/nuetzliches/hookaido/security/policy
-    about: Please report security vulnerabilities via the security policy process.
+    url: https://github.com/nuetzliches/hookaido/security/advisories/new
+    about: Report vulnerabilities privately via GitHub Security Advisories.
   - name: Usage Questions and Support
     url: https://github.com/nuetzliches/hookaido/blob/main/SUPPORT.md
     about: Please use the support guide for questions and troubleshooting.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@
 
 Please report vulnerabilities privately via GitHub Security Advisories:
 
-- `https://github.com/nuetzliches/hookaido/security/advisories/new`
+- [Create a private security advisory](https://github.com/nuetzliches/hookaido/security/advisories/new)
 
 Do not open public issues for unpatched vulnerabilities.
 
@@ -32,4 +32,3 @@ Do not open public issues for unpatched vulnerabilities.
 ## Disclosure
 
 We follow coordinated disclosure. Once a fix is available, maintainers publish release notes and, if applicable, a security advisory.
-


### PR DESCRIPTION
## Summary
- make advisory reporting link in SECURITY.md clickable markdown
- point issue-template security contact link directly to security/advisories/new
- add warning in bug issue template to avoid public vulnerability reports

## Why
- security reports should go directly to private advisory flow
- avoid accidental public disclosure in standard bug issues