### PR TITLE
fix(control-plane): keep metrics and health responsive under queue pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Documentation UX refresh: docs navigation is now grouped by workflow area, `docs/index.md` is rebuilt as a landing page with quick-start/task-oriented entry points, search now supports command-palette style `Ctrl+K`, and docs stack evaluation is documented in `docs/documentation-platform.md` (decision: keep MkDocs Material for current roadmap window).
 - CI now runs on pull requests and pushes to `main` only, and cancels superseded in-progress runs per ref to reduce duplicate workflow executions.
 - Release workflow now exports Sigstore attestation bundles as `*.intoto.jsonl` assets (plus compatibility `*.attestation.json` copies), and `hookaido verify-release` now auto-detects either naming scheme with `.intoto.jsonl` preference.
+- Control-plane hardening under saturation: `/metrics` queue depth and `/healthz?details=1` queue diagnostics now use short-TTL stale-while-refresh snapshots, reducing contention-coupled latency spikes during high queue pressure.
 
 ### Fixed
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -270,6 +270,12 @@ The Admin API health endpoint (`GET /healthz?details=1`) aggregates observabilit
 - Backlog trend signals with operator action playbooks
 - Tracing counters (init failures, export errors)
 - Top route/target backlog buckets
+- Queue diagnostics are cached (short TTL) and served stale-while-refresh under heavy load to keep control-plane endpoints responsive.
+
+Operational guidance for control-plane responsiveness:
+
+- Keep SLO probes on `GET /healthz` (without details) for the fastest liveness path.
+- Use `GET /healthz?details=1` and `GET /metrics` for diagnostics/monitoring; under queue saturation these endpoints prioritize bounded latency over strictly real-time queue snapshots.
 
 See [Admin API](admin-api.md) for details.
 


### PR DESCRIPTION
## Summary
- c703b72 fix(control-plane): keep metrics and health responsive under queue pressure

## Stack Base
feat/sqlite-contention-metrics-25