### PR TITLE
fix(queue): guard memory delivered retention with max_depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- Memory backend retention safety: with `delivered_retention` enabled, `queue_limits.max_depth` now also caps `queued + leased + delivered` items so sustained pull/ack traffic cannot grow delivered retention unbounded in RAM.
+
 ## [1.1.0] - 2026-02-12
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -178,6 +178,8 @@ Persisted, replayable envelope:
 - Controlled by `delivered_retention { max_age }` (opt-in).
 - Pruning removes delivered items older than `max_age`.
 - Pruning cadence uses `queue_retention.prune_interval`.
+- For `queue { backend memory }`, when delivered retention is enabled, `queue_limits.max_depth`
+  also guards `queued + leased + delivered` items to bound in-memory retention growth.
 - Set `max_age off` (or `0`) to disable delivered retention.
 
 ### DLQ Retention & Pruning

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -219,6 +219,11 @@ delivered_retention {
 
 Pruning uses the same `queue_retention.prune_interval` cadence. Set `max_age off` to disable.
 
+When `queue { backend memory }` is used and delivered retention is enabled, `queue_limits.max_depth`
+also guards `queued + leased + delivered` items. This prevents unbounded delivered-retention growth
+under sustained pull/ack workloads. If the guard is reached, new enqueues are rejected until retention
+pruning frees capacity.
+
 ### `dlq_retention`
 
 ```hcl


### PR DESCRIPTION
## Summary
- fix memory-backend retention growth when delivered_retention is enabled by applying a second admission guard in MemoryStore.Enqueue/EnqueueBatch
- keep active queue pressure semantics (queued+leased) and additionally cap queued+leased+delivered against queue_limits.max_depth for this mode
- add regression tests for single and batch enqueue under delivered retention saturation
- document the behavior in DESIGN.md, docs/configuration.md, and CHANGELOG.md

## Why
Issue #40 reports that sustained pull/ack traffic with delivered retention can keep RAM growing while active depth appears healthy, because delivered items were not part of admission checks.

## Validation
- go test ./...

## MCP Coverage Decision
No MCP surface changes are required for this runtime guard fix (no new tool/schema/arguments). Existing MCP queue/admin tools observe unchanged API contracts.

Closes #40