### PR TITLE
feat(metrics): add queue lag/age gauges for saturation alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- Prometheus queue saturation gauges: `hookaido_queue_oldest_queued_age_seconds`, `hookaido_queue_ready_lag_seconds`, and `hookaido_queue_total` on `/metrics` (alongside `hookaido_queue_depth{state}`) for direct lag/age alerting without Admin health JSON scraping.
+
 ## [1.1.0] - 2026-02-12
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -363,7 +363,7 @@ Secret rotation semantics:
 - Metrics include publish mutation counters: `hookaido_publish_accepted_total`, `hookaido_publish_rejected_total`, rejection-class counters (`hookaido_publish_rejected_validation_total`, `hookaido_publish_rejected_policy_total`, `hookaido_publish_rejected_conflict_total`, `hookaido_publish_rejected_queue_full_total`, `hookaido_publish_rejected_store_total`), managed-ownership policy counters (`hookaido_publish_rejected_managed_target_mismatch_total`, `hookaido_publish_rejected_managed_resolver_missing_total`), and scoped counters (`hookaido_publish_scoped_accepted_total`, `hookaido_publish_scoped_rejected_total`).
 - Metrics include ingress counters: `hookaido_ingress_accepted_total`, `hookaido_ingress_rejected_total`, `hookaido_ingress_enqueued_total`, adaptive-backpressure counters `hookaido_ingress_adaptive_backpressure_total{reason}`, and `hookaido_ingress_adaptive_backpressure_applied_total`.
 - Metrics include delivery counters: `hookaido_delivery_attempts_total`, `hookaido_delivery_acked_total`, `hookaido_delivery_retry_total`, `hookaido_delivery_dead_total`.
-- Metrics include on-scrape queue depth gauge: `hookaido_queue_depth{state}` (queued, leased, dead).
+- Metrics include on-scrape queue gauges: `hookaido_queue_depth{state}` (queued, leased, dead), `hookaido_queue_total`, `hookaido_queue_oldest_queued_age_seconds`, and `hookaido_queue_ready_lag_seconds`.
 
 ## CLI
 - `hookaido run --config ./Hookaidofile [--db ./hookaido.db] [--pid-file ./hookaido.pid] [--watch] [--log-level info] [--dotenv ./.env]`

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -117,9 +117,9 @@ Set `enabled off` to disable the metrics listener while keeping config in place.
 | Metric                          | Type    | Description                                   |
 | ------------------------------- | ------- | --------------------------------------------- |
 | `hookaido_queue_depth`          | gauge   | Current items by state (queued, leased, dead) |
-| `hookaido_queue_enqueued_total` | counter | Total enqueued items                          |
-| `hookaido_queue_acked_total`    | counter | Total acknowledged items                      |
-| `hookaido_queue_dead_total`     | counter | Total dead-lettered items                     |
+| `hookaido_queue_total`          | gauge   | Current total items across all queue states   |
+| `hookaido_queue_oldest_queued_age_seconds` | gauge | Age of the oldest queued item in seconds |
+| `hookaido_queue_ready_lag_seconds` | gauge | Ready lag of the earliest runnable queued item in seconds |
 
 **Ingress metrics:**
 

--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -924,6 +924,15 @@ func newMetricsHandler(version string, start time.Time, rm *runtimeMetrics) http
 				_, _ = fmt.Fprintf(w, "hookaido_queue_depth{state=\"queued\"} %d\n", queued)
 				_, _ = fmt.Fprintf(w, "hookaido_queue_depth{state=\"leased\"} %d\n", leased)
 				_, _ = fmt.Fprintf(w, "hookaido_queue_depth{state=\"dead\"} %d\n", dead)
+				_, _ = fmt.Fprintf(w, "# HELP hookaido_queue_total Current total number of items in the queue.\n")
+				_, _ = fmt.Fprintf(w, "# TYPE hookaido_queue_total gauge\n")
+				_, _ = fmt.Fprintf(w, "hookaido_queue_total %d\n", stats.Total)
+				_, _ = fmt.Fprintf(w, "# HELP hookaido_queue_oldest_queued_age_seconds Age in seconds of the oldest queued item.\n")
+				_, _ = fmt.Fprintf(w, "# TYPE hookaido_queue_oldest_queued_age_seconds gauge\n")
+				_, _ = fmt.Fprintf(w, "hookaido_queue_oldest_queued_age_seconds %.6f\n", stats.OldestQueuedAge.Seconds())
+				_, _ = fmt.Fprintf(w, "# HELP hookaido_queue_ready_lag_seconds Lag in seconds of the earliest ready queued item.\n")
+				_, _ = fmt.Fprintf(w, "# TYPE hookaido_queue_ready_lag_seconds gauge\n")
+				_, _ = fmt.Fprintf(w, "hookaido_queue_ready_lag_seconds %.6f\n", stats.ReadyLag.Seconds())
 			}
 
 			if provider, ok := queueStore.(queue.RuntimeMetricsProvider); ok {


### PR DESCRIPTION
﻿## Summary
- add queue saturation gauges to `/metrics`:
  - `hookaido_queue_oldest_queued_age_seconds`
  - `hookaido_queue_ready_lag_seconds`
  - `hookaido_queue_total`
- keep existing `hookaido_queue_depth{state}` output unchanged
- extend metrics tests for non-nil store, deterministic lag/age values, and nil-store absence checks
- update `docs/observability.md`, `DESIGN.md`, and `CHANGELOG.md`

## Why
Issue #35 requests direct Prometheus queue lag/age signals so saturation alerting does not require polling `/healthz?details=1` and parsing JSON.

## Validation
- `go test ./internal/app -run TestMetricsHandler_Queue -count=1`
- `go test ./...`

## MCP Coverage Decision
No MCP schema/tool changes required. Existing read tools (`admin_health`, backlog views) already expose queue diagnostics; this PR only adds Prometheus series.

Closes #35
