### PR TITLE
feat(queue): add memory pressure metrics and rejection signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ### Added
 
 - Prometheus queue saturation gauges: `hookaido_queue_oldest_queued_age_seconds`, `hookaido_queue_ready_lag_seconds`, and `hookaido_queue_total` on `/metrics` (alongside `hookaido_queue_depth{state}`) for direct lag/age alerting without Admin health JSON scraping.
+- Memory-backend observability on `/metrics`: `hookaido_store_memory_items{state}`, `hookaido_store_memory_retained_bytes{state}`, `hookaido_store_memory_retained_bytes_total`, and `hookaido_store_memory_evictions_total{reason}`.
+- Ingress rejection breakdown counters via `hookaido_ingress_rejected_by_reason_total{reason,status}` now include `memory_pressure` (`status="503"`) for memory-backend pressure rejects.
 
+### Changed
+
+- Memory backend now emits explicit `ErrMemoryPressure` admission rejects when retained (non-active) memory footprint crosses pressure guard thresholds; ingress surfaces these as HTTP `503` with rejection reason `memory_pressure` instead of generic store-unavailable.
+- Admin health diagnostics (`GET /healthz?details=1`) now include ingress `rejected_by_reason` and memory-store runtime diagnostics (`items_by_state`, retained bytes, eviction counters, and memory pressure state) when the memory backend is active.
 - Ingress rejection breakdown metric `hookaido_ingress_rejected_by_reason_total{reason,status}` for bounded-cardinality attribution across queue pressure, adaptive backpressure, auth, routing, policy, and fallback reject paths.
 
 ### Fixed

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -49,12 +49,29 @@ Returns detailed JSON diagnostics:
     "ingress": {
       "accepted_total": 100000,
       "rejected_total": 4123,
+      "rejected_by_reason": {
+        "memory_pressure": 12,
+        "queue_full": 41,
+        "adaptive_backpressure": 345
+      },
       "adaptive_backpressure_applied_total": 345,
       "adaptive_backpressure_by_reason": {
         "queued_pressure": 221,
         "ready_lag": 79,
         "oldest_queued_age": 31,
         "sustained_growth": 14
+      }
+    },
+    "store": {
+      "backend": "memory",
+      "items_by_state": { "queued": 1200, "leased": 300, "delivered": 4000, "dead": 23 },
+      "retained_bytes_total": 91234567,
+      "memory_pressure": {
+        "active": false,
+        "reason": "",
+        "retained_item_limit": 10000,
+        "retained_bytes_limit": 268435456,
+        "rejected_total": 12
       }
     }
   }
@@ -66,7 +83,8 @@ The health endpoint includes:
 - Queue state rollups with age/lag indicators
 - Top route/target backlog buckets
 - Persisted trend signals with operator action playbooks
-- Ingress counters and adaptive-backpressure diagnostics (when runtime metrics are enabled)
+- Ingress counters, rejection-by-reason counters, and adaptive-backpressure diagnostics (when runtime metrics are enabled)
+- Memory-store runtime diagnostics (`store.*`) when queue backend is `memory`
 - Tracing counters (when metrics are enabled)
 
 ## Queue Reads

--- a/internal/ingress/http.go
+++ b/internal/ingress/http.go
@@ -176,7 +176,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusServiceUnavailable)
 			s.observe(false, enqueued)
 			reason := "other"
-			if errors.Is(err, queue.ErrQueueFull) {
+			switch {
+			case errors.Is(err, queue.ErrMemoryPressure):
+				reason = "memory_pressure"
+			case errors.Is(err, queue.ErrQueueFull):
 				reason = "queue_full"
 			}
 			s.observeReject(route, http.StatusServiceUnavailable, reason)

--- a/internal/mcp/spec.md
+++ b/internal/mcp/spec.md
@@ -135,6 +135,7 @@ Notes:
 - Includes `admin_api` probe result (`checked`, `ok`, `status_code`, `error`) and optional diagnostics details payload.
 - Passes through Admin diagnostics payloads (for example `diagnostics.publish` counters), including publish rejection diagnostics such as `rejected_managed_target_mismatch_total` and `rejected_managed_resolver_missing_total` when provided by Admin runtime metrics.
 - Passes through ingress adaptive backpressure diagnostics when available (`diagnostics.ingress.adaptive_backpressure_applied_total` and `diagnostics.ingress.adaptive_backpressure_by_reason`).
+- Passes through ingress rejection-by-reason diagnostics (`diagnostics.ingress.rejected_by_reason`) and memory-store pressure diagnostics (`diagnostics.store.memory_pressure`, retained bytes/items, eviction counters) when present in Admin health details.
 - Includes MCP-local Admin-proxy publish rollback counters under `mcp.admin_proxy_publish` (`rollback_attempts_total`, `rollback_succeeded_total`, `rollback_failed_total`, `rollback_ids_total`).
 - `trend_signals` evaluation uses compiled `defaults.trend_signals` policy when available; otherwise built-in defaults.
 - `trend_signals` include `operator_actions` playbooks with stable action IDs, severity, alert-routing keys, and suggested Admin/MCP operations.

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -261,9 +261,28 @@ type SQLiteRuntimeMetrics struct {
 	CheckpointErrorTotal      int64
 }
 
+type MemoryPressureRuntimeMetrics struct {
+	Active             bool
+	Reason             string
+	RetainedItems      int64
+	RetainedBytes      int64
+	RetainedItemLimit  int64
+	RetainedBytesLimit int64
+	RejectTotal        int64
+}
+
+type MemoryRuntimeMetrics struct {
+	ItemsByState           map[State]int64
+	RetainedBytesByState   map[State]int64
+	RetainedBytesTotal     int64
+	EvictionsTotalByReason map[string]int64
+	Pressure               MemoryPressureRuntimeMetrics
+}
+
 type StoreRuntimeMetrics struct {
 	Backend string
 	SQLite  *SQLiteRuntimeMetrics
+	Memory  *MemoryRuntimeMetrics
 }
 
 type RuntimeMetricsProvider interface {


### PR DESCRIPTION
## Summary
- add memory-backend runtime metrics (items, retained bytes, eviction counters) via RuntimeMetrics() and export them on /metrics
- add memory-pressure admission signaling in MemoryStore (ErrMemoryPressure) with retained-state pressure guardrails and rejection counters
- add ingress rejection reason instrumentation (hookaido_ingress_rejected_reason_total{reason}), including memory_pressure
- surface ingress ejected_by_reason plus memory store pressure diagnostics in /healthz?details=1
- update docs/specs (CHANGELOG.md, DESIGN.md, docs/observability.md, docs/admin-api.md, internal/mcp/spec.md) and extend MCP tests for diagnostics passthrough

## Testing
- go test ./...

Closes #41