### PR TITLE
ci/docs: reduce duplicate CI runs and fix Pages links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,13 @@ name: ci
 
 on:
   push:
+    branches:
+      - main
   pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ### Changed
 
 - Documentation UX refresh: docs navigation is now grouped by workflow area, `docs/index.md` is rebuilt as a landing page with quick-start/task-oriented entry points, search now supports command-palette style `Ctrl+K`, and docs stack evaluation is documented in `docs/documentation-platform.md` (decision: keep MkDocs Material for current roadmap window).
+- CI now runs on pull requests and pushes to `main` only, and cancels superseded in-progress runs per ref to reduce duplicate workflow executions.
 
 ### Fixed
 
 - Go module path now matches the repository path (`github.com/nuetzliches/hookaido`), fixing module resolution and `go install` for `cmd/hookaido`.
 - Docker image build metadata flags now target the correct package variables, so `hookaido version --long` reports release metadata correctly in container builds.
 - `config validate` now rejects invalid secret-reference schemes (`pull_api/admin_api auth token`, `pull.auth token`, direct `auth hmac` secrets, direct `deliver sign hmac`, and `secrets.value`) instead of failing later at runtime start.
+- Docs landing page links now use MkDocs directory URLs (`/page/`) so GitHub Pages navigation no longer points to missing `*.md` endpoints.
 
 ## [1.0.0] - 2026-02-10
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,9 +8,9 @@
     and lets internal workers consume at their own pace through pull or push flows.
   </p>
   <div class="hk-actions">
-    <a class="hk-button hk-button-primary" href="getting-started.md">Start in 5 minutes</a>
-    <a class="hk-button hk-button-secondary" href="configuration.md">Read the DSL reference</a>
-    <a class="hk-button hk-button-secondary" href="deployment-modes.md">Choose deployment mode</a>
+    <a class="hk-button hk-button-primary" href="getting-started/">Start in 5 minutes</a>
+    <a class="hk-button hk-button-secondary" href="configuration/">Read the DSL reference</a>
+    <a class="hk-button hk-button-secondary" href="deployment-modes/">Choose deployment mode</a>
   </div>
 </div>
 
@@ -22,22 +22,22 @@ Use <span class="hk-kbd">Ctrl</span> + <span class="hk-kbd">K</span> to open sea
   <div class="hk-card">
     <h3>Run Pull Mode</h3>
     <p>Use the DMZ default: ingress + queue in DMZ, internal workers dequeue and ack.</p>
-    <p><a href="pull-api.md">Pull API reference</a></p>
+    <p><a href="pull-api/">Pull API reference</a></p>
   </div>
   <div class="hk-card">
     <h3>Run Push Mode</h3>
     <p>Deliver to internal endpoints with retry, backoff, and optional outbound signing.</p>
-    <p><a href="delivery.md">Delivery reference</a></p>
+    <p><a href="delivery/">Delivery reference</a></p>
   </div>
   <div class="hk-card">
     <h3>Operate the Queue</h3>
     <p>Inspect health, DLQ, and backlog trends from the Admin API.</p>
-    <p><a href="admin-api.md">Admin API reference</a></p>
+    <p><a href="admin-api/">Admin API reference</a></p>
   </div>
   <div class="hk-card">
     <h3>Integrate with MCP</h3>
     <p>Expose typed ops tools for AI agents with role-gated read and mutation controls.</p>
-    <p><a href="mcp.md">MCP integration</a></p>
+    <p><a href="mcp/">MCP integration</a></p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- run `ci` on pull requests and on `main` pushes only
- add workflow-level concurrency cancellation for superseded runs
- fix docs landing-page HTML links to MkDocs directory URLs (remove `*.md` 404 targets)

## Validation
- `go test ./...`
- verified no raw `href="*.md"` remains in `docs/index.md`

## Notes
- this keeps required PR checks intact; it only removes duplicate branch-push CI runs
