### PR TITLE
chore(build): write local binary to bin/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,12 @@
+GOEXE := $(shell go env GOEXE)
+BINARY := hookaido$(GOEXE)
+BINDIR := bin
+
 .PHONY: build test fmt lint check release-check dist dist-signed dist-verify
 
 build:
-	go build ./cmd/hookaido
+	@mkdir -p "$(BINDIR)"
+	go build -o "$(BINDIR)/$(BINARY)" ./cmd/hookaido
 
 test:
 	go test ./...


### PR DESCRIPTION
## Summary
- make `build` output deterministic in `bin/` instead of repository root
- avoid untracked `./hookaido` artifact during local checks (e.g. `make release-check`)
- keep platform compatibility via `GOEXE`

## Verification
- `make build`
- `make release-check`