### PR TITLE
feat(ingress+metrics): integrate saturation resilience stack into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Documentation UX refresh: docs navigation is now grouped by workflow area, `docs/index.md` is rebuilt as a landing page with quick-start/task-oriented entry points, search now supports command-palette style `Ctrl+K`, and docs stack evaluation is documented in `docs/documentation-platform.md` (decision: keep MkDocs Material for current roadmap window).
 - CI now runs on pull requests and pushes to `main` only, and cancels superseded in-progress runs per ref to reduce duplicate workflow executions.
 - Release workflow now exports Sigstore attestation bundles as `*.intoto.jsonl` assets (plus compatibility `*.attestation.json` copies), and `hookaido verify-release` now auto-detects either naming scheme with `.intoto.jsonl` preference.
+- Control-plane hardening under saturation: `/metrics` queue depth and `/healthz?details=1` queue diagnostics now use short-TTL stale-while-refresh snapshots, reducing contention-coupled latency spikes during high queue pressure.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Optional strict secret preflight in config validation: `hookaido config validate --strict-secrets` and MCP `config_validate` argument `strict_secrets` now actively load refs to catch missing env vars, unreadable files, and Vault connectivity/access issues before runtime start.
 - First-class Pull Prometheus metrics by route: dequeue totals (`status` labels `200|204|4xx|5xx`), ack/nack totals, ack/nack conflict totals, active lease gauge, and lease-expired totals.
 - SQLite/store contention metrics on `/metrics`: write/dequeue/checkpoint duration histograms plus busy/retry, transaction commit/rollback, and checkpoint success/error counters.
+- Adaptive ingress backpressure guardrails (`defaults.adaptive_backpressure`) with soft-pressure 503 admission before hard `max_depth`, plus reason-labeled Prometheus counters and health diagnostics (`adaptive_backpressure_applied_total`, `adaptive_backpressure_by_reason`).
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - CI now runs on pull requests and pushes to `main` only, and cancels superseded in-progress runs per ref to reduce duplicate workflow executions.
 - Release workflow now exports Sigstore attestation bundles as `*.intoto.jsonl` assets (plus compatibility `*.attestation.json` copies), and `hookaido verify-release` now auto-detects either naming scheme with `.intoto.jsonl` preference.
 - Control-plane hardening under saturation: `/metrics` queue depth and `/healthz?details=1` queue diagnostics now use short-TTL stale-while-refresh snapshots, reducing contention-coupled latency spikes during high queue pressure.
+- SQLite `max_depth` admission checks now use trigger-maintained active-depth counters (`queue_counters`) instead of per-enqueue `COUNT(*)` scans, reducing write-path contention near saturation.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Vault secret adapter for secret refs via `vault:...` (HashiCorp Vault-compatible HTTP API), including KV v1/v2 field extraction and env-configured namespace/TLS options.
 - Optional strict secret preflight in config validation: `hookaido config validate --strict-secrets` and MCP `config_validate` argument `strict_secrets` now actively load refs to catch missing env vars, unreadable files, and Vault connectivity/access issues before runtime start.
 - First-class Pull Prometheus metrics by route: dequeue totals (`status` labels `200|204|4xx|5xx`), ack/nack totals, ack/nack conflict totals, active lease gauge, and lease-expired totals.
+- SQLite/store contention metrics on `/metrics`: write/dequeue/checkpoint duration histograms plus busy/retry, transaction commit/rollback, and checkpoint success/error counters.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ observability {
 }
 ```
 
-Prometheus counters for ingress, pull (`dequeue`/`ack`/`nack`/conflicts/leases), and push delivery, plus queue depth gauges. OpenTelemetry traces with full OTLP/HTTP configuration.
+Prometheus counters for ingress, pull (`dequeue`/`ack`/`nack`/conflicts/leases), and push delivery, plus queue depth gauges and SQLite store contention metrics (write/dequeue/checkpoint durations, busy/retry, tx commit/rollback). OpenTelemetry traces with full OTLP/HTTP configuration.
 
 ## MCP Server (AI Integration)
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ observability {
 }
 ```
 
-Prometheus counters for ingress, pull (`dequeue`/`ack`/`nack`/conflicts/leases), and push delivery, plus queue depth gauges and SQLite store contention metrics (write/dequeue/checkpoint durations, busy/retry, tx commit/rollback). OpenTelemetry traces with full OTLP/HTTP configuration.
+Prometheus counters for ingress, adaptive backpressure (`reason`-labeled), pull (`dequeue`/`ack`/`nack`/conflicts/leases), and push delivery, plus queue depth gauges and SQLite store contention metrics (write/dequeue/checkpoint durations, busy/retry, tx commit/rollback). OpenTelemetry traces with full OTLP/HTTP configuration.
 
 ## MCP Server (AI Integration)
 

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -31,20 +31,33 @@ Returns detailed JSON diagnostics:
 
 ```json
 {
-  "status": "ok",
-  "queue": {
-    "total": 1523,
-    "by_state": { "queued": 1200, "leased": 300, "dead": 23 },
-    "oldest_queued_received_at": "2026-02-09T08:00:00Z",
-    "oldest_queued_age_seconds": 7200,
-    "ready_lag_seconds": 0,
-    "top_queued": [...],
-    "trend_signals": {
-      "signals": [...],
-      "operator_actions": [...]
+  "ok": true,
+  "time": "2026-02-12T20:15:00Z",
+  "diagnostics": {
+    "queue": {
+      "total": 1523,
+      "by_state": { "queued": 1200, "leased": 300, "dead": 23 },
+      "oldest_queued_received_at": "2026-02-09T08:00:00Z",
+      "oldest_queued_age_seconds": 7200,
+      "ready_lag_seconds": 0,
+      "top_queued": [...],
+      "trend_signals": {
+        "signals": [...],
+        "operator_actions": [...]
+      }
+    },
+    "ingress": {
+      "accepted_total": 100000,
+      "rejected_total": 4123,
+      "adaptive_backpressure_applied_total": 345,
+      "adaptive_backpressure_by_reason": {
+        "queued_pressure": 221,
+        "ready_lag": 79,
+        "oldest_queued_age": 31,
+        "sustained_growth": 14
+      }
     }
-  },
-  "tracing": { ... }
+  }
 }
 ```
 
@@ -53,6 +66,7 @@ The health endpoint includes:
 - Queue state rollups with age/lag indicators
 - Top route/target backlog buckets
 - Persisted trend signals with operator action playbooks
+- Ingress counters and adaptive-backpressure diagnostics (when runtime metrics are enabled)
 - Tracing counters (when metrics are enabled)
 
 ## Queue Reads

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -315,8 +315,25 @@ defaults {
     queued_pressure_percent 75
     queued_pressure_leased_multiplier 2
   }
+
+  adaptive_backpressure {
+    enabled off
+    min_total 200
+    queued_percent 80
+    ready_lag 30s
+    oldest_queued_age 60s
+    sustained_growth on
+  }
 }
 ```
+
+`adaptive_backpressure` is an optional soft-pressure ingress guardrail that applies `503` before hard `queue_limits.max_depth` is reached.
+- `enabled`: turn adaptive backpressure on/off.
+- `min_total`: minimum queue total (`queued+leased+dead`) before guardrails evaluate.
+- `queued_percent`: reject when queued share reaches this percentage.
+- `ready_lag`: reject when queue `ready_lag_seconds` reaches this duration.
+- `oldest_queued_age`: reject when `oldest_queued_age_seconds` reaches this duration.
+- `sustained_growth`: when `on`, also reject on sustained backlog growth signals (if trend samples are available).
 
 ### `observability`
 
@@ -507,6 +524,12 @@ Placeholders resolve within a single value (no cross-token expansion).
 | `deliver.retry`                  | `exponential max 8 base 2s cap 2m jitter 0.2` |
 | `deliver.timeout`                | `10s`                                         |
 | `deliver.concurrency`            | `20`                                          |
+| `defaults.adaptive_backpressure.enabled` | `false`                              |
+| `defaults.adaptive_backpressure.min_total` | `200`                               |
+| `defaults.adaptive_backpressure.queued_percent` | `80`                         |
+| `defaults.adaptive_backpressure.ready_lag` | `30s`                              |
+| `defaults.adaptive_backpressure.oldest_queued_age` | `60s`                     |
+| `defaults.adaptive_backpressure.sustained_growth` | `true`                      |
 | `pull_api.max_batch`             | `100`                                         |
 | `pull_api.default_lease_ttl`     | `30s`                                         |
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -270,6 +270,12 @@ The Admin API health endpoint (`GET /healthz?details=1`) aggregates observabilit
 - Backlog trend signals with operator action playbooks
 - Tracing counters (init failures, export errors)
 - Top route/target backlog buckets
+- Queue diagnostics are cached (short TTL) and served stale-while-refresh under heavy load to keep control-plane endpoints responsive.
+
+Operational guidance for control-plane responsiveness:
+
+- Keep SLO probes on `GET /healthz` (without details) for the fastest liveness path.
+- Use `GET /healthz?details=1` and `GET /metrics` for diagnostics/monitoring; under queue saturation these endpoints prioritize bounded latency over strictly real-time queue snapshots.
 
 See [Admin API](admin-api.md) for details.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -150,6 +150,20 @@ Set `enabled off` to disable the metrics listener while keeping config in place.
 | `hookaido_pull_lease_active`          | gauge   | Active Pull leases currently tracked by `route`                              |
 | `hookaido_pull_lease_expired_total`   | counter | Lease expirations observed during Pull `ack`/`nack`/`extend` by `route`      |
 
+**Store/SQLite metrics:**
+
+| Metric                                           | Type      | Description                                                                |
+| ------------------------------------------------ | --------- | -------------------------------------------------------------------------- |
+| `hookaido_store_sqlite_write_seconds`            | histogram | SQLite write transaction duration (queue mutation paths)                   |
+| `hookaido_store_sqlite_dequeue_seconds`          | histogram | SQLite dequeue transaction duration                                        |
+| `hookaido_store_sqlite_checkpoint_seconds`       | histogram | SQLite WAL checkpoint duration (periodic passive checkpoints)              |
+| `hookaido_store_sqlite_busy_total`               | counter   | SQLite busy/locked errors observed in instrumented paths                   |
+| `hookaido_store_sqlite_retry_total`              | counter   | SQLite begin-transaction retry attempts after busy/locked errors           |
+| `hookaido_store_sqlite_tx_commit_total`          | counter   | Committed SQLite transactions in instrumented queue paths                  |
+| `hookaido_store_sqlite_tx_rollback_total`        | counter   | Rolled-back SQLite transactions in instrumented queue paths                |
+| `hookaido_store_sqlite_checkpoint_total`         | counter   | Successful periodic SQLite WAL checkpoints                                 |
+| `hookaido_store_sqlite_checkpoint_errors_total`  | counter   | Failed periodic SQLite WAL checkpoints                                     |
+
 **Publish metrics:**
 
 | Metric                                       | Type    | Description                       |

--- a/internal/app/adaptive_backpressure.go
+++ b/internal/app/adaptive_backpressure.go
@@ -1,0 +1,327 @@
+package app
+
+import (
+	"math"
+	"sync"
+	"time"
+
+	"github.com/nuetzliches/hookaido/internal/config"
+	"github.com/nuetzliches/hookaido/internal/queue"
+)
+
+const (
+	defaultAdaptiveStatsCacheTTL        = 250 * time.Millisecond
+	defaultAdaptiveTrendSignalsCacheTTL = time.Second
+	adaptiveTrendSignalSamples          = 512
+)
+
+type adaptiveAdmissionController struct {
+	mu       sync.RWMutex
+	cfg      config.AdaptiveBackpressureConfig
+	trendCfg config.TrendSignalsConfig
+	store    queue.Store
+	now      func() time.Time
+
+	stats struct {
+		mu         sync.Mutex
+		ttl        time.Duration
+		cached     queue.Stats
+		cachedAt   time.Time
+		cachedOK   bool
+		refreshing bool
+	}
+
+	trend struct {
+		mu         sync.Mutex
+		ttl        time.Duration
+		cached     queue.BacklogTrendSignals
+		cachedAt   time.Time
+		cachedOK   bool
+		refreshing bool
+	}
+}
+
+func newAdaptiveAdmissionController(cfg config.AdaptiveBackpressureConfig, trendCfg config.TrendSignalsConfig) *adaptiveAdmissionController {
+	c := &adaptiveAdmissionController{
+		cfg:      cfg,
+		trendCfg: trendCfg,
+		now:      time.Now,
+	}
+	c.stats.ttl = defaultAdaptiveStatsCacheTTL
+	c.trend.ttl = defaultAdaptiveTrendSignalsCacheTTL
+	return c
+}
+
+func (c *adaptiveAdmissionController) setStore(store queue.Store) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.store = store
+	c.mu.Unlock()
+
+	c.stats.mu.Lock()
+	c.stats.cached = queue.Stats{}
+	c.stats.cachedAt = time.Time{}
+	c.stats.cachedOK = false
+	c.stats.refreshing = false
+	c.stats.mu.Unlock()
+
+	c.trend.mu.Lock()
+	c.trend.cached = queue.BacklogTrendSignals{}
+	c.trend.cachedAt = time.Time{}
+	c.trend.cachedOK = false
+	c.trend.refreshing = false
+	c.trend.mu.Unlock()
+}
+
+func (c *adaptiveAdmissionController) updateConfig(cfg config.AdaptiveBackpressureConfig, trendCfg config.TrendSignalsConfig) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	c.cfg = cfg
+	c.trendCfg = trendCfg
+	c.mu.Unlock()
+
+	// Trend interpretation depends on trend config; force quick recompute.
+	c.trend.mu.Lock()
+	c.trend.cached = queue.BacklogTrendSignals{}
+	c.trend.cachedAt = time.Time{}
+	c.trend.cachedOK = false
+	c.trend.refreshing = false
+	c.trend.mu.Unlock()
+}
+
+func (c *adaptiveAdmissionController) evaluate() (apply bool, reason string) {
+	if c == nil {
+		return false, ""
+	}
+
+	cfg, _, _ := c.snapshot()
+	if !cfg.Enabled {
+		return false, ""
+	}
+
+	stats, ok := c.statsSnapshot()
+	if !ok {
+		// Fail open when pressure signals are unavailable.
+		return false, ""
+	}
+	activeTotal := adaptiveActiveTotal(stats)
+	if activeTotal < cfg.MinTotal {
+		return false, ""
+	}
+
+	queuedPercent := adaptiveQueuedPercent(stats, activeTotal)
+	if queuedPercent >= cfg.QueuedPercent {
+		return true, "queued_pressure"
+	}
+	if cfg.ReadyLag > 0 && stats.ReadyLag >= cfg.ReadyLag {
+		return true, "ready_lag"
+	}
+	if cfg.OldestQueuedAge > 0 && stats.OldestQueuedAge >= cfg.OldestQueuedAge {
+		return true, "oldest_queued_age"
+	}
+	if cfg.SustainedGrowth && c.sustainedGrowthActive() {
+		return true, "sustained_growth"
+	}
+	return false, ""
+}
+
+func adaptiveActiveTotal(stats queue.Stats) int {
+	return stats.ByState[queue.StateQueued] + stats.ByState[queue.StateLeased]
+}
+
+func adaptiveQueuedPercent(stats queue.Stats, activeTotal int) int {
+	if activeTotal <= 0 {
+		return 0
+	}
+	queued := stats.ByState[queue.StateQueued]
+	return int(math.Round(float64(queued) * 100 / float64(activeTotal)))
+}
+
+func (c *adaptiveAdmissionController) snapshot() (config.AdaptiveBackpressureConfig, config.TrendSignalsConfig, queue.Store) {
+	c.mu.RLock()
+	cfg := c.cfg
+	trendCfg := c.trendCfg
+	store := c.store
+	c.mu.RUnlock()
+	return cfg, trendCfg, store
+}
+
+func (c *adaptiveAdmissionController) nowUTC() time.Time {
+	c.mu.RLock()
+	nowFn := c.now
+	c.mu.RUnlock()
+	now := time.Now()
+	if nowFn != nil {
+		now = nowFn()
+	}
+	return now.UTC()
+}
+
+func (c *adaptiveAdmissionController) statsSnapshot() (queue.Stats, bool) {
+	if c == nil {
+		return queue.Stats{}, false
+	}
+	_, _, store := c.snapshot()
+	if store == nil {
+		return queue.Stats{}, false
+	}
+
+	now := c.nowUTC()
+	c.stats.mu.Lock()
+	if c.stats.cachedOK && (c.stats.ttl <= 0 || now.Sub(c.stats.cachedAt) <= c.stats.ttl) {
+		stats := c.stats.cached
+		c.stats.mu.Unlock()
+		return stats, true
+	}
+
+	// Cold-start fetch happens once synchronously.
+	if !c.stats.cachedOK {
+		if c.stats.refreshing {
+			c.stats.mu.Unlock()
+			return queue.Stats{}, false
+		}
+		c.stats.refreshing = true
+		c.stats.mu.Unlock()
+		return c.refreshStatsSync(store)
+	}
+
+	// Stale cache: return cached snapshot and refresh in the background.
+	if !c.stats.refreshing {
+		c.stats.refreshing = true
+		go c.refreshStatsAsync(store)
+	}
+	stats := c.stats.cached
+	c.stats.mu.Unlock()
+	return stats, true
+}
+
+func (c *adaptiveAdmissionController) refreshStatsSync(store queue.Store) (queue.Stats, bool) {
+	stats, err := store.Stats()
+	at := c.nowUTC()
+
+	c.stats.mu.Lock()
+	defer c.stats.mu.Unlock()
+	c.stats.refreshing = false
+	if err == nil {
+		c.stats.cached = stats
+		c.stats.cachedAt = at
+		c.stats.cachedOK = true
+		return stats, true
+	}
+	if c.stats.cachedOK {
+		return c.stats.cached, true
+	}
+	return queue.Stats{}, false
+}
+
+func (c *adaptiveAdmissionController) refreshStatsAsync(store queue.Store) {
+	stats, err := store.Stats()
+	at := c.nowUTC()
+
+	c.stats.mu.Lock()
+	defer c.stats.mu.Unlock()
+	c.stats.refreshing = false
+	if err != nil {
+		return
+	}
+	c.stats.cached = stats
+	c.stats.cachedAt = at
+	c.stats.cachedOK = true
+}
+
+func (c *adaptiveAdmissionController) sustainedGrowthActive() bool {
+	signals, ok := c.trendSnapshot()
+	if !ok {
+		return false
+	}
+	return signals.SustainedGrowth
+}
+
+func (c *adaptiveAdmissionController) trendSnapshot() (queue.BacklogTrendSignals, bool) {
+	if c == nil {
+		return queue.BacklogTrendSignals{}, false
+	}
+	_, trendCfg, store := c.snapshot()
+	trendStore, ok := store.(queue.BacklogTrendStore)
+	if !ok || trendStore == nil {
+		return queue.BacklogTrendSignals{}, false
+	}
+
+	now := c.nowUTC()
+	c.trend.mu.Lock()
+	if c.trend.cachedOK && (c.trend.ttl <= 0 || now.Sub(c.trend.cachedAt) <= c.trend.ttl) {
+		signals := c.trend.cached
+		c.trend.mu.Unlock()
+		return signals, true
+	}
+
+	if !c.trend.cachedOK {
+		if c.trend.refreshing {
+			c.trend.mu.Unlock()
+			return queue.BacklogTrendSignals{}, false
+		}
+		c.trend.refreshing = true
+		c.trend.mu.Unlock()
+		return c.refreshTrendSync(trendStore, trendCfg, now)
+	}
+
+	if !c.trend.refreshing {
+		c.trend.refreshing = true
+		go c.refreshTrendAsync(trendStore, trendCfg, now)
+	}
+	signals := c.trend.cached
+	c.trend.mu.Unlock()
+	return signals, true
+}
+
+func (c *adaptiveAdmissionController) refreshTrendSync(trendStore queue.BacklogTrendStore, trendCfg config.TrendSignalsConfig, now time.Time) (queue.BacklogTrendSignals, bool) {
+	signals, err := computeTrendSignals(trendStore, trendCfg, now)
+
+	c.trend.mu.Lock()
+	defer c.trend.mu.Unlock()
+	c.trend.refreshing = false
+	if err == nil {
+		c.trend.cached = signals
+		c.trend.cachedAt = now
+		c.trend.cachedOK = true
+		return signals, true
+	}
+	if c.trend.cachedOK {
+		return c.trend.cached, true
+	}
+	return queue.BacklogTrendSignals{}, false
+}
+
+func (c *adaptiveAdmissionController) refreshTrendAsync(trendStore queue.BacklogTrendStore, trendCfg config.TrendSignalsConfig, now time.Time) {
+	signals, err := computeTrendSignals(trendStore, trendCfg, now)
+
+	c.trend.mu.Lock()
+	defer c.trend.mu.Unlock()
+	c.trend.refreshing = false
+	if err != nil {
+		return
+	}
+	c.trend.cached = signals
+	c.trend.cachedAt = now
+	c.trend.cachedOK = true
+}
+
+func computeTrendSignals(trendStore queue.BacklogTrendStore, trendCfg config.TrendSignalsConfig, now time.Time) (queue.BacklogTrendSignals, error) {
+	resp, err := trendStore.ListBacklogTrend(queue.BacklogTrendListRequest{
+		Since: now.Add(-trendCfg.Window),
+		Until: now,
+		Limit: adaptiveTrendSignalSamples,
+	})
+	if err != nil {
+		return queue.BacklogTrendSignals{}, err
+	}
+	signals := queue.AnalyzeBacklogTrendSignals(resp.Items, resp.Truncated, queue.BacklogTrendSignalOptions{
+		Now:    now,
+		Config: queueTrendSignalConfigFromCompiled(trendCfg),
+	})
+	return signals, nil
+}

--- a/internal/app/adaptive_backpressure_test.go
+++ b/internal/app/adaptive_backpressure_test.go
@@ -1,0 +1,164 @@
+package app
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/internal/config"
+	"github.com/nuetzliches/hookaido/internal/queue"
+)
+
+type adaptiveTestStore struct {
+	queue.Store
+	statsFn func() (queue.Stats, error)
+	trendFn func(req queue.BacklogTrendListRequest) (queue.BacklogTrendListResponse, error)
+}
+
+func (s *adaptiveTestStore) Stats() (queue.Stats, error) {
+	if s != nil && s.statsFn != nil {
+		return s.statsFn()
+	}
+	return s.Store.Stats()
+}
+
+func (s *adaptiveTestStore) CaptureBacklogTrendSample(time.Time) error {
+	return nil
+}
+
+func (s *adaptiveTestStore) ListBacklogTrend(req queue.BacklogTrendListRequest) (queue.BacklogTrendListResponse, error) {
+	if s != nil && s.trendFn != nil {
+		return s.trendFn(req)
+	}
+	return queue.BacklogTrendListResponse{}, nil
+}
+
+func TestAdaptiveAdmissionController_QueuedPressure(t *testing.T) {
+	c := newAdaptiveAdmissionController(
+		config.AdaptiveBackpressureConfig{
+			Enabled:         true,
+			MinTotal:        1,
+			QueuedPercent:   70,
+			ReadyLag:        time.Hour,
+			OldestQueuedAge: time.Hour,
+			SustainedGrowth: false,
+		},
+		config.TrendSignalsConfig{},
+	)
+	c.setStore(&adaptiveTestStore{
+		Store: queue.NewMemoryStore(),
+		statsFn: func() (queue.Stats, error) {
+			return queue.Stats{
+				Total: 10,
+				ByState: map[queue.State]int{
+					queue.StateQueued: 8,
+					queue.StateLeased: 2,
+				},
+			}, nil
+		},
+	})
+
+	apply, reason := c.evaluate()
+	if !apply {
+		t.Fatal("expected adaptive backpressure to apply")
+	}
+	if reason != "queued_pressure" {
+		t.Fatalf("expected reason queued_pressure, got %q", reason)
+	}
+}
+
+func TestAdaptiveAdmissionController_ReadyLag(t *testing.T) {
+	c := newAdaptiveAdmissionController(
+		config.AdaptiveBackpressureConfig{
+			Enabled:         true,
+			MinTotal:        1,
+			QueuedPercent:   90,
+			ReadyLag:        time.Minute,
+			OldestQueuedAge: time.Hour,
+			SustainedGrowth: false,
+		},
+		config.TrendSignalsConfig{},
+	)
+	c.setStore(&adaptiveTestStore{
+		Store: queue.NewMemoryStore(),
+		statsFn: func() (queue.Stats, error) {
+			return queue.Stats{
+				Total:    10,
+				ReadyLag: 2 * time.Minute,
+				ByState: map[queue.State]int{
+					queue.StateQueued: 2,
+					queue.StateLeased: 8,
+				},
+			}, nil
+		},
+	})
+
+	apply, reason := c.evaluate()
+	if !apply {
+		t.Fatal("expected adaptive backpressure to apply")
+	}
+	if reason != "ready_lag" {
+		t.Fatalf("expected reason ready_lag, got %q", reason)
+	}
+}
+
+func TestAdaptiveAdmissionController_SustainedGrowth(t *testing.T) {
+	now := time.Date(2026, 2, 12, 20, 0, 0, 0, time.UTC)
+
+	c := newAdaptiveAdmissionController(
+		config.AdaptiveBackpressureConfig{
+			Enabled:         true,
+			MinTotal:        1,
+			QueuedPercent:   95,
+			ReadyLag:        time.Hour,
+			OldestQueuedAge: time.Hour,
+			SustainedGrowth: true,
+		},
+		config.TrendSignalsConfig{
+			Window:                         15 * time.Minute,
+			ExpectedCaptureInterval:        time.Minute,
+			StaleGraceFactor:               3,
+			SustainedGrowthConsecutive:     3,
+			SustainedGrowthMinSamples:      5,
+			SustainedGrowthMinDelta:        10,
+			RecentSurgeMinTotal:            20,
+			RecentSurgeMinDelta:            10,
+			RecentSurgePercent:             50,
+			DeadShareHighMinTotal:          10,
+			DeadShareHighPercent:           20,
+			QueuedPressureMinTotal:         20,
+			QueuedPressurePercent:          75,
+			QueuedPressureLeasedMultiplier: 2,
+		},
+	)
+	c.now = func() time.Time { return now }
+	c.setStore(&adaptiveTestStore{
+		Store: queue.NewMemoryStore(),
+		statsFn: func() (queue.Stats, error) {
+			return queue.Stats{
+				Total: 100,
+				ByState: map[queue.State]int{
+					queue.StateQueued: 10,
+					queue.StateLeased: 90,
+				},
+			}, nil
+		},
+		trendFn: func(req queue.BacklogTrendListRequest) (queue.BacklogTrendListResponse, error) {
+			samples := []queue.BacklogTrendSample{
+				{CapturedAt: now.Add(-4 * time.Minute), Queued: 10},
+				{CapturedAt: now.Add(-3 * time.Minute), Queued: 20},
+				{CapturedAt: now.Add(-2 * time.Minute), Queued: 30},
+				{CapturedAt: now.Add(-1 * time.Minute), Queued: 40},
+				{CapturedAt: now, Queued: 50},
+			}
+			return queue.BacklogTrendListResponse{Items: samples}, nil
+		},
+	})
+
+	apply, reason := c.evaluate()
+	if !apply {
+		t.Fatal("expected adaptive backpressure to apply")
+	}
+	if reason != "sustained_growth" {
+		t.Fatalf("expected reason sustained_growth, got %q", reason)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,8 @@ type DefaultsBlock struct {
 
 	Deliver      *DeliverBlock
 	TrendSignals *TrendSignalsBlock
+
+	AdaptiveBackpressure *AdaptiveBackpressureBlock
 }
 
 type VarsBlock struct {
@@ -672,6 +674,32 @@ type TrendSignalsBlock struct {
 	QueuedPressureLeasedMultiplier       string
 	QueuedPressureLeasedMultiplierQuoted bool
 	QueuedPressureLeasedMultiplierSet    bool
+}
+
+type AdaptiveBackpressureBlock struct {
+	Enabled       string
+	EnabledQuoted bool
+	EnabledSet    bool
+
+	MinTotal       string
+	MinTotalQuoted bool
+	MinTotalSet    bool
+
+	QueuedPercent       string
+	QueuedPercentQuoted bool
+	QueuedPercentSet    bool
+
+	ReadyLag       string
+	ReadyLagQuoted bool
+	ReadyLagSet    bool
+
+	OldestQueuedAge       string
+	OldestQueuedAgeQuoted bool
+	OldestQueuedAgeSet    bool
+
+	SustainedGrowth       string
+	SustainedGrowthQuoted bool
+	SustainedGrowthSet    bool
 }
 
 type RetryBlock struct {

--- a/internal/config/format.go
+++ b/internal/config/format.go
@@ -194,6 +194,9 @@ func writeDefaultsBlock(b *bytes.Buffer, def *DefaultsBlock) {
 	if def.TrendSignals != nil {
 		writeTrendSignalsBlock(b, def.TrendSignals)
 	}
+	if def.AdaptiveBackpressure != nil {
+		writeAdaptiveBackpressureBlock(b, def.AdaptiveBackpressure)
+	}
 	b.WriteString("}\n")
 }
 
@@ -286,6 +289,29 @@ func writeTrendSignalsBlock(b *bytes.Buffer, block *TrendSignalsBlock) {
 	}
 	if block.QueuedPressureLeasedMultiplierSet {
 		fmt.Fprintf(b, "    queued_pressure_leased_multiplier %s\n", formatValue(block.QueuedPressureLeasedMultiplier, block.QueuedPressureLeasedMultiplierQuoted))
+	}
+	b.WriteString("  }\n")
+}
+
+func writeAdaptiveBackpressureBlock(b *bytes.Buffer, block *AdaptiveBackpressureBlock) {
+	b.WriteString("  adaptive_backpressure {\n")
+	if block.EnabledSet {
+		fmt.Fprintf(b, "    enabled %s\n", formatValue(block.Enabled, block.EnabledQuoted))
+	}
+	if block.MinTotalSet {
+		fmt.Fprintf(b, "    min_total %s\n", formatValue(block.MinTotal, block.MinTotalQuoted))
+	}
+	if block.QueuedPercentSet {
+		fmt.Fprintf(b, "    queued_percent %s\n", formatValue(block.QueuedPercent, block.QueuedPercentQuoted))
+	}
+	if block.ReadyLagSet {
+		fmt.Fprintf(b, "    ready_lag %s\n", formatValue(block.ReadyLag, block.ReadyLagQuoted))
+	}
+	if block.OldestQueuedAgeSet {
+		fmt.Fprintf(b, "    oldest_queued_age %s\n", formatValue(block.OldestQueuedAge, block.OldestQueuedAgeQuoted))
+	}
+	if block.SustainedGrowthSet {
+		fmt.Fprintf(b, "    sustained_growth %s\n", formatValue(block.SustainedGrowth, block.SustainedGrowthQuoted))
 	}
 	b.WriteString("  }\n")
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -1302,6 +1302,15 @@ func TestToolAdminHealthIncludesAdminDiagnostics(t *testing.T) {
 							"rejected_managed_target_mismatch_total":  2,
 							"rejected_managed_resolver_missing_total": 1,
 						},
+						"ingress": map[string]any{
+							"accepted_total":                      7,
+							"rejected_total":                      11,
+							"adaptive_backpressure_applied_total": 4,
+							"adaptive_backpressure_by_reason": map[string]any{
+								"queued_pressure": 3,
+								"ready_lag":       1,
+							},
+						},
 					},
 				})
 				return
@@ -1412,6 +1421,20 @@ func TestToolAdminHealthIncludesAdminDiagnostics(t *testing.T) {
 	}
 	if got := intFromAny(publishDiag["rejected_managed_resolver_missing_total"]); got != 1 {
 		t.Fatalf("expected rejected_managed_resolver_missing_total=1, got %#v", publishDiag["rejected_managed_resolver_missing_total"])
+	}
+	ingressDiag, ok := diagnostics["ingress"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected ingress diagnostics in admin health details, got %T", diagnostics["ingress"])
+	}
+	if got := intFromAny(ingressDiag["adaptive_backpressure_applied_total"]); got != 4 {
+		t.Fatalf("expected adaptive_backpressure_applied_total=4, got %#v", ingressDiag["adaptive_backpressure_applied_total"])
+	}
+	reasonDiag, ok := ingressDiag["adaptive_backpressure_by_reason"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected adaptive_backpressure_by_reason diagnostics map, got %T", ingressDiag["adaptive_backpressure_by_reason"])
+	}
+	if got := intFromAny(reasonDiag["queued_pressure"]); got != 3 {
+		t.Fatalf("expected adaptive_backpressure_by_reason.queued_pressure=3, got %#v", reasonDiag["queued_pressure"])
 	}
 }
 

--- a/internal/mcp/spec.md
+++ b/internal/mcp/spec.md
@@ -134,6 +134,7 @@ Notes:
 - Also probes configured Admin API health endpoint (`/healthz?details=1`) when config compiles successfully.
 - Includes `admin_api` probe result (`checked`, `ok`, `status_code`, `error`) and optional diagnostics details payload.
 - Passes through Admin diagnostics payloads (for example `diagnostics.publish` counters), including publish rejection diagnostics such as `rejected_managed_target_mismatch_total` and `rejected_managed_resolver_missing_total` when provided by Admin runtime metrics.
+- Passes through ingress adaptive backpressure diagnostics when available (`diagnostics.ingress.adaptive_backpressure_applied_total` and `diagnostics.ingress.adaptive_backpressure_by_reason`).
 - Includes MCP-local Admin-proxy publish rollback counters under `mcp.admin_proxy_publish` (`rollback_attempts_total`, `rollback_succeeded_total`, `rollback_failed_total`, `rollback_ids_total`).
 - `trend_signals` evaluation uses compiled `defaults.trend_signals` policy when available; otherwise built-in defaults.
 - `trend_signals` include `operator_actions` playbooks with stable action IDs, severity, alert-routing keys, and suggested Admin/MCP operations.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -238,6 +238,38 @@ type Stats struct {
 	TopQueued []BacklogBucket
 }
 
+type HistogramBucket struct {
+	Le    float64
+	Count int64
+}
+
+type HistogramSnapshot struct {
+	Buckets []HistogramBucket
+	Count   int64
+	Sum     float64
+}
+
+type SQLiteRuntimeMetrics struct {
+	WriteDurationSeconds      HistogramSnapshot
+	DequeueDurationSeconds    HistogramSnapshot
+	CheckpointDurationSeconds HistogramSnapshot
+	BusyTotal                 int64
+	RetryTotal                int64
+	TxCommitTotal             int64
+	TxRollbackTotal           int64
+	CheckpointTotal           int64
+	CheckpointErrorTotal      int64
+}
+
+type StoreRuntimeMetrics struct {
+	Backend string
+	SQLite  *SQLiteRuntimeMetrics
+}
+
+type RuntimeMetricsProvider interface {
+	RuntimeMetrics() StoreRuntimeMetrics
+}
+
 type Store interface {
 	Enqueue(env Envelope) error
 	Dequeue(req DequeueRequest) (DequeueResponse, error)

--- a/internal/queue/sqlite_test.go
+++ b/internal/queue/sqlite_test.go
@@ -1252,6 +1252,71 @@ func TestSQLiteStore_QueueLimitsDropOldest(t *testing.T) {
 	}
 }
 
+func TestSQLiteStore_QueueCountersTrackActiveDepth(t *testing.T) {
+	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
+	nowVar := now
+	s := newSQLiteStoreForTest(t, func() time.Time { return nowVar })
+
+	mustCounters := func(wantQueued, wantLeased int) {
+		t.Helper()
+		var queued int
+		var leased int
+		if err := s.db.QueryRow(`SELECT queued, leased FROM queue_counters WHERE id = 1;`).Scan(&queued, &leased); err != nil {
+			t.Fatalf("queue_counters query: %v", err)
+		}
+		if queued != wantQueued || leased != wantLeased {
+			t.Fatalf("queue_counters: got queued=%d leased=%d, want queued=%d leased=%d", queued, leased, wantQueued, wantLeased)
+		}
+	}
+
+	mustCounters(0, 0)
+
+	if err := s.Enqueue(Envelope{ID: "q1", Route: "/r", Target: "pull", State: StateQueued}); err != nil {
+		t.Fatalf("enqueue q1: %v", err)
+	}
+	if err := s.Enqueue(Envelope{ID: "d1", Route: "/r", Target: "pull", State: StateDead}); err != nil {
+		t.Fatalf("enqueue d1: %v", err)
+	}
+	if err := s.Enqueue(Envelope{ID: "q2", Route: "/r", Target: "pull", State: StateQueued}); err != nil {
+		t.Fatalf("enqueue q2: %v", err)
+	}
+	mustCounters(2, 0)
+
+	resp, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 1, LeaseTTL: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 dequeued item, got %d", len(resp.Items))
+	}
+	leaseID := resp.Items[0].LeaseID
+	mustCounters(1, 1)
+
+	if err := s.Nack(leaseID, 0); err != nil {
+		t.Fatalf("nack: %v", err)
+	}
+	mustCounters(2, 0)
+
+	resp2, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 2, LeaseTTL: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("dequeue2: %v", err)
+	}
+	if len(resp2.Items) != 2 {
+		t.Fatalf("expected 2 dequeued items, got %d", len(resp2.Items))
+	}
+	mustCounters(0, 2)
+
+	if err := s.Ack(resp2.Items[0].LeaseID); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+	mustCounters(0, 1)
+
+	if err := s.MarkDead(resp2.Items[1].LeaseID, "no_retry"); err != nil {
+		t.Fatalf("mark dead: %v", err)
+	}
+	mustCounters(0, 0)
+}
+
 func TestSQLiteStore_RuntimeMetrics(t *testing.T) {
 	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
 	nowVar := now


### PR DESCRIPTION
## Summary
Integrates the saturation resilience stack into `main` in one step:
- adaptive soft-pressure backpressure before hard queue limits
- SQLite/store contention and checkpoint metrics
- control-plane hardening for `/metrics` and health diagnostics under pressure

## Tracking
- refs #24
- refs #25
- refs #26

## Notes
Issue #23 remains open pending a fresh stress rerun and measured throughput/latency comparison.