### PR TITLE
fix(codeql): reduce allocation-related security alerts

### DIFF
--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -892,7 +892,7 @@ func (s *runtimeState) loadAuth(compiled config.Compiled) error {
 			}
 			auth.SelectSecrets = func(at time.Time) [][]byte {
 				valid := set.ValidAt(at)
-				out := make([][]byte, 0, len(valid)+len(secs))
+				out := make([][]byte, 0, len(valid))
 				for _, v := range valid {
 					out = append(out, v.Value)
 				}

--- a/internal/config/io.go
+++ b/internal/config/io.go
@@ -34,7 +34,7 @@ func canonicalize(in []byte) []byte {
 		in = in[3:]
 	}
 
-	out := make([]byte, 0, len(in)+1)
+	out := make([]byte, 0, len(in))
 	for i := 0; i < len(in); i++ {
 		b := in[i]
 		if b == '\r' {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2363,7 +2363,7 @@ func (s *Server) toolAdminHealth(args map[string]any) (any, error) {
 				if details, ok := adminProbe["details"].(map[string]any); ok {
 					if diagnostics, ok := details["diagnostics"].(map[string]any); ok {
 						if queueDiag, ok := diagnostics["queue"].(map[string]any); ok {
-							proxyQueue := make(map[string]any, len(queueDiag)+2)
+							proxyQueue := make(map[string]any)
 							for k, v := range queueDiag {
 								proxyQueue[k] = v
 							}

--- a/internal/queue/memory.go
+++ b/internal/queue/memory.go
@@ -1405,7 +1405,7 @@ func (s *MemoryStore) ListAttempts(req AttemptListRequest) (AttemptListResponse,
 		limit = 1000
 	}
 
-	items := make([]DeliveryAttempt, 0, limit)
+	items := make([]DeliveryAttempt, 0)
 	for _, attempt := range s.attempts {
 		if req.Route != "" && attempt.Route != req.Route {
 			continue

--- a/internal/queue/sqlite.go
+++ b/internal/queue/sqlite.go
@@ -834,7 +834,7 @@ WHERE state = ?
 	}
 	defer rows.Close()
 
-	out := make([]Envelope, 0, batch)
+	out := make([]Envelope, 0)
 	for rows.Next() {
 		var env Envelope
 		var receivedAtNanos int64
@@ -1081,7 +1081,7 @@ WHERE state = ?`
 	}
 	defer rows.Close()
 
-	items := make([]Envelope, 0, limit)
+	items := make([]Envelope, 0)
 	for rows.Next() {
 		var env Envelope
 		var receivedAtNanos int64
@@ -1261,7 +1261,7 @@ WHERE 1 = 1`
 	}
 	defer rows.Close()
 
-	items := make([]Envelope, 0, limit)
+	items := make([]Envelope, 0)
 	for rows.Next() {
 		var env Envelope
 		var receivedAtNanos int64
@@ -1933,7 +1933,7 @@ WHERE 1 = 1`
 	}
 	defer rows.Close()
 
-	ids := make([]string, 0, limit)
+	ids := make([]string, 0)
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {
@@ -2036,7 +2036,7 @@ WHERE 1 = 1`
 	}
 	defer rows.Close()
 
-	items := make([]DeliveryAttempt, 0, limit)
+	items := make([]DeliveryAttempt, 0)
 	for rows.Next() {
 		var item DeliveryAttempt
 		var createdAtNanos int64


### PR DESCRIPTION
## Summary
- remove overflow-prone capacity arithmetic in a few slice/map preallocations
- avoid preallocating list buffers from request-derived limits in queue listing paths
- keep behavior unchanged while reducing CodeQL false-positive/edge-risk surface

## Validation
- go test ./...
