### PR TITLE
ci(docs): install GNU tar for Pages artifact upload

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
       image: squidfunk/mkdocs-material:9.7.1@sha256:3bba0a99bc6e635bb8e53f379d32ab9cecb554adee9cc8f59a347f93ecf82f3b
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install GNU tar for Pages artifact packaging
+        run: apk add --no-cache tar
       - run: mkdocs build --strict
       - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - "docs/**"
       - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - ".github/workflows/docs.yml"
   workflow_dispatch:
 
 permissions: read-all


### PR DESCRIPTION
## Summary
- install GNU `tar` inside the MkDocs container before `upload-pages-artifact`
- fixes Pages deploy failure caused by BusyBox `tar` missing `--hard-dereference`

## Context
- run https://github.com/nuetzliches/hookaido/actions/runs/21904144311 failed in `upload-pages-artifact` with `tar: unrecognized option: hard-dereference`
