### PR TITLE
release: cut v1.1.0 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-02-12
+
 ### Added
 
 - Official container publishing to GHCR (`ghcr.io/nuetzliches/hookaido`) via tag-triggered multi-arch workflow (`linux/amd64`, `linux/arm64`) with registry provenance attestation.


### PR DESCRIPTION
Finalize changelog section for v1.1.0 (2026-02-12). Tag v1.1.0 is already pushed.