### PR TITLE
feat: complete issue #39 performance and saturation slices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ hookaido.db-wal
 
 # Local artifacts (keys, binaries, etc.)
 /.artifacts/
+/.bench/

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,6 +12,9 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 
 ## P1 - Medium Priority (v1.x)
 
+- [x] **~~Mixed-workload tail latency playbook~~** — Reproducible mixed ingress+drain benchmark workflow with p95/p99 reporting added (`bench-pull-mixed*`; moved to Completed).
+- [x] **~~Drain fairness under saturation~~** — Reproducible push saturation/skewed benchmark guardrails now include reject-reason splits plus `p95_ms`/`p99_ms`; dispatcher saturation path tuned with route-shared workers, target-aware dequeue micro-batching, and single-target lease-mutation batching with multi-target fallback (moved to Completed).
+- [x] **~~Adaptive backpressure production tuning guide~~** — Data-driven threshold tuning guidance with enterprise starting profiles published (moved to Completed).
 - [x] **~~Management model runtime wiring~~** — All Admin API management fields wired in `run.go` (moved to Completed).
 - [x] **~~Config `validate --format json`~~** — Parse/file errors now respect `--format` flag; 7 CLI tests added (moved to Completed).
 - [x] **~~Egress policy enforcement~~** — Full test coverage added: deny-before-allow ordering, CIDR-deny-overrides-allow, subdomain wildcards, deny-only mode, empty policy, non-HTTP scheme, redirect blocked/followed/hop-recheck, HTTPS-only delivery denial (moved to Completed).
@@ -37,6 +40,9 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 
 ## Completed (move here when done)
 
+- [x] **Drain fairness under saturation** — Completed saturation tuning across push drain paths: route-shared workers with target-aware dequeue micro-batching (`single-target` up to 4, `multi-target` up to 2), single-target lease-mutation batching with fallback safety, and reproducible push benchmarks with reject-reason and tail-latency (`p95_ms`/`p99_ms`) guardrails.
+- [x] **Mixed-workload tail latency playbook** — Added reproducible mixed ingress+drain benchmark profile in `internal/pullapi/bench_test.go` (`BenchmarkMixedIngressDrain`) with `p95_ms`/`p99_ms` reporting and Makefile targets `bench-pull-mixed-baseline`, `bench-pull-mixed`, `bench-pull-mixed-compare`.
+- [x] **Adaptive backpressure production tuning guide** — Added dedicated operations guide `docs/adaptive-backpressure.md` with recommended starting profiles (`balanced`, `latency_first`, `throughput_first`), a metrics-first decision matrix, and guardrails for dashboard/version compatibility.
 - [x] **CII Best Practices badge** — OpenSSF Best Practices badge published at <https://www.bestpractices.dev/projects/11921>; `README.md` badge/link and docs references updated. Ongoing evidence/maintenance notes live in `docs/ossf-best-practices.md`.
 - [x] **Documentation UX refresh** — Refreshed docs information architecture in `mkdocs.yml` (grouped navigation), rebuilt `docs/index.md` with a landing hero + task-oriented quick paths, added command-palette style search shortcut (`Ctrl+K`) via `docs/assets/javascripts/command-palette.js`, added docs UX styling in `docs/assets/stylesheets/extra.css`, and documented docs-stack evaluation/decision in `docs/documentation-platform.md` (keep MkDocs Material for current roadmap window).
 - [x] **CII badge readiness docs** — Added `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `SUPPORT.md`, `GOVERNANCE.md`, and `.github/CODEOWNERS`; linked governance/security docs from `README.md` and `docs/index.md` to prepare badge evidence links.
@@ -74,4 +80,3 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 - [x] **VS Code Extension** — TextMate grammar for full DSL syntax highlighting (top-level blocks, route paths, directives, auth keywords, channel types, placeholders, durations, built-in constants). 18 snippets for common blocks. File association for `Hookaidofile`, `*.hookaido`, `*.hkd`. Located in `editors/vscode/`.
 - [x] **Score hardening pass (round 2)** — Ingress body-too-large 413 + body-read-error 400 tests, egress DNS resolver error test, memory store Extend edge cases (unknown lease, expired lease, zero-duration noop), pull API dequeue-store-error 503 + unknown-operation 404 tests.
 - [x] **Score hardening pass (round 3)** — Pull API Ack/Nack/MarkDead store-error + lease-expired paths (6 tests), config secrets validation edge cases (5 subtests), HTTP deliverer signing-header-missing error (4 subtests), SQLite Extend zero/negative noop test.
-

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,37 @@
 GOEXE := $(shell go env GOEXE)
 BINARY := hookaido$(GOEXE)
 BINDIR := bin
+BENCH_DIR := .bench
+PULL_BENCH_FLAGS := -run '^$$' -bench '^BenchmarkPull' -benchmem -benchtime=3s -count=5 -cpu 1
+PULL_BENCH_CURRENT := $(BENCH_DIR)/pull.txt
+PULL_BENCH_BASELINE := $(BENCH_DIR)/pull-baseline.txt
+PULL_BENCH_COMPARE := $(BENCH_DIR)/pull-compare.txt
+PULL_EXTEND_BENCH_FLAGS := -run '^$$' -bench '^BenchmarkPullDequeueExtendSingle$$' -benchmem -benchtime=5s -count=10 -cpu 1
+PULL_EXTEND_CURRENT := $(BENCH_DIR)/pull-extend.txt
+PULL_EXTEND_COMPARE := $(BENCH_DIR)/pull-extend-compare.txt
+PULL_DRAIN_BENCH_FLAGS := -run '^$$' -bench '^BenchmarkPullDequeueAckBatch15$$' -benchmem -benchtime=5s -count=10 -cpu 1
+PULL_DRAIN_CURRENT := $(BENCH_DIR)/pull-drain.txt
+PULL_DRAIN_BASELINE := $(BENCH_DIR)/pull-drain-baseline.txt
+PULL_DRAIN_COMPARE := $(BENCH_DIR)/pull-drain-compare.txt
+PULL_CONTENTION_BENCH_FLAGS := -run '^$$' -bench '^BenchmarkPull(Ack|Nack)RetryParallel$$' -benchmem -benchtime=5s -count=10 -cpu 1,4
+PULL_CONTENTION_CURRENT := $(BENCH_DIR)/pull-contention.txt
+PULL_CONTENTION_BASELINE := $(BENCH_DIR)/pull-contention-baseline.txt
+PULL_CONTENTION_COMPARE := $(BENCH_DIR)/pull-contention-compare.txt
+PULL_MIXED_BENCH_FLAGS := -run '^$$' -bench '^BenchmarkMixedIngressDrain$$' -benchmem -benchtime=8s -count=5 -cpu 4
+PULL_MIXED_CURRENT := $(BENCH_DIR)/pull-mixed.txt
+PULL_MIXED_BASELINE := $(BENCH_DIR)/pull-mixed-baseline.txt
+PULL_MIXED_COMPARE := $(BENCH_DIR)/pull-mixed-compare.txt
+PUSH_MIXED_BENCH_FLAGS := -run '^$$' -bench '^BenchmarkPushIngressDrainSaturation$$' -benchmem -benchtime=8s -count=5 -cpu 4
+PUSH_MIXED_CURRENT := $(BENCH_DIR)/push-mixed.txt
+PUSH_MIXED_BASELINE := $(BENCH_DIR)/push-mixed-baseline.txt
+PUSH_MIXED_COMPARE := $(BENCH_DIR)/push-mixed-compare.txt
+PUSH_SKEWED_BENCH_FLAGS := -run '^$$' -bench '^BenchmarkPushIngressDrainSkewedTargets$$' -benchmem -benchtime=8s -count=5 -cpu 4
+PUSH_SKEWED_CURRENT := $(BENCH_DIR)/push-skewed.txt
+PUSH_SKEWED_BASELINE := $(BENCH_DIR)/push-skewed-baseline.txt
+PUSH_SKEWED_COMPARE := $(BENCH_DIR)/push-skewed-compare.txt
+BENCHSTAT_CMD := golang.org/x/perf/cmd/benchstat@v0.0.0-20260211190930-8161c38c6cdc
 
-.PHONY: build test fmt lint check release-check dist dist-signed dist-verify
+.PHONY: build test fmt lint check bench-pull bench-pull-baseline bench-pull-compare bench-pull-extend bench-pull-extend-compare bench-pull-drain bench-pull-drain-baseline bench-pull-drain-compare bench-pull-contention bench-pull-contention-baseline bench-pull-contention-compare bench-pull-mixed bench-pull-mixed-baseline bench-pull-mixed-compare bench-push-mixed bench-push-mixed-baseline bench-push-mixed-compare bench-push-skewed bench-push-skewed-baseline bench-push-skewed-compare release-check dist dist-signed dist-verify
 
 build:
 	@mkdir -p "$(BINDIR)"
@@ -18,6 +47,93 @@ lint:
 	go vet ./...
 
 check: lint test
+
+bench-pull:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=1 go test ./internal/pullapi $(PULL_BENCH_FLAGS) | tee "$(PULL_BENCH_CURRENT)"
+
+bench-pull-baseline:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=1 go test ./internal/pullapi $(PULL_BENCH_FLAGS) | tee "$(PULL_BENCH_BASELINE)"
+
+bench-pull-compare:
+	@test -f "$(PULL_BENCH_BASELINE)" || (echo "baseline missing: run 'make bench-pull-baseline' first" && exit 1)
+	@test -f "$(PULL_BENCH_CURRENT)" || (echo "current run missing: run 'make bench-pull' first" && exit 1)
+	go run "$(BENCHSTAT_CMD)" "$(PULL_BENCH_BASELINE)" "$(PULL_BENCH_CURRENT)" | tee "$(PULL_BENCH_COMPARE)"
+
+bench-pull-extend:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=1 go test ./internal/pullapi $(PULL_EXTEND_BENCH_FLAGS) | tee "$(PULL_EXTEND_CURRENT)"
+
+bench-pull-extend-compare:
+	@test -f "$(PULL_BENCH_BASELINE)" || (echo "baseline missing: run 'make bench-pull-baseline' first" && exit 1)
+	@test -f "$(PULL_EXTEND_CURRENT)" || (echo "current extend run missing: run 'make bench-pull-extend' first" && exit 1)
+	go run "$(BENCHSTAT_CMD)" "$(PULL_BENCH_BASELINE)" "$(PULL_EXTEND_CURRENT)" | tee "$(PULL_EXTEND_COMPARE)"
+
+bench-pull-drain:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=1 go test ./internal/pullapi $(PULL_DRAIN_BENCH_FLAGS) | tee "$(PULL_DRAIN_CURRENT)"
+
+bench-pull-drain-baseline:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=1 go test ./internal/pullapi $(PULL_DRAIN_BENCH_FLAGS) | tee "$(PULL_DRAIN_BASELINE)"
+
+bench-pull-drain-compare:
+	@test -f "$(PULL_DRAIN_BASELINE)" || (echo "baseline missing: run 'make bench-pull-drain-baseline' first" && exit 1)
+	@test -f "$(PULL_DRAIN_CURRENT)" || (echo "current drain run missing: run 'make bench-pull-drain' first" && exit 1)
+	go run "$(BENCHSTAT_CMD)" "$(PULL_DRAIN_BASELINE)" "$(PULL_DRAIN_CURRENT)" | tee "$(PULL_DRAIN_COMPARE)"
+
+bench-pull-contention:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/pullapi $(PULL_CONTENTION_BENCH_FLAGS) | tee "$(PULL_CONTENTION_CURRENT)"
+
+bench-pull-contention-baseline:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/pullapi $(PULL_CONTENTION_BENCH_FLAGS) | tee "$(PULL_CONTENTION_BASELINE)"
+
+bench-pull-contention-compare:
+	@test -f "$(PULL_CONTENTION_BASELINE)" || (echo "baseline missing: run 'make bench-pull-contention-baseline' first" && exit 1)
+	@test -f "$(PULL_CONTENTION_CURRENT)" || (echo "current contention run missing: run 'make bench-pull-contention' first" && exit 1)
+	go run "$(BENCHSTAT_CMD)" "$(PULL_CONTENTION_BASELINE)" "$(PULL_CONTENTION_CURRENT)" | tee "$(PULL_CONTENTION_COMPARE)"
+
+bench-pull-mixed:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/pullapi $(PULL_MIXED_BENCH_FLAGS) | tee "$(PULL_MIXED_CURRENT)"
+
+bench-pull-mixed-baseline:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/pullapi $(PULL_MIXED_BENCH_FLAGS) | tee "$(PULL_MIXED_BASELINE)"
+
+bench-pull-mixed-compare:
+	@test -f "$(PULL_MIXED_BASELINE)" || (echo "baseline missing: run 'make bench-pull-mixed-baseline' first" && exit 1)
+	@test -f "$(PULL_MIXED_CURRENT)" || (echo "current mixed run missing: run 'make bench-pull-mixed' first" && exit 1)
+	go run "$(BENCHSTAT_CMD)" "$(PULL_MIXED_BASELINE)" "$(PULL_MIXED_CURRENT)" | tee "$(PULL_MIXED_COMPARE)"
+
+bench-push-mixed:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/dispatcher $(PUSH_MIXED_BENCH_FLAGS) | tee "$(PUSH_MIXED_CURRENT)"
+
+bench-push-mixed-baseline:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/dispatcher $(PUSH_MIXED_BENCH_FLAGS) | tee "$(PUSH_MIXED_BASELINE)"
+
+bench-push-mixed-compare:
+	@test -f "$(PUSH_MIXED_BASELINE)" || (echo "baseline missing: run 'make bench-push-mixed-baseline' first" && exit 1)
+	@test -f "$(PUSH_MIXED_CURRENT)" || (echo "current mixed push run missing: run 'make bench-push-mixed' first" && exit 1)
+	go run "$(BENCHSTAT_CMD)" "$(PUSH_MIXED_BASELINE)" "$(PUSH_MIXED_CURRENT)" | tee "$(PUSH_MIXED_COMPARE)"
+
+bench-push-skewed:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/dispatcher $(PUSH_SKEWED_BENCH_FLAGS) | tee "$(PUSH_SKEWED_CURRENT)"
+
+bench-push-skewed-baseline:
+	@mkdir -p "$(BENCH_DIR)"
+	GOMAXPROCS=4 go test ./internal/dispatcher $(PUSH_SKEWED_BENCH_FLAGS) | tee "$(PUSH_SKEWED_BASELINE)"
+
+bench-push-skewed-compare:
+	@test -f "$(PUSH_SKEWED_BASELINE)" || (echo "baseline missing: run 'make bench-push-skewed-baseline' first" && exit 1)
+	@test -f "$(PUSH_SKEWED_CURRENT)" || (echo "current skewed push run missing: run 'make bench-push-skewed' first" && exit 1)
+	go run "$(BENCHSTAT_CMD)" "$(PUSH_SKEWED_BASELINE)" "$(PUSH_SKEWED_CURRENT)" | tee "$(PUSH_SKEWED_COMPARE)"
 
 release-check: check build
 

--- a/docs/adaptive-backpressure.md
+++ b/docs/adaptive-backpressure.md
@@ -1,0 +1,92 @@
+# Adaptive Backpressure Tuning
+
+This guide provides a production-focused tuning workflow for `defaults.adaptive_backpressure`.
+
+Goal:
+- stabilize ingress tail latency (p95/p99) before hard queue saturation
+- reduce hard `queue_full` rejects (`503`) without over-throttling ingress
+
+## Prerequisites
+
+Enable metrics and collect:
+
+- `hookaido_queue_total`
+- `hookaido_queue_ready_lag_seconds`
+- `hookaido_queue_oldest_queued_age_seconds`
+- `hookaido_ingress_adaptive_backpressure_applied_total`
+- `hookaido_ingress_adaptive_backpressure_total{reason}`
+- `hookaido_ingress_rejected_by_reason_total{reason,status}`
+
+Also capture ingress request latency percentiles from your HTTP telemetry (`p95`, `p99`).
+
+## Starting Profiles
+
+Pick one profile and adjust from there.
+
+| Profile | Use when | `min_total` | `queued_percent` | `ready_lag` | `oldest_queued_age` | `sustained_growth` |
+| --- | --- | ---: | ---: | --- | --- | --- |
+| `balanced` | default for most teams | `200` | `80` | `30s` | `60s` | `on` |
+| `latency_first` | strict p95/p99 protection | `100` | `72` | `15s` | `30s` | `on` |
+| `throughput_first` | fewer early rejects, more queue elasticity | `400` | `88` | `45s` | `90s` | `on` |
+
+Example (`latency_first`):
+
+```hcl
+defaults {
+  adaptive_backpressure {
+    enabled on
+    min_total 100
+    queued_percent 72
+    ready_lag 15s
+    oldest_queued_age 30s
+    sustained_growth on
+  }
+}
+```
+
+## Tuning Loop
+
+Run each step with production-like traffic for at least 15-30 minutes.
+
+1. Set one starting profile.
+2. Observe latency (`p95`/`p99`), adaptive rejects, and hard queue rejects.
+3. Change one parameter at a time.
+4. Keep the change only if tail latency improves without unacceptable throughput loss.
+
+## Decision Matrix
+
+If `p95/p99` rises and `queue_full` rejects increase before adaptive rejects appear:
+- lower `queued_percent` by `3-5`
+- lower `ready_lag` by `5-10s`
+- lower `oldest_queued_age` by `10-20s`
+- optionally lower `min_total` by `50-100`
+
+If adaptive rejects are high but queue lag/age stay low:
+- raise `queued_percent` by `3-5`
+- raise `ready_lag` by `5-10s`
+- raise `oldest_queued_age` by `10-20s`
+
+If `reason="sustained_growth"` dominates during normal bursts:
+- keep `sustained_growth on`
+- raise `min_total` gradually so short bursts do not trigger early
+
+## Guardrails
+
+- Keep hard `queue_limits.max_depth` as the final safety boundary.
+- Avoid large jumps; use small deltas and re-measure.
+- In bursty enterprise workloads, keep `sustained_growth on` unless you have strong evidence to disable it.
+- Treat adaptive rejects as an intentional control signal, not only as an error.
+
+## Benchmark Alignment
+
+Use Pull benchmarks (`make bench-pull*`, `make bench-pull-mixed*`) to compare internal queue/drain optimization slices.
+
+Use production-like ingress load tests for threshold tuning decisions. The benchmark suite is best for relative runtime regressions/improvements, while threshold tuning depends on workload shape and SLO targets.
+
+## Dashboard Compatibility
+
+When dashboards span versions, gate adaptive panels/alerts with:
+
+- `hookaido_metrics_schema_info{schema="1.2.0"} == 1`
+
+This avoids interpreting missing pre-`1.2.0` series as zero.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -340,6 +340,8 @@ defaults {
 - `oldest_queued_age`: reject when `oldest_queued_age_seconds` reaches this duration.
 - `sustained_growth`: when `on`, also reject on sustained backlog growth signals (if trend samples are available).
 
+For production threshold tuning profiles, see [Adaptive Backpressure Tuning](adaptive-backpressure.md).
+
 ### `observability`
 
 See [Observability](observability.md) for full reference.
@@ -499,6 +501,8 @@ Per-route concurrency can override the global default:
   deliver "https://ci.internal/build" { ... }
 }
 ```
+
+`deliver_concurrency` is enforced as a shared per-route budget across all route targets.
 
 ## Placeholders
 

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -108,6 +108,9 @@ defaults {
 }
 ```
 
+`deliver_concurrency` is a shared per-route budget across all route targets.
+When a route has multiple targets, dispatcher workers are not pinned permanently to one target; idle-target capacity can drain backlog from active targets under saturation.
+
 ## Dead-Lettering
 
 Messages are moved to the DLQ when:

--- a/docs/index.md
+++ b/docs/index.md
@@ -66,6 +66,8 @@ graph LR
 | [Delivery](delivery.md) | Push retries, timeouts, concurrency, and signing |
 | [Security](security.md) | Secret refs, TLS/mTLS, replay protection, SSRF policy |
 | [Observability](observability.md) | Logs, metrics, tracing, and diagnostics |
+| [Adaptive Backpressure Tuning](adaptive-backpressure.md) | Production threshold tuning profiles and decision matrix |
+| [Performance Baselines](performance.md) | Reproducible Pull benchmark workflow and benchstat comparison |
 | [Management Model](management-model.md) | Application and endpoint mapping semantics |
 | [MCP Integration](mcp.md) | Tooling model, roles, and runtime controls |
 | [Docs Platform Decision](documentation-platform.md) | Why docs currently stay on MkDocs Material |

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,212 @@
+# Performance Baselines
+
+This page defines the reproducible benchmark workflow used for #39 optimization slices across Pull and Push drain paths.
+
+## Scope
+
+Current benchmarks cover:
+
+- dequeue + `ack` (single)
+- dequeue + `ack` (batch size 15, sustained-drain profile)
+- dequeue + `ack` (batch size 32)
+- dequeue + `nack` (single)
+- dequeue + repeated `extend` on an active lease (single)
+- duplicate `ack`/`nack` retry path under parallel load (contention profile)
+- mixed ingress + pull drain profile with latency percentiles (`p95_ms`, `p99_ms`)
+- mixed ingress + push drain saturation profile with ingress reject and delivery counts
+- mixed ingress + push skewed-target saturation profile (fast + slow target) for cross-target drain fairness checks
+
+Each benchmark runs against both queue backends:
+
+- `memory`
+- `sqlite`
+
+Benchmarks are implemented in:
+
+- `internal/pullapi/bench_test.go`
+- `internal/dispatcher/bench_test.go`
+
+## Reproducible Runbook
+
+Run all commands from the repository root.
+
+1. Capture a baseline before changes:
+
+```bash
+make bench-pull-baseline
+```
+
+This writes `./.bench/pull-baseline.txt`.
+
+2. Apply code changes.
+
+3. Capture current results:
+
+```bash
+make bench-pull
+```
+
+This writes `./.bench/pull.txt`.
+
+4. Compare baseline vs current:
+
+```bash
+make bench-pull-compare
+```
+
+This writes `./.bench/pull-compare.txt` and prints a `benchstat` diff table.
+
+### Isolated Extend Check
+
+When you want to validate only the active-lease `extend` path:
+
+```bash
+make bench-pull-extend
+make bench-pull-extend-compare
+```
+
+This uses a longer, higher-count run to reduce variance from unrelated Pull-path benchmarks.
+
+### Sustained Drain Check (Batch 15)
+
+For an issue-#39-style pull workload (dequeue + batch ack with `batch=15`):
+
+```bash
+make bench-pull-drain-baseline
+make bench-pull-drain
+make bench-pull-drain-compare
+```
+
+This writes:
+
+- `./.bench/pull-drain-baseline.txt`
+- `./.bench/pull-drain.txt`
+- `./.bench/pull-drain-compare.txt`
+
+The drain profile uses a longer run (`-benchtime=5s`, `-count=10`) for lower variance.
+
+### ACK/NACK Contention Check
+
+For high-parallel duplicate-retry pressure on Pull `ack`/`nack`:
+
+```bash
+make bench-pull-contention-baseline
+make bench-pull-contention
+make bench-pull-contention-compare
+```
+
+This writes:
+
+- `./.bench/pull-contention-baseline.txt`
+- `./.bench/pull-contention.txt`
+- `./.bench/pull-contention-compare.txt`
+
+The contention profile runs with `GOMAXPROCS=4` and `-cpu 1,4` to expose scaling behavior and conflict-path costs.
+
+### Mixed Ingress + Drain Tail-Latency Check
+
+For a mixed workload (concurrent ingress writes while pull workers dequeue+ack in the background):
+
+```bash
+make bench-pull-mixed-baseline
+make bench-pull-mixed
+make bench-pull-mixed-compare
+```
+
+This writes:
+
+- `./.bench/pull-mixed-baseline.txt`
+- `./.bench/pull-mixed.txt`
+- `./.bench/pull-mixed-compare.txt`
+
+`BenchmarkMixedIngressDrain` also reports custom metrics per backend:
+
+- `p95_ms`
+- `p99_ms`
+- `ingress_rejects`
+- `drain_errors`
+
+### Push Ingress + Drain Saturation Check
+
+For push-mode saturation behavior (ingress while dispatcher drains a single-target route):
+
+```bash
+make bench-push-mixed-baseline
+make bench-push-mixed
+make bench-push-mixed-compare
+```
+
+This writes:
+
+- `./.bench/push-mixed-baseline.txt`
+- `./.bench/push-mixed.txt`
+- `./.bench/push-mixed-compare.txt`
+
+`BenchmarkPushIngressDrainSaturation` reports:
+
+- `ingress_rejects`
+- `ingress_rejects_queue_full`
+- `ingress_rejects_adaptive_backpressure`
+- `ingress_rejects_memory_pressure`
+- `ingress_rejects_other`
+- `p95_ms`
+- `p99_ms`
+- `deliveries`
+
+### Push Ingress + Skewed-Target Saturation Check
+
+For push-mode cross-target fairness under saturation (single route with one fast and one slow target):
+
+```bash
+make bench-push-skewed-baseline
+make bench-push-skewed
+make bench-push-skewed-compare
+```
+
+This writes:
+
+- `./.bench/push-skewed-baseline.txt`
+- `./.bench/push-skewed.txt`
+- `./.bench/push-skewed-compare.txt`
+
+`BenchmarkPushIngressDrainSkewedTargets` reports:
+
+- `ingress_rejects`
+- `ingress_rejects_queue_full`
+- `ingress_rejects_adaptive_backpressure`
+- `ingress_rejects_memory_pressure`
+- `ingress_rejects_other`
+- `p95_ms`
+- `p99_ms`
+- `deliveries_fast`
+- `deliveries_slow`
+
+## Reproducibility Defaults
+
+The Make targets enforce:
+
+- `GOMAXPROCS=1`
+- `-cpu 1`
+- `-count=5` and `-benchtime=3s` for the default pull suite
+- `-count=10` and `-benchtime=5s` for isolated extend/drain profiles
+- `GOMAXPROCS=4` and `-cpu 1,4` for the contention profile
+- `GOMAXPROCS=4` and `-cpu 4` for the mixed ingress+drain profile
+- `GOMAXPROCS=4` and `-cpu 4` for the push saturation profile
+- `GOMAXPROCS=4` and `-cpu 4` for the push skewed-target profile
+
+This reduces host variance and gives stable median trends across runs.
+
+## Interpreting Results
+
+- Focus first on `sec/op` deltas for the same benchmark/backend pair.
+- Use `B/op` and `allocs/op` to catch regressions hidden by throughput changes.
+- For SQLite, compare both single and batch paths; batch wins should show up most clearly in `AckBatch32`.
+- For mixed profile runs, track `p95_ms`/`p99_ms` first, then check `ingress_rejects` and `drain_errors` to interpret latency shifts.
+- For push saturation runs, track `p95_ms`/`p99_ms` and `ingress_rejects_queue_full` first, then compare `deliveries`.
+- For push skewed-target runs, track `p95_ms`/`p99_ms`, `deliveries_slow`, and `ingress_rejects_queue_full`; improving slow-target drain without growing queue-full rejects or tail latency indicates better cross-target fairness.
+
+## Notes
+
+- Benchmark artifacts are written under `./.bench/` and ignored by git.
+- `bench-pull-compare` uses a pinned `benchstat` module version in `Makefile` to avoid tool drift.
+- For production threshold tuning of adaptive ingress pressure, use [Adaptive Backpressure Tuning](adaptive-backpressure.md).

--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -14,6 +14,8 @@ import (
 	"github.com/nuetzliches/hookaido/internal/queue"
 )
 
+const metricsSchemaVersion = "1.2.0"
+
 type runtimeMetrics struct {
 	tracingEnabled                             atomic.Int64
 	tracingInitFailuresTotal                   atomic.Int64
@@ -955,6 +957,9 @@ func newMetricsHandler(version string, start time.Time, rm *runtimeMetrics) http
 		_, _ = fmt.Fprintf(w, "# HELP hookaido_build_info Build information.\n")
 		_, _ = fmt.Fprintf(w, "# TYPE hookaido_build_info gauge\n")
 		_, _ = fmt.Fprintf(w, "hookaido_build_info{version=%q} 1\n", version)
+		_, _ = fmt.Fprintf(w, "# HELP hookaido_metrics_schema_info Prometheus metrics schema version information.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE hookaido_metrics_schema_info gauge\n")
+		_, _ = fmt.Fprintf(w, "hookaido_metrics_schema_info{schema=%q} 1\n", metricsSchemaVersion)
 		_, _ = fmt.Fprintf(w, "# HELP hookaido_start_time_seconds Start time since unix epoch.\n")
 		_, _ = fmt.Fprintf(w, "# TYPE hookaido_start_time_seconds gauge\n")
 		_, _ = fmt.Fprintf(w, "hookaido_start_time_seconds %d\n", start.Unix())

--- a/internal/app/metrics_test.go
+++ b/internal/app/metrics_test.go
@@ -22,6 +22,7 @@ func TestMetricsHandler_DefaultDiagnostics(t *testing.T) {
 
 	body := rr.Body.String()
 	for _, want := range []string{
+		`hookaido_metrics_schema_info{schema="1.2.0"} 1`,
 		"hookaido_tracing_enabled 0",
 		"hookaido_tracing_init_failures_total 0",
 		"hookaido_tracing_export_errors_total 0",
@@ -80,6 +81,7 @@ func TestMetricsHandler_WithDiagnostics(t *testing.T) {
 
 	body := rr.Body.String()
 	for _, want := range []string{
+		`hookaido_metrics_schema_info{schema="1.2.0"} 1`,
 		"hookaido_tracing_enabled 1",
 		"hookaido_tracing_init_failures_total 1",
 		"hookaido_tracing_export_errors_total 2",

--- a/internal/dispatcher/bench_test.go
+++ b/internal/dispatcher/bench_test.go
@@ -1,0 +1,356 @@
+package dispatcher
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/internal/ingress"
+	"github.com/nuetzliches/hookaido/internal/queue"
+)
+
+const (
+	pushBenchRoute       = "/webhooks/push"
+	pushBenchIngressPath = "/hooks/push/events"
+	pushBenchTargetURL   = "https://target.example/internal/hook"
+	pushBenchFastTarget  = "https://fast-target.example/internal/hook"
+	pushBenchSlowTarget  = "https://slow-target.example/internal/hook"
+	pushBenchMaxDepth    = 512
+)
+
+func BenchmarkPushIngressDrainSaturation(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeStore := newPushBenchStore(b, backend)
+			defer closeStore()
+
+			ingressSrv := ingress.NewServer(store)
+			ingressSrv.ResolveRoute = func(_ *http.Request, requestPath string) (string, bool) {
+				if requestPath == pushBenchIngressPath {
+					return pushBenchRoute, true
+				}
+				return "", false
+			}
+			ingressSrv.TargetsFor = func(route string) []string {
+				if route == pushBenchRoute {
+					return []string{pushBenchTargetURL}
+				}
+				return nil
+			}
+			rejectStats := &pushBenchRejectStats{}
+			ingressSrv.ObserveReject = rejectStats.Observe
+
+			deliverer := &pushBenchDeliverer{
+				delay: 2 * time.Millisecond,
+			}
+			dispatcher := PushDispatcher{
+				Store:     store,
+				Deliverer: deliverer,
+				Logger:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+				MaxWait:   2 * time.Millisecond,
+				Routes: []RouteConfig{
+					{
+						Route: pushBenchRoute,
+						Targets: []TargetConfig{
+							{
+								URL:     pushBenchTargetURL,
+								Timeout: 5 * time.Second,
+								Retry: RetryConfig{
+									Max: 1,
+								},
+							},
+						},
+						Concurrency: 8,
+					},
+				},
+			}
+			dispatcher.Start()
+			defer func() {
+				if ok := dispatcher.Drain(10 * time.Second); !ok {
+					b.Fatalf("dispatcher drain timeout")
+				}
+			}()
+
+			var ingressRejects atomic.Int64
+			latencyNanos := make([]int64, b.N)
+			var latencyCount atomic.Int64
+			payload := []byte(`{"ok":true}`)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					start := time.Now()
+					rr := httptest.NewRecorder()
+					req := httptest.NewRequest(http.MethodPost, "http://example"+pushBenchIngressPath, bytes.NewReader(payload))
+					req.Header.Set("Content-Type", "application/json")
+					ingressSrv.ServeHTTP(rr, req)
+					if rr.Code != http.StatusAccepted {
+						ingressRejects.Add(1)
+					}
+					idx := int(latencyCount.Add(1)) - 1
+					if idx < len(latencyNanos) {
+						latencyNanos[idx] = time.Since(start).Nanoseconds()
+					}
+				}
+			})
+			b.StopTimer()
+
+			samples := int(latencyCount.Load())
+			if samples > len(latencyNanos) {
+				samples = len(latencyNanos)
+			}
+			p95 := pushBenchPercentileNanos(latencyNanos[:samples], 95)
+			p99 := pushBenchPercentileNanos(latencyNanos[:samples], 99)
+			b.ReportMetric(float64(p95)/float64(time.Millisecond), "p95_ms")
+			b.ReportMetric(float64(p99)/float64(time.Millisecond), "p99_ms")
+			b.ReportMetric(float64(ingressRejects.Load()), "ingress_rejects")
+			b.ReportMetric(float64(rejectStats.queueFull.Load()), "ingress_rejects_queue_full")
+			b.ReportMetric(float64(rejectStats.adaptiveBackpressure.Load()), "ingress_rejects_adaptive_backpressure")
+			b.ReportMetric(float64(rejectStats.memoryPressure.Load()), "ingress_rejects_memory_pressure")
+			b.ReportMetric(float64(rejectStats.other.Load()), "ingress_rejects_other")
+			b.ReportMetric(float64(deliverer.completed.Load()), "deliveries")
+		})
+	}
+}
+
+func BenchmarkPushIngressDrainSkewedTargets(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeStore := newPushBenchStore(b, backend)
+			defer closeStore()
+
+			ingressSrv := ingress.NewServer(store)
+			ingressSrv.ResolveRoute = func(_ *http.Request, requestPath string) (string, bool) {
+				if requestPath == pushBenchIngressPath {
+					return pushBenchRoute, true
+				}
+				return "", false
+			}
+			ingressSrv.TargetsFor = func(route string) []string {
+				if route == pushBenchRoute {
+					return []string{pushBenchFastTarget, pushBenchSlowTarget}
+				}
+				return nil
+			}
+			rejectStats := &pushBenchRejectStats{}
+			ingressSrv.ObserveReject = rejectStats.Observe
+
+			deliverer := &pushBenchSkewedDeliverer{
+				delays: map[string]time.Duration{
+					pushBenchFastTarget: 500 * time.Microsecond,
+					pushBenchSlowTarget: 8 * time.Millisecond,
+				},
+			}
+			dispatcher := PushDispatcher{
+				Store:     store,
+				Deliverer: deliverer,
+				Logger:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+				MaxWait:   2 * time.Millisecond,
+				Routes: []RouteConfig{
+					{
+						Route: pushBenchRoute,
+						Targets: []TargetConfig{
+							{
+								URL:     pushBenchFastTarget,
+								Timeout: 5 * time.Second,
+								Retry: RetryConfig{
+									Max: 1,
+								},
+							},
+							{
+								URL:     pushBenchSlowTarget,
+								Timeout: 5 * time.Second,
+								Retry: RetryConfig{
+									Max: 1,
+								},
+							},
+						},
+						Concurrency: 8,
+					},
+				},
+			}
+			dispatcher.Start()
+			defer func() {
+				if ok := dispatcher.Drain(10 * time.Second); !ok {
+					b.Fatalf("dispatcher drain timeout")
+				}
+			}()
+
+			var ingressRejects atomic.Int64
+			latencyNanos := make([]int64, b.N)
+			var latencyCount atomic.Int64
+			payload := []byte(`{"ok":true}`)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					start := time.Now()
+					rr := httptest.NewRecorder()
+					req := httptest.NewRequest(http.MethodPost, "http://example"+pushBenchIngressPath, bytes.NewReader(payload))
+					req.Header.Set("Content-Type", "application/json")
+					ingressSrv.ServeHTTP(rr, req)
+					if rr.Code != http.StatusAccepted {
+						ingressRejects.Add(1)
+					}
+					idx := int(latencyCount.Add(1)) - 1
+					if idx < len(latencyNanos) {
+						latencyNanos[idx] = time.Since(start).Nanoseconds()
+					}
+				}
+			})
+			b.StopTimer()
+
+			samples := int(latencyCount.Load())
+			if samples > len(latencyNanos) {
+				samples = len(latencyNanos)
+			}
+			p95 := pushBenchPercentileNanos(latencyNanos[:samples], 95)
+			p99 := pushBenchPercentileNanos(latencyNanos[:samples], 99)
+			b.ReportMetric(float64(p95)/float64(time.Millisecond), "p95_ms")
+			b.ReportMetric(float64(p99)/float64(time.Millisecond), "p99_ms")
+			b.ReportMetric(float64(ingressRejects.Load()), "ingress_rejects")
+			b.ReportMetric(float64(rejectStats.queueFull.Load()), "ingress_rejects_queue_full")
+			b.ReportMetric(float64(rejectStats.adaptiveBackpressure.Load()), "ingress_rejects_adaptive_backpressure")
+			b.ReportMetric(float64(rejectStats.memoryPressure.Load()), "ingress_rejects_memory_pressure")
+			b.ReportMetric(float64(rejectStats.other.Load()), "ingress_rejects_other")
+			b.ReportMetric(float64(deliverer.fastCompleted.Load()), "deliveries_fast")
+			b.ReportMetric(float64(deliverer.slowCompleted.Load()), "deliveries_slow")
+		})
+	}
+}
+
+type pushBenchRejectStats struct {
+	queueFull            atomic.Int64
+	adaptiveBackpressure atomic.Int64
+	memoryPressure       atomic.Int64
+	other                atomic.Int64
+}
+
+func (s *pushBenchRejectStats) Observe(_ string, _ int, reason string) {
+	switch reason {
+	case "queue_full":
+		s.queueFull.Add(1)
+	case "adaptive_backpressure":
+		s.adaptiveBackpressure.Add(1)
+	case "memory_pressure":
+		s.memoryPressure.Add(1)
+	default:
+		s.other.Add(1)
+	}
+}
+
+func pushBenchPercentileNanos(values []int64, percentile int) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
+	})
+
+	if percentile <= 0 {
+		return sorted[0]
+	}
+	if percentile >= 100 {
+		return sorted[len(sorted)-1]
+	}
+
+	rank := (percentile*len(sorted) + 99) / 100
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > len(sorted) {
+		rank = len(sorted)
+	}
+	return sorted[rank-1]
+}
+
+func newPushBenchStore(b *testing.B, backend string) (queue.Store, func()) {
+	b.Helper()
+
+	switch backend {
+	case "memory":
+		s := queue.NewMemoryStore(
+			queue.WithQueueLimits(pushBenchMaxDepth, "reject"),
+		)
+		return s, func() {}
+	case "sqlite":
+		dbPath := filepath.Join(b.TempDir(), "hookaido-push-bench.db")
+		s, err := queue.NewSQLiteStore(
+			dbPath,
+			queue.WithSQLiteQueueLimits(pushBenchMaxDepth, "reject"),
+			queue.WithSQLiteCheckpointInterval(0),
+			queue.WithSQLitePollInterval(2*time.Millisecond),
+		)
+		if err != nil {
+			b.Fatalf("new sqlite store: %v", err)
+		}
+		return s, func() {
+			_ = s.Close()
+		}
+	default:
+		b.Fatalf("unknown backend: %q", backend)
+		return nil, func() {}
+	}
+}
+
+type pushBenchDeliverer struct {
+	delay     time.Duration
+	completed atomic.Int64
+}
+
+func (d *pushBenchDeliverer) Deliver(ctx context.Context, _ Delivery) Result {
+	if d.delay > 0 {
+		timer := time.NewTimer(d.delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return Result{Err: ctx.Err()}
+		case <-timer.C:
+		}
+	}
+	d.completed.Add(1)
+	return Result{StatusCode: http.StatusNoContent}
+}
+
+type pushBenchSkewedDeliverer struct {
+	delays map[string]time.Duration
+
+	fastCompleted atomic.Int64
+	slowCompleted atomic.Int64
+}
+
+func (d *pushBenchSkewedDeliverer) Deliver(ctx context.Context, in Delivery) Result {
+	if delay := d.delays[in.Target]; delay > 0 {
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return Result{Err: ctx.Err()}
+		case <-timer.C:
+		}
+	}
+
+	switch in.Target {
+	case pushBenchFastTarget:
+		d.fastCompleted.Add(1)
+	case pushBenchSlowTarget:
+		d.slowCompleted.Add(1)
+	}
+	return Result{StatusCode: http.StatusNoContent}
+}

--- a/internal/dispatcher/push.go
+++ b/internal/dispatcher/push.go
@@ -97,11 +97,185 @@ func (d *PushDispatcher) Start() {
 		if concurrency <= 0 {
 			concurrency = 1
 		}
-		sem := make(chan struct{}, concurrency)
-
-		for _, target := range rt.Targets {
+		routeLeaseTTL := routeLeaseTTL(rt.Targets, leaseSlack)
+		targetsByURL := targetConfigByURL(rt.Targets)
+		dequeueBatch := routeDequeueBatch(concurrency, len(rt.Targets))
+		for w := 0; w < concurrency; w++ {
 			d.wg.Add(1)
-			go d.runTarget(logger, rt.Route, target, sem, maxWait, leaseSlack)
+			go d.runRoute(logger, rt.Route, targetsByURL, maxWait, routeLeaseTTL, dequeueBatch)
+		}
+	}
+}
+
+func targetConfigByURL(targets []TargetConfig) map[string]TargetConfig {
+	byURL := make(map[string]TargetConfig, len(targets))
+	for _, target := range targets {
+		byURL[target.URL] = target
+	}
+	return byURL
+}
+
+func routeLeaseTTL(targets []TargetConfig, leaseSlack time.Duration) time.Duration {
+	maxTimeout := time.Duration(0)
+	for _, target := range targets {
+		timeout := target.Timeout
+		if timeout <= 0 {
+			timeout = 10 * time.Second
+		}
+		if timeout > maxTimeout {
+			maxTimeout = timeout
+		}
+	}
+	ttl := maxTimeout + leaseSlack
+	if ttl < 30*time.Second {
+		ttl = 30 * time.Second
+	}
+	return ttl
+}
+
+func routeDequeueBatch(concurrency int, targetCount int) int {
+	if concurrency <= 1 {
+		return 1
+	}
+	// Multi-target routes favor fairness and lower lease hold time per worker
+	// over dequeue roundtrip reduction.
+	if targetCount > 1 {
+		if concurrency >= 2 {
+			return 2
+		}
+		return 1
+	}
+	if concurrency >= 4 {
+		return 4
+	}
+	return concurrency
+}
+
+func routeMutationBatch(dequeueBatch int) int {
+	if dequeueBatch <= 1 {
+		return 1
+	}
+	return 2
+}
+
+type leaseActionKind int
+
+const (
+	leaseActionAck leaseActionKind = iota
+	leaseActionNack
+	leaseActionMarkDead
+)
+
+type leaseAction struct {
+	kind             leaseActionKind
+	route            string
+	target           string
+	leaseID          string
+	delay            time.Duration
+	reason           string
+	tolerateNotFound bool
+}
+
+func (d *PushDispatcher) runRoute(
+	logger *slog.Logger,
+	route string,
+	targetsByURL map[string]TargetConfig,
+	maxWait time.Duration,
+	leaseTTL time.Duration,
+	dequeueBatch int,
+) {
+	defer d.wg.Done()
+
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	const missingTargetBackoff = time.Second
+	if dequeueBatch <= 0 {
+		dequeueBatch = 1
+	}
+	useBatchMutations := len(targetsByURL) == 1
+
+	for {
+		select {
+		case <-d.stopCh:
+			return
+		default:
+		}
+
+		resp, err := d.Store.Dequeue(queue.DequeueRequest{
+			Route:    route,
+			Batch:    dequeueBatch,
+			MaxWait:  maxWait,
+			LeaseTTL: leaseTTL,
+		})
+		if err != nil {
+			logger.Warn("dispatcher_dequeue_failed",
+				slog.String("route", route),
+				slog.String("target", "<any>"),
+				slog.Any("err", err),
+			)
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+		if len(resp.Items) == 0 {
+			continue
+		}
+
+		mutationBatch := routeMutationBatch(dequeueBatch)
+		actions := make([]leaseAction, 0, mutationBatch)
+		for i, env := range resp.Items {
+			select {
+			case <-d.stopCh:
+				d.requeueLeases(logger, resp.Items[i:], 0, "dispatcher_stop_requeue_failed")
+				return
+			default:
+			}
+
+			target, ok := targetsByURL[env.Target]
+			if !ok {
+				logger.Warn("dispatcher_target_config_missing",
+					slog.String("route", env.Route),
+					slog.String("target", env.Target),
+					slog.String("lease_id", env.LeaseID),
+				)
+				d.applyLeaseAction(logger, leaseAction{
+					kind:             leaseActionNack,
+					route:            env.Route,
+					target:           env.Target,
+					leaseID:          env.LeaseID,
+					delay:            missingTargetBackoff,
+					tolerateNotFound: true,
+				})
+				continue
+			}
+			action := d.classifyDelivery(logger, env, target)
+			if !useBatchMutations {
+				d.applyLeaseAction(logger, action)
+				continue
+			}
+			actions = append(actions, action)
+			if len(actions) >= mutationBatch {
+				d.applyLeaseActions(logger, actions)
+				actions = actions[:0]
+			}
+		}
+
+		if useBatchMutations && len(actions) > 0 {
+			d.applyLeaseActions(logger, actions)
+		}
+	}
+}
+
+func (d *PushDispatcher) requeueLeases(logger *slog.Logger, items []queue.Envelope, delay time.Duration, warnMsg string) {
+	for _, env := range items {
+		if err := d.Store.Nack(env.LeaseID, delay); err != nil && !errors.Is(err, queue.ErrLeaseExpired) && !errors.Is(err, queue.ErrLeaseNotFound) {
+			logger.Warn(warnMsg,
+				slog.String("route", env.Route),
+				slog.String("target", env.Target),
+				slog.String("lease_id", env.LeaseID),
+				slog.Any("err", err),
+			)
 		}
 	}
 }
@@ -127,58 +301,16 @@ func (d *PushDispatcher) Drain(timeout time.Duration) bool {
 	}
 }
 
-func (d *PushDispatcher) runTarget(logger *slog.Logger, route string, target TargetConfig, sem chan struct{}, maxWait, leaseSlack time.Duration) {
-	defer d.wg.Done()
-
+func (d *PushDispatcher) handleDelivery(logger *slog.Logger, env queue.Envelope, target TargetConfig) {
 	if logger == nil {
 		logger = slog.Default()
 	}
 
-	timeout := target.Timeout
-	if timeout <= 0 {
-		timeout = 10 * time.Second
-	}
-	leaseTTL := timeout + leaseSlack
-	if leaseTTL < 30*time.Second {
-		leaseTTL = 30 * time.Second
-	}
-
-	for {
-		select {
-		case <-d.stopCh:
-			return
-		case sem <- struct{}{}:
-		}
-
-		resp, err := d.Store.Dequeue(queue.DequeueRequest{
-			Route:    route,
-			Target:   target.URL,
-			Batch:    1,
-			MaxWait:  maxWait,
-			LeaseTTL: leaseTTL,
-		})
-		if err != nil {
-			<-sem
-			logger.Warn("dispatcher_dequeue_failed",
-				slog.String("route", route),
-				slog.String("target", target.URL),
-				slog.Any("err", err),
-			)
-			time.Sleep(200 * time.Millisecond)
-			continue
-		}
-		if len(resp.Items) == 0 {
-			<-sem
-			continue
-		}
-
-		env := resp.Items[0]
-		d.handleDelivery(logger, env, target)
-		<-sem
-	}
+	action := d.classifyDelivery(logger, env, target)
+	d.applyLeaseAction(logger, action)
 }
 
-func (d *PushDispatcher) handleDelivery(logger *slog.Logger, env queue.Envelope, target TargetConfig) {
+func (d *PushDispatcher) classifyDelivery(logger *slog.Logger, env queue.Envelope, target TargetConfig) leaseAction {
 	if logger == nil {
 		logger = slog.Default()
 	}
@@ -220,15 +352,12 @@ func (d *PushDispatcher) handleDelivery(logger *slog.Logger, env queue.Envelope,
 	if isSuccess(res) {
 		attempt.Outcome = queue.AttemptOutcomeAcked
 		d.recordAttempt(logger, attempt)
-		if err := d.Store.Ack(env.LeaseID); err != nil && !errors.Is(err, queue.ErrLeaseExpired) {
-			logger.Warn("dispatcher_ack_failed",
-				slog.String("route", env.Route),
-				slog.String("target", target.URL),
-				slog.String("lease_id", env.LeaseID),
-				slog.Any("err", err),
-			)
+		return leaseAction{
+			kind:    leaseActionAck,
+			route:   env.Route,
+			target:  target.URL,
+			leaseID: env.LeaseID,
 		}
-		return
 	}
 
 	shouldRetry := shouldRetry(res)
@@ -236,15 +365,13 @@ func (d *PushDispatcher) handleDelivery(logger *slog.Logger, env queue.Envelope,
 		delay := retryDelay(env.Attempt, target.Retry)
 		attempt.Outcome = queue.AttemptOutcomeRetry
 		d.recordAttempt(logger, attempt)
-		if err := d.Store.Nack(env.LeaseID, delay); err != nil && !errors.Is(err, queue.ErrLeaseExpired) {
-			logger.Warn("dispatcher_nack_failed",
-				slog.String("route", env.Route),
-				slog.String("target", target.URL),
-				slog.String("lease_id", env.LeaseID),
-				slog.Any("err", err),
-			)
+		return leaseAction{
+			kind:    leaseActionNack,
+			route:   env.Route,
+			target:  target.URL,
+			leaseID: env.LeaseID,
+			delay:   delay,
 		}
-		return
 	}
 
 	reason := "no_retry"
@@ -256,13 +383,167 @@ func (d *PushDispatcher) handleDelivery(logger *slog.Logger, env queue.Envelope,
 	attempt.Outcome = queue.AttemptOutcomeDead
 	attempt.DeadReason = reason
 	d.recordAttempt(logger, attempt)
-	if err := d.Store.MarkDead(env.LeaseID, reason); err != nil && !errors.Is(err, queue.ErrLeaseExpired) {
-		logger.Warn("dispatcher_mark_dead_failed",
-			slog.String("route", env.Route),
-			slog.String("target", target.URL),
-			slog.String("lease_id", env.LeaseID),
-			slog.Any("err", err),
+	return leaseAction{
+		kind:    leaseActionMarkDead,
+		route:   env.Route,
+		target:  target.URL,
+		leaseID: env.LeaseID,
+		reason:  reason,
+	}
+}
+
+func (d *PushDispatcher) applyLeaseActions(logger *slog.Logger, actions []leaseAction) {
+	if len(actions) == 0 {
+		return
+	}
+
+	batchStore, ok := d.Store.(queue.LeaseBatchStore)
+	if !ok {
+		for _, action := range actions {
+			d.applyLeaseAction(logger, action)
+		}
+		return
+	}
+
+	d.applyLeaseActionsBatch(logger, batchStore, actions)
+}
+
+func (d *PushDispatcher) applyLeaseActionsBatch(logger *slog.Logger, batchStore queue.LeaseBatchStore, actions []leaseAction) {
+	acks := make([]leaseAction, 0, len(actions))
+	nacksByDelay := make(map[time.Duration][]leaseAction)
+	deadByReason := make(map[string][]leaseAction)
+
+	for _, action := range actions {
+		switch action.kind {
+		case leaseActionAck:
+			acks = append(acks, action)
+		case leaseActionNack:
+			nacksByDelay[action.delay] = append(nacksByDelay[action.delay], action)
+		case leaseActionMarkDead:
+			deadByReason[action.reason] = append(deadByReason[action.reason], action)
+		}
+	}
+
+	if len(acks) > 0 {
+		ids := leaseIDsFromActions(acks)
+		res, err := batchStore.AckBatch(ids)
+		if err != nil {
+			logger.Warn("dispatcher_ack_batch_failed",
+				slog.Int("batch", len(ids)),
+				slog.Any("err", err),
+			)
+			for _, action := range acks {
+				d.applyLeaseAction(logger, action)
+			}
+		} else {
+			d.logBatchConflicts(logger, "dispatcher_ack_failed", acks, res.Conflicts)
+		}
+	}
+
+	for delay, grouped := range nacksByDelay {
+		ids := leaseIDsFromActions(grouped)
+		res, err := batchStore.NackBatch(ids, delay)
+		if err != nil {
+			logger.Warn("dispatcher_nack_batch_failed",
+				slog.Int("batch", len(ids)),
+				slog.Duration("delay", delay),
+				slog.Any("err", err),
+			)
+			for _, action := range grouped {
+				d.applyLeaseAction(logger, action)
+			}
+			continue
+		}
+		d.logBatchConflicts(logger, "dispatcher_nack_failed", grouped, res.Conflicts)
+	}
+
+	for reason, grouped := range deadByReason {
+		ids := leaseIDsFromActions(grouped)
+		res, err := batchStore.MarkDeadBatch(ids, reason)
+		if err != nil {
+			logger.Warn("dispatcher_mark_dead_batch_failed",
+				slog.Int("batch", len(ids)),
+				slog.String("reason", reason),
+				slog.Any("err", err),
+			)
+			for _, action := range grouped {
+				d.applyLeaseAction(logger, action)
+			}
+			continue
+		}
+		d.logBatchConflicts(logger, "dispatcher_mark_dead_failed", grouped, res.Conflicts)
+	}
+}
+
+func leaseIDsFromActions(actions []leaseAction) []string {
+	out := make([]string, 0, len(actions))
+	for _, action := range actions {
+		out = append(out, action.leaseID)
+	}
+	return out
+}
+
+func (d *PushDispatcher) logBatchConflicts(
+	logger *slog.Logger,
+	warnMsg string,
+	actions []leaseAction,
+	conflicts []queue.LeaseBatchConflict,
+) {
+	if len(conflicts) == 0 {
+		return
+	}
+
+	byLease := make(map[string]leaseAction, len(actions))
+	for _, action := range actions {
+		byLease[action.leaseID] = action
+	}
+	for _, conflict := range conflicts {
+		if conflict.Expired {
+			continue
+		}
+		action, ok := byLease[conflict.LeaseID]
+		if !ok {
+			continue
+		}
+		logger.Warn(warnMsg,
+			slog.String("route", action.route),
+			slog.String("target", action.target),
+			slog.String("lease_id", conflict.LeaseID),
+			slog.Any("err", queue.ErrLeaseNotFound),
 		)
+	}
+}
+
+func (d *PushDispatcher) applyLeaseAction(logger *slog.Logger, action leaseAction) {
+	switch action.kind {
+	case leaseActionAck:
+		if err := d.Store.Ack(action.leaseID); err != nil && !errors.Is(err, queue.ErrLeaseExpired) {
+			logger.Warn("dispatcher_ack_failed",
+				slog.String("route", action.route),
+				slog.String("target", action.target),
+				slog.String("lease_id", action.leaseID),
+				slog.Any("err", err),
+			)
+		}
+	case leaseActionNack:
+		err := d.Store.Nack(action.leaseID, action.delay)
+		if err != nil && !errors.Is(err, queue.ErrLeaseExpired) && (!action.tolerateNotFound || !errors.Is(err, queue.ErrLeaseNotFound)) {
+			logger.Warn("dispatcher_nack_failed",
+				slog.String("route", action.route),
+				slog.String("target", action.target),
+				slog.String("lease_id", action.leaseID),
+				slog.Any("err", err),
+			)
+		}
+	case leaseActionMarkDead:
+		if err := d.Store.MarkDead(action.leaseID, action.reason); err != nil && !errors.Is(err, queue.ErrLeaseExpired) {
+			logger.Warn("dispatcher_mark_dead_failed",
+				slog.String("route", action.route),
+				slog.String("target", action.target),
+				slog.String("lease_id", action.leaseID),
+				slog.Any("err", err),
+			)
+		}
 	}
 }
 

--- a/internal/mcp/spec.md
+++ b/internal/mcp/spec.md
@@ -157,6 +157,8 @@ Queue tool backend behavior:
 - When compiled `queue_backend` is `sqlite`, MCP queue tools use direct SQLite access.
 - When compiled `queue_backend` is `memory`, MCP queue tools proxy the configured Admin API endpoints.
 - Memory backend proxy mode requires a running Hookaido instance that serves the Admin API.
+- Pull worker operations remain Pull API-only; MCP does not expose dequeue/ack/nack/extend endpoints (including Pull API batch ack/nack via `lease_ids`).
+- Coverage decision: Pull API lease-retry idempotency (`ack`/`nack` duplicate success window) remains Pull runtime behavior only; no MCP tool surface changes required.
 - In proxy mode, queue read (`GET`) calls use bounded retries for transient failures (`408/429/5xx` and transport errors).
 - Proxy errors map common Admin statuses (`400/401/403/404/409/429/503`) to explicit MCP error messages and include structured response metadata when available (`code`, `item_index`, `detail`).
 - Mutation tools that accept audit metadata enforce Admin-aligned limits: `reason` max `512` chars, `actor` max `256`, `request_id` max `256`.

--- a/internal/pullapi/bench_test.go
+++ b/internal/pullapi/bench_test.go
@@ -1,0 +1,531 @@
+package pullapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/internal/ingress"
+	"github.com/nuetzliches/hookaido/internal/queue"
+)
+
+const (
+	pullBenchEndpointRoute = "/pull/github"
+	pullBenchInternalRoute = "/webhooks/github"
+	mixedBenchIngressPath  = "/hooks/github/events"
+	pullBenchRefillMemory  = 8192
+	pullBenchRefillSQLite  = 512
+)
+
+func BenchmarkPullDequeueAckSingle(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeFn := newPullBenchStore(b, backend)
+			defer closeFn()
+
+			refillChunk := pullBenchRefillChunk(backend, 1)
+			nextSeedID := seedPullBenchStoreRange(b, store, 0, refillChunk)
+			queued := refillChunk
+			srv := newPullBenchServer(store)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if queued < 1 {
+					b.StopTimer()
+					nextSeedID = seedPullBenchStoreRange(b, store, nextSeedID, refillChunk)
+					queued += refillChunk
+					b.StartTimer()
+				}
+				leaseIDs := pullBenchDequeue(b, srv, 1)
+				pullBenchAckSingle(b, srv, leaseIDs[0])
+				queued--
+			}
+		})
+	}
+}
+
+func BenchmarkPullDequeueAckBatch15(b *testing.B) {
+	benchmarkPullDequeueAckBatch(b, 15)
+}
+
+func BenchmarkPullDequeueAckBatch32(b *testing.B) {
+	benchmarkPullDequeueAckBatch(b, 32)
+}
+
+func BenchmarkPullDequeueNackSingle(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeFn := newPullBenchStore(b, backend)
+			defer closeFn()
+
+			seedPullBenchStore(b, store, 1)
+			srv := newPullBenchServer(store)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				leaseIDs := pullBenchDequeue(b, srv, 1)
+				pullBenchNackSingle(b, srv, leaseIDs[0])
+			}
+		})
+	}
+}
+
+func BenchmarkPullDequeueExtendSingle(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeFn := newPullBenchStore(b, backend)
+			defer closeFn()
+
+			seedPullBenchStore(b, store, 1)
+			srv := newPullBenchServer(store)
+
+			leaseIDs := pullBenchDequeue(b, srv, 1)
+			leaseID := leaseIDs[0]
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				pullBenchExtendSingle(b, srv, leaseID)
+			}
+		})
+	}
+}
+
+func BenchmarkPullAckRetryParallel(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeFn := newPullBenchStore(b, backend)
+			defer closeFn()
+
+			seedPullBenchStore(b, store, 1)
+			srv := newPullBenchServer(store)
+			leaseIDs := pullBenchDequeue(b, srv, 1)
+			leaseID := leaseIDs[0]
+			pullBenchAckSingle(b, srv, leaseID)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					pullBenchAckSingle(b, srv, leaseID)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkPullNackRetryParallel(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeFn := newPullBenchStore(b, backend)
+			defer closeFn()
+
+			seedPullBenchStore(b, store, 1)
+			srv := newPullBenchServer(store)
+			leaseIDs := pullBenchDequeue(b, srv, 1)
+			leaseID := leaseIDs[0]
+			pullBenchNackSingle(b, srv, leaseID)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					pullBenchNackSingle(b, srv, leaseID)
+				}
+			})
+		})
+	}
+}
+
+func BenchmarkMixedIngressDrain(b *testing.B) {
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeFn := newPullBenchStore(b, backend)
+			defer closeFn()
+
+			ingressSrv := ingress.NewServer(store)
+			ingressSrv.ResolveRoute = func(_ *http.Request, requestPath string) (string, bool) {
+				if requestPath == mixedBenchIngressPath {
+					return pullBenchInternalRoute, true
+				}
+				return "", false
+			}
+			ingressSrv.TargetsFor = func(route string) []string {
+				if route == pullBenchInternalRoute {
+					return []string{"pull"}
+				}
+				return nil
+			}
+
+			pullSrv := newPullBenchServer(store)
+
+			const (
+				workerCount = 16
+				batchSize   = 15
+			)
+			stopCh := make(chan struct{})
+			var wg sync.WaitGroup
+			var drainErrors atomic.Int64
+			for i := 0; i < workerCount; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					mixedBenchDrainWorker(stopCh, pullSrv, batchSize, &drainErrors)
+				}()
+			}
+
+			latencyNanos := make([]int64, 0, b.N)
+			var ingressRejects int64
+			body := []byte(`{"ok":true}`)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				start := time.Now()
+				rr := httptest.NewRecorder()
+				req := httptest.NewRequest(http.MethodPost, "http://example"+mixedBenchIngressPath, bytes.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				ingressSrv.ServeHTTP(rr, req)
+
+				latencyNanos = append(latencyNanos, time.Since(start).Nanoseconds())
+				if rr.Code != http.StatusAccepted {
+					ingressRejects++
+				}
+			}
+			b.StopTimer()
+
+			close(stopCh)
+			wg.Wait()
+
+			p95 := mixedBenchPercentileNanos(latencyNanos, 95)
+			p99 := mixedBenchPercentileNanos(latencyNanos, 99)
+			b.ReportMetric(float64(p95)/float64(time.Millisecond), "p95_ms")
+			b.ReportMetric(float64(p99)/float64(time.Millisecond), "p99_ms")
+			b.ReportMetric(float64(ingressRejects), "ingress_rejects")
+			b.ReportMetric(float64(drainErrors.Load()), "drain_errors")
+		})
+	}
+}
+
+func mixedBenchDrainWorker(stopCh <-chan struct{}, srv *Server, batchSize int, drainErrors *atomic.Int64) {
+	for {
+		select {
+		case <-stopCh:
+			return
+		default:
+		}
+
+		leaseIDs, statusCode := mixedBenchDequeue(srv, batchSize)
+		if statusCode != http.StatusOK {
+			drainErrors.Add(1)
+			continue
+		}
+		if len(leaseIDs) == 0 {
+			continue
+		}
+		if mixedBenchAckBatch(srv, leaseIDs) != http.StatusOK {
+			drainErrors.Add(1)
+		}
+	}
+}
+
+func mixedBenchDequeue(srv *Server, batchSize int) ([]string, int) {
+	body := `{"batch":` + strconv.Itoa(batchSize) + `,"lease_ttl":"30s","max_wait":"10ms"}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example"+pullBenchEndpointRoute+"/dequeue", strings.NewReader(body))
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		return nil, rr.Code
+	}
+
+	var out struct {
+		Items []struct {
+			LeaseID string `json:"lease_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		return nil, http.StatusInternalServerError
+	}
+
+	leaseIDs := make([]string, 0, len(out.Items))
+	for _, item := range out.Items {
+		if item.LeaseID == "" {
+			continue
+		}
+		leaseIDs = append(leaseIDs, item.LeaseID)
+	}
+	return leaseIDs, rr.Code
+}
+
+func mixedBenchAckBatch(srv *Server, leaseIDs []string) int {
+	var body strings.Builder
+	body.Grow(32 + len(leaseIDs)*40)
+	body.WriteString(`{"lease_ids":[`)
+	for i, leaseID := range leaseIDs {
+		if i > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteByte('"')
+		body.WriteString(leaseID)
+		body.WriteByte('"')
+	}
+	body.WriteString(`]}`)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example"+pullBenchEndpointRoute+"/ack", strings.NewReader(body.String()))
+	srv.ServeHTTP(rr, req)
+	return rr.Code
+}
+
+func mixedBenchPercentileNanos(values []int64, percentile int) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i] < sorted[j]
+	})
+
+	if percentile <= 0 {
+		return sorted[0]
+	}
+	if percentile >= 100 {
+		return sorted[len(sorted)-1]
+	}
+
+	rank := (percentile*len(sorted) + 99) / 100 // nearest-rank ceil(p*n/100)
+	if rank < 1 {
+		rank = 1
+	}
+	if rank > len(sorted) {
+		rank = len(sorted)
+	}
+	return sorted[rank-1]
+}
+
+func benchmarkPullDequeueAckBatch(b *testing.B, batchSize int) {
+	b.Helper()
+
+	for _, backend := range []string{"memory", "sqlite"} {
+		b.Run(backend, func(b *testing.B) {
+			store, closeFn := newPullBenchStore(b, backend)
+			defer closeFn()
+
+			refillChunk := pullBenchRefillChunk(backend, batchSize)
+			nextSeedID := seedPullBenchStoreRange(b, store, 0, refillChunk)
+			queued := refillChunk
+			srv := newPullBenchServer(store)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if queued < batchSize {
+					b.StopTimer()
+					nextSeedID = seedPullBenchStoreRange(b, store, nextSeedID, refillChunk)
+					queued += refillChunk
+					b.StartTimer()
+				}
+				leaseIDs := pullBenchDequeue(b, srv, batchSize)
+				pullBenchAckBatch(b, srv, leaseIDs)
+				queued -= batchSize
+			}
+		})
+	}
+}
+
+func newPullBenchStore(b *testing.B, backend string) (queue.Store, func()) {
+	b.Helper()
+
+	switch backend {
+	case "memory":
+		s := queue.NewMemoryStore()
+		return s, func() {}
+	case "sqlite":
+		dbPath := filepath.Join(b.TempDir(), "hookaido-bench.db")
+		s, err := queue.NewSQLiteStore(
+			dbPath,
+			queue.WithSQLiteCheckpointInterval(0),
+			queue.WithSQLitePollInterval(2*time.Millisecond),
+		)
+		if err != nil {
+			b.Fatalf("new sqlite store: %v", err)
+		}
+		return s, func() {
+			_ = s.Close()
+		}
+	default:
+		b.Fatalf("unknown backend: %q", backend)
+		return nil, func() {}
+	}
+}
+
+func seedPullBenchStore(b *testing.B, store queue.Store, count int) {
+	_ = seedPullBenchStoreRange(b, store, 0, count)
+}
+
+func seedPullBenchStoreRange(b *testing.B, store queue.Store, startID int, count int) int {
+	b.Helper()
+
+	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
+	if batchStore, ok := store.(queue.BatchEnqueuer); ok {
+		items := make([]queue.Envelope, 0, count)
+		for i := 0; i < count; i++ {
+			items = append(items, queue.Envelope{
+				ID:         fmt.Sprintf("bench_evt_%08d", startID+i),
+				Route:      pullBenchInternalRoute,
+				Target:     "pull",
+				ReceivedAt: now,
+				NextRunAt:  now,
+				Payload:    []byte(`{"ok":true}`),
+			})
+		}
+		if _, err := batchStore.EnqueueBatch(items); err != nil {
+			b.Fatalf("seed batch enqueue count=%d: %v", count, err)
+		}
+		return startID + count
+	}
+
+	for i := 0; i < count; i++ {
+		if err := store.Enqueue(queue.Envelope{
+			ID:         fmt.Sprintf("bench_evt_%08d", startID+i),
+			Route:      pullBenchInternalRoute,
+			Target:     "pull",
+			ReceivedAt: now,
+			NextRunAt:  now,
+			Payload:    []byte(`{"ok":true}`),
+		}); err != nil {
+			b.Fatalf("seed enqueue %d/%d: %v", i+1, count, err)
+		}
+	}
+	return startID + count
+}
+
+func pullBenchRefillChunk(backend string, min int) int {
+	chunk := pullBenchRefillMemory
+	if backend == "sqlite" {
+		chunk = pullBenchRefillSQLite
+	}
+	if chunk < min {
+		return min
+	}
+	return chunk
+}
+
+func newPullBenchServer(store queue.Store) *Server {
+	srv := NewServer(store)
+	srv.ResolveRoute = func(endpoint string) (string, bool) {
+		if endpoint == pullBenchEndpointRoute {
+			return pullBenchInternalRoute, true
+		}
+		return "", false
+	}
+	return srv
+}
+
+func pullBenchDequeue(b *testing.B, srv *Server, batch int) []string {
+	b.Helper()
+
+	body := `{"batch":` + strconv.Itoa(batch) + `,"lease_ttl":"30s"}`
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example"+pullBenchEndpointRoute+"/dequeue", strings.NewReader(body))
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		b.Fatalf("dequeue status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var out struct {
+		Items []struct {
+			LeaseID string `json:"lease_id"`
+		} `json:"items"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		b.Fatalf("decode dequeue response: %v", err)
+	}
+	if len(out.Items) != batch {
+		b.Fatalf("expected %d dequeued items, got %d", batch, len(out.Items))
+	}
+
+	leaseIDs := make([]string, 0, len(out.Items))
+	for _, item := range out.Items {
+		leaseIDs = append(leaseIDs, item.LeaseID)
+	}
+	return leaseIDs
+}
+
+func pullBenchAckSingle(b *testing.B, srv *Server, leaseID string) {
+	b.Helper()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example"+pullBenchEndpointRoute+"/ack", strings.NewReader(`{"lease_id":"`+leaseID+`"}`))
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		b.Fatalf("ack status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func pullBenchAckBatch(b *testing.B, srv *Server, leaseIDs []string) {
+	b.Helper()
+
+	var body strings.Builder
+	body.Grow(32 + len(leaseIDs)*40)
+	body.WriteString(`{"lease_ids":[`)
+	for i, leaseID := range leaseIDs {
+		if i > 0 {
+			body.WriteByte(',')
+		}
+		body.WriteByte('"')
+		body.WriteString(leaseID)
+		body.WriteByte('"')
+	}
+	body.WriteString(`]}`)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example"+pullBenchEndpointRoute+"/ack", strings.NewReader(body.String()))
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		b.Fatalf("ack batch status=%d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var out ackBatchResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		b.Fatalf("decode ack batch response: %v", err)
+	}
+	if out.Acked != len(leaseIDs) || len(out.Conflicts) != 0 {
+		b.Fatalf("unexpected ack batch response: %+v", out)
+	}
+}
+
+func pullBenchNackSingle(b *testing.B, srv *Server, leaseID string) {
+	b.Helper()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example"+pullBenchEndpointRoute+"/nack", strings.NewReader(`{"lease_id":"`+leaseID+`","delay":"0s"}`))
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		b.Fatalf("nack status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func pullBenchExtendSingle(b *testing.B, srv *Server, leaseID string) {
+	b.Helper()
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "http://example"+pullBenchEndpointRoute+"/extend", strings.NewReader(`{"lease_id":"`+leaseID+`","extend_by":"5s"}`))
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		b.Fatalf("extend status=%d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/pullapi/http.go
+++ b/internal/pullapi/http.go
@@ -1,6 +1,7 @@
 package pullapi
 
 import (
+	"container/list"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -8,6 +9,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/nuetzliches/hookaido/internal/queue"
@@ -22,6 +24,9 @@ const (
 	pullErrLeaseConflict     = "lease_conflict"
 	pullErrStoreUnavailable  = "store_unavailable"
 	pullErrInternal          = "internal_error"
+
+	recentLeaseOpAck  = "ack"
+	recentLeaseOpNack = "nack"
 )
 
 type Server struct {
@@ -35,19 +40,42 @@ type Server struct {
 	ObserveExtend   func(route string, statusCode int, leaseID string, extendBy time.Duration, leaseExpired bool)
 	DefaultLeaseTTL time.Duration
 	MaxBatch        int
+	MaxLeaseBatch   int
 	MaxLeaseTTL     time.Duration
 	DefaultMaxWait  time.Duration
 	MaxWait         time.Duration
+
+	RecentLeaseOpTTL time.Duration
+	RecentLeaseOpCap int
+
+	recentLeaseMu    sync.Mutex
+	recentLeaseOps   map[recentLeaseOpKey]*list.Element
+	recentLeaseOrder list.List
+	now              func() time.Time
 }
 
 func NewServer(store queue.Store) *Server {
 	return &Server{
-		Store:           store,
-		Target:          "pull",
-		ResolveRoute:    nil,
-		DefaultLeaseTTL: 30 * time.Second,
-		MaxBatch:        100,
+		Store:            store,
+		Target:           "pull",
+		ResolveRoute:     nil,
+		DefaultLeaseTTL:  30 * time.Second,
+		MaxBatch:         100,
+		MaxLeaseBatch:    100,
+		RecentLeaseOpTTL: 2 * time.Minute,
+		RecentLeaseOpCap: 20000,
+		now:              time.Now,
 	}
+}
+
+type recentLeaseOpKey struct {
+	leaseID string
+	op      string
+}
+
+type recentLeaseOpEntry struct {
+	key       recentLeaseOpKey
+	expiresAt time.Time
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -186,11 +214,31 @@ func (s *Server) handleDequeue(w http.ResponseWriter, r *http.Request, route str
 }
 
 type leaseRequest struct {
-	LeaseID  string `json:"lease_id"`
-	Delay    string `json:"delay,omitempty"`
-	ExtendBy string `json:"extend_by,omitempty"`
-	Dead     bool   `json:"dead,omitempty"`
-	Reason   string `json:"reason,omitempty"`
+	LeaseID  string   `json:"lease_id"`
+	LeaseIDs []string `json:"lease_ids,omitempty"`
+	Delay    string   `json:"delay,omitempty"`
+	ExtendBy string   `json:"extend_by,omitempty"`
+	Dead     bool     `json:"dead,omitempty"`
+	Reason   string   `json:"reason,omitempty"`
+}
+
+type ackBatchConflict struct {
+	LeaseID string `json:"lease_id"`
+	Reason  string `json:"reason"`
+}
+
+type ackBatchResponse struct {
+	Code      string             `json:"code,omitempty"`
+	Detail    string             `json:"detail,omitempty"`
+	Acked     int                `json:"acked"`
+	Conflicts []ackBatchConflict `json:"conflicts,omitempty"`
+}
+
+type nackBatchResponse struct {
+	Code      string             `json:"code,omitempty"`
+	Detail    string             `json:"detail,omitempty"`
+	Succeeded int                `json:"succeeded"`
+	Conflicts []ackBatchConflict `json:"conflicts,omitempty"`
 }
 
 func (s *Server) handleAck(w http.ResponseWriter, r *http.Request, route string) {
@@ -199,25 +247,126 @@ func (s *Server) handleAck(w http.ResponseWriter, r *http.Request, route string)
 		s.observeAck(route, http.StatusBadRequest, "", false)
 		return
 	}
-	if req.LeaseID == "" {
-		writeError(w, http.StatusBadRequest, pullErrInvalidBody, "lease_id is required")
+
+	leaseIDs, isBatch, errDetail := normalizeLeaseIDs(req, s.MaxLeaseBatch)
+	if errDetail != "" {
+		writeError(w, http.StatusBadRequest, pullErrInvalidBody, errDetail)
 		s.observeAck(route, http.StatusBadRequest, "", false)
 		return
 	}
+	if !isBatch {
+		s.handleAckSingle(w, route, leaseIDs[0])
+		return
+	}
+	s.handleAckBatch(w, route, leaseIDs)
+}
 
-	if err := s.Store.Ack(req.LeaseID); err != nil {
+func (s *Server) handleAckSingle(w http.ResponseWriter, route string, leaseID string) {
+	if s.isRecentlyCompletedLease(leaseID, recentLeaseOpAck) {
+		w.WriteHeader(http.StatusNoContent)
+		s.observeAck(route, http.StatusNoContent, leaseID, false)
+		return
+	}
+
+	if err := s.Store.Ack(leaseID); err != nil {
 		if errors.Is(err, queue.ErrLeaseNotFound) || errors.Is(err, queue.ErrLeaseExpired) {
 			writeError(w, http.StatusConflict, pullErrLeaseConflict, "lease is invalid or expired")
-			s.observeAck(route, http.StatusConflict, req.LeaseID, errors.Is(err, queue.ErrLeaseExpired))
+			s.observeAck(route, http.StatusConflict, leaseID, errors.Is(err, queue.ErrLeaseExpired))
 			return
 		}
 		writeError(w, http.StatusInternalServerError, pullErrInternal, "ack failed")
-		s.observeAck(route, http.StatusInternalServerError, req.LeaseID, false)
+		s.observeAck(route, http.StatusInternalServerError, leaseID, false)
 		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	s.observeAck(route, http.StatusNoContent, req.LeaseID, false)
+	s.observeAck(route, http.StatusNoContent, leaseID, false)
+	s.rememberCompletedLease(leaseID, recentLeaseOpAck)
+}
+
+func (s *Server) handleAckBatch(w http.ResponseWriter, route string, leaseIDs []string) {
+	pendingLeaseIDs, completedLeaseIDs := s.partitionRecentlyCompletedLeases(leaseIDs, recentLeaseOpAck)
+	for _, leaseID := range completedLeaseIDs {
+		s.observeAck(route, http.StatusNoContent, leaseID, false)
+	}
+
+	ackedFromCompleted := len(completedLeaseIDs)
+	if len(pendingLeaseIDs) == 0 {
+		writeJSON(w, http.StatusOK, ackBatchResponse{Acked: ackedFromCompleted})
+		return
+	}
+
+	if batchStore, ok := s.Store.(queue.LeaseBatchStore); ok {
+		res, err := batchStore.AckBatch(pendingLeaseIDs)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, pullErrInternal, "ack failed")
+			s.observeAck(route, http.StatusInternalServerError, "", false)
+			return
+		}
+
+		observeBatchAck(s, route, pendingLeaseIDs, res)
+		for _, leaseID := range s.successfulLeaseIDs(pendingLeaseIDs, res.Conflicts) {
+			s.rememberCompletedLease(leaseID, recentLeaseOpAck)
+		}
+
+		status := http.StatusOK
+		out := ackBatchResponse{
+			Acked:     ackedFromCompleted + res.Succeeded,
+			Conflicts: mapLeaseBatchConflicts(res.Conflicts),
+		}
+		if len(res.Conflicts) > 0 {
+			status = http.StatusConflict
+			out.Code = pullErrLeaseConflict
+			out.Detail = "one or more leases are invalid or expired"
+		}
+		writeJSON(w, status, out)
+		return
+	}
+
+	acked := 0
+	conflicts := make([]ackBatchConflict, 0)
+
+	for _, leaseID := range pendingLeaseIDs {
+		err := s.Store.Ack(leaseID)
+		if err == nil {
+			acked++
+			s.observeAck(route, http.StatusNoContent, leaseID, false)
+			s.rememberCompletedLease(leaseID, recentLeaseOpAck)
+			continue
+		}
+		if errors.Is(err, queue.ErrLeaseExpired) {
+			conflicts = append(conflicts, ackBatchConflict{
+				LeaseID: leaseID,
+				Reason:  "lease_expired",
+			})
+			s.observeAck(route, http.StatusConflict, leaseID, true)
+			continue
+		}
+		if errors.Is(err, queue.ErrLeaseNotFound) {
+			conflicts = append(conflicts, ackBatchConflict{
+				LeaseID: leaseID,
+				Reason:  "lease_not_found",
+			})
+			s.observeAck(route, http.StatusConflict, leaseID, false)
+			continue
+		}
+
+		writeError(w, http.StatusInternalServerError, pullErrInternal, "ack failed")
+		s.observeAck(route, http.StatusInternalServerError, leaseID, false)
+		return
+	}
+
+	status := http.StatusOK
+	out := ackBatchResponse{
+		Acked:     ackedFromCompleted + acked,
+		Conflicts: conflicts,
+	}
+	if len(conflicts) > 0 {
+		status = http.StatusConflict
+		out.Code = pullErrLeaseConflict
+		out.Detail = "one or more leases are invalid or expired"
+	}
+	writeJSON(w, status, out)
 }
 
 func (s *Server) handleNack(w http.ResponseWriter, r *http.Request, route string) {
@@ -226,48 +375,226 @@ func (s *Server) handleNack(w http.ResponseWriter, r *http.Request, route string
 		s.observeNack(route, http.StatusBadRequest, "", false)
 		return
 	}
-	if req.LeaseID == "" {
-		writeError(w, http.StatusBadRequest, pullErrInvalidBody, "lease_id is required")
+
+	leaseIDs, isBatch, errDetail := normalizeLeaseIDs(req, s.MaxLeaseBatch)
+	if errDetail != "" {
+		writeError(w, http.StatusBadRequest, pullErrInvalidBody, errDetail)
 		s.observeNack(route, http.StatusBadRequest, "", false)
+		return
+	}
+	if !isBatch {
+		s.handleNackSingle(w, route, req, leaseIDs[0])
+		return
+	}
+	s.handleNackBatch(w, route, req, leaseIDs)
+}
+
+func (s *Server) handleNackSingle(w http.ResponseWriter, route string, req leaseRequest, leaseID string) {
+	if s.isRecentlyCompletedLease(leaseID, recentLeaseOpNack) {
+		w.WriteHeader(http.StatusNoContent)
+		s.observeNack(route, http.StatusNoContent, leaseID, false)
 		return
 	}
 
 	if req.Dead {
-		if err := s.Store.MarkDead(req.LeaseID, req.Reason); err != nil {
+		if err := s.Store.MarkDead(leaseID, req.Reason); err != nil {
 			if errors.Is(err, queue.ErrLeaseNotFound) || errors.Is(err, queue.ErrLeaseExpired) {
 				writeError(w, http.StatusConflict, pullErrLeaseConflict, "lease is invalid or expired")
-				s.observeNack(route, http.StatusConflict, req.LeaseID, errors.Is(err, queue.ErrLeaseExpired))
+				s.observeNack(route, http.StatusConflict, leaseID, errors.Is(err, queue.ErrLeaseExpired))
 				return
 			}
 			writeError(w, http.StatusInternalServerError, pullErrInternal, "mark dead failed")
-			s.observeNack(route, http.StatusInternalServerError, req.LeaseID, false)
+			s.observeNack(route, http.StatusInternalServerError, leaseID, false)
 			return
 		}
 		w.WriteHeader(http.StatusNoContent)
-		s.observeNack(route, http.StatusNoContent, req.LeaseID, false)
+		s.observeNack(route, http.StatusNoContent, leaseID, false)
+		s.rememberCompletedLease(leaseID, recentLeaseOpNack)
 		return
 	}
 
 	delay, ok := parseDuration(req.Delay)
 	if !ok {
 		writeError(w, http.StatusBadRequest, pullErrInvalidBody, "delay must be a valid duration")
-		s.observeNack(route, http.StatusBadRequest, req.LeaseID, false)
+		s.observeNack(route, http.StatusBadRequest, leaseID, false)
 		return
 	}
 
-	if err := s.Store.Nack(req.LeaseID, delay); err != nil {
+	if err := s.Store.Nack(leaseID, delay); err != nil {
 		if errors.Is(err, queue.ErrLeaseNotFound) || errors.Is(err, queue.ErrLeaseExpired) {
 			writeError(w, http.StatusConflict, pullErrLeaseConflict, "lease is invalid or expired")
-			s.observeNack(route, http.StatusConflict, req.LeaseID, errors.Is(err, queue.ErrLeaseExpired))
+			s.observeNack(route, http.StatusConflict, leaseID, errors.Is(err, queue.ErrLeaseExpired))
 			return
 		}
 		writeError(w, http.StatusInternalServerError, pullErrInternal, "nack failed")
-		s.observeNack(route, http.StatusInternalServerError, req.LeaseID, false)
+		s.observeNack(route, http.StatusInternalServerError, leaseID, false)
 		return
 	}
 
 	w.WriteHeader(http.StatusNoContent)
-	s.observeNack(route, http.StatusNoContent, req.LeaseID, false)
+	s.observeNack(route, http.StatusNoContent, leaseID, false)
+	s.rememberCompletedLease(leaseID, recentLeaseOpNack)
+}
+
+func (s *Server) handleNackBatch(w http.ResponseWriter, route string, req leaseRequest, leaseIDs []string) {
+	delay, ok := parseDuration(req.Delay)
+	if !req.Dead && !ok {
+		writeError(w, http.StatusBadRequest, pullErrInvalidBody, "delay must be a valid duration")
+		s.observeNack(route, http.StatusBadRequest, "", false)
+		return
+	}
+
+	pendingLeaseIDs, completedLeaseIDs := s.partitionRecentlyCompletedLeases(leaseIDs, recentLeaseOpNack)
+	for _, leaseID := range completedLeaseIDs {
+		s.observeNack(route, http.StatusNoContent, leaseID, false)
+	}
+
+	succeededFromCompleted := len(completedLeaseIDs)
+	if len(pendingLeaseIDs) == 0 {
+		writeJSON(w, http.StatusOK, nackBatchResponse{Succeeded: succeededFromCompleted})
+		return
+	}
+
+	if batchStore, ok := s.Store.(queue.LeaseBatchStore); ok {
+		var (
+			res queue.LeaseBatchResult
+			err error
+		)
+		if req.Dead {
+			res, err = batchStore.MarkDeadBatch(pendingLeaseIDs, req.Reason)
+		} else {
+			res, err = batchStore.NackBatch(pendingLeaseIDs, delay)
+		}
+		if err != nil {
+			if req.Dead {
+				writeError(w, http.StatusInternalServerError, pullErrInternal, "mark dead failed")
+			} else {
+				writeError(w, http.StatusInternalServerError, pullErrInternal, "nack failed")
+			}
+			s.observeNack(route, http.StatusInternalServerError, "", false)
+			return
+		}
+
+		observeBatchNack(s, route, pendingLeaseIDs, res)
+		for _, leaseID := range s.successfulLeaseIDs(pendingLeaseIDs, res.Conflicts) {
+			s.rememberCompletedLease(leaseID, recentLeaseOpNack)
+		}
+
+		status := http.StatusOK
+		out := nackBatchResponse{
+			Succeeded: succeededFromCompleted + res.Succeeded,
+			Conflicts: mapLeaseBatchConflicts(res.Conflicts),
+		}
+		if len(res.Conflicts) > 0 {
+			status = http.StatusConflict
+			out.Code = pullErrLeaseConflict
+			out.Detail = "one or more leases are invalid or expired"
+		}
+		writeJSON(w, status, out)
+		return
+	}
+
+	succeeded := 0
+	conflicts := make([]ackBatchConflict, 0)
+
+	for _, leaseID := range pendingLeaseIDs {
+		var err error
+		if req.Dead {
+			err = s.Store.MarkDead(leaseID, req.Reason)
+		} else {
+			err = s.Store.Nack(leaseID, delay)
+		}
+		if err == nil {
+			succeeded++
+			s.observeNack(route, http.StatusNoContent, leaseID, false)
+			s.rememberCompletedLease(leaseID, recentLeaseOpNack)
+			continue
+		}
+		if errors.Is(err, queue.ErrLeaseExpired) {
+			conflicts = append(conflicts, ackBatchConflict{
+				LeaseID: leaseID,
+				Reason:  "lease_expired",
+			})
+			s.observeNack(route, http.StatusConflict, leaseID, true)
+			continue
+		}
+		if errors.Is(err, queue.ErrLeaseNotFound) {
+			conflicts = append(conflicts, ackBatchConflict{
+				LeaseID: leaseID,
+				Reason:  "lease_not_found",
+			})
+			s.observeNack(route, http.StatusConflict, leaseID, false)
+			continue
+		}
+
+		if req.Dead {
+			writeError(w, http.StatusInternalServerError, pullErrInternal, "mark dead failed")
+		} else {
+			writeError(w, http.StatusInternalServerError, pullErrInternal, "nack failed")
+		}
+		s.observeNack(route, http.StatusInternalServerError, leaseID, false)
+		return
+	}
+
+	status := http.StatusOK
+	out := nackBatchResponse{
+		Succeeded: succeededFromCompleted + succeeded,
+		Conflicts: conflicts,
+	}
+	if len(conflicts) > 0 {
+		status = http.StatusConflict
+		out.Code = pullErrLeaseConflict
+		out.Detail = "one or more leases are invalid or expired"
+	}
+	writeJSON(w, status, out)
+}
+
+func mapLeaseBatchConflicts(conflicts []queue.LeaseBatchConflict) []ackBatchConflict {
+	if len(conflicts) == 0 {
+		return nil
+	}
+	out := make([]ackBatchConflict, 0, len(conflicts))
+	for _, conflict := range conflicts {
+		reason := "lease_not_found"
+		if conflict.Expired {
+			reason = "lease_expired"
+		}
+		out = append(out, ackBatchConflict{
+			LeaseID: conflict.LeaseID,
+			Reason:  reason,
+		})
+	}
+	return out
+}
+
+func observeBatchAck(s *Server, route string, leaseIDs []string, res queue.LeaseBatchResult) {
+	conflicts := make(map[string]bool, len(res.Conflicts))
+	for _, conflict := range res.Conflicts {
+		conflicts[conflict.LeaseID] = conflict.Expired
+	}
+	for _, leaseID := range leaseIDs {
+		expired, isConflict := conflicts[leaseID]
+		if isConflict {
+			s.observeAck(route, http.StatusConflict, leaseID, expired)
+			continue
+		}
+		s.observeAck(route, http.StatusNoContent, leaseID, false)
+	}
+}
+
+func observeBatchNack(s *Server, route string, leaseIDs []string, res queue.LeaseBatchResult) {
+	conflicts := make(map[string]bool, len(res.Conflicts))
+	for _, conflict := range res.Conflicts {
+		conflicts[conflict.LeaseID] = conflict.Expired
+	}
+	for _, leaseID := range leaseIDs {
+		expired, isConflict := conflicts[leaseID]
+		if isConflict {
+			s.observeNack(route, http.StatusConflict, leaseID, expired)
+			continue
+		}
+		s.observeNack(route, http.StatusNoContent, leaseID, false)
+	}
 }
 
 func (s *Server) handleExtend(w http.ResponseWriter, r *http.Request, route string) {
@@ -335,6 +662,153 @@ func (s *Server) observeExtend(route string, statusCode int, leaseID string, ext
 	}
 }
 
+func (s *Server) nowTime() time.Time {
+	if s != nil && s.now != nil {
+		return s.now()
+	}
+	return time.Now()
+}
+
+func (s *Server) isRecentlyCompletedLease(leaseID string, op string) bool {
+	leaseID = strings.TrimSpace(leaseID)
+	op = strings.TrimSpace(op)
+	if leaseID == "" || op == "" {
+		return false
+	}
+	if s.RecentLeaseOpTTL <= 0 || s.RecentLeaseOpCap <= 0 {
+		return false
+	}
+
+	now := s.nowTime()
+	key := recentLeaseOpKey{leaseID: leaseID, op: op}
+
+	s.recentLeaseMu.Lock()
+	defer s.recentLeaseMu.Unlock()
+
+	s.pruneRecentLeaseOpsLocked(now)
+	elem, ok := s.recentLeaseOps[key]
+	if !ok {
+		return false
+	}
+
+	entry, _ := elem.Value.(*recentLeaseOpEntry)
+	if entry == nil || !now.Before(entry.expiresAt) {
+		s.removeRecentLeaseOpLocked(elem)
+		return false
+	}
+	return true
+}
+
+func (s *Server) rememberCompletedLease(leaseID string, op string) {
+	leaseID = strings.TrimSpace(leaseID)
+	op = strings.TrimSpace(op)
+	if leaseID == "" || op == "" {
+		return
+	}
+	if s.RecentLeaseOpTTL <= 0 || s.RecentLeaseOpCap <= 0 {
+		return
+	}
+
+	now := s.nowTime()
+	expiresAt := now.Add(s.RecentLeaseOpTTL)
+	key := recentLeaseOpKey{leaseID: leaseID, op: op}
+
+	s.recentLeaseMu.Lock()
+	defer s.recentLeaseMu.Unlock()
+
+	s.pruneRecentLeaseOpsLocked(now)
+	if s.recentLeaseOps == nil {
+		s.recentLeaseOps = make(map[recentLeaseOpKey]*list.Element)
+	}
+
+	if elem, ok := s.recentLeaseOps[key]; ok {
+		entry, _ := elem.Value.(*recentLeaseOpEntry)
+		if entry == nil {
+			entry = &recentLeaseOpEntry{key: key, expiresAt: expiresAt}
+			elem.Value = entry
+		}
+		entry.expiresAt = expiresAt
+		s.recentLeaseOrder.MoveToBack(elem)
+		return
+	}
+
+	elem := s.recentLeaseOrder.PushBack(&recentLeaseOpEntry{
+		key:       key,
+		expiresAt: expiresAt,
+	})
+	s.recentLeaseOps[key] = elem
+
+	for len(s.recentLeaseOps) > s.RecentLeaseOpCap {
+		front := s.recentLeaseOrder.Front()
+		if front == nil {
+			break
+		}
+		s.removeRecentLeaseOpLocked(front)
+	}
+}
+
+func (s *Server) partitionRecentlyCompletedLeases(leaseIDs []string, op string) (pending []string, completed []string) {
+	if len(leaseIDs) == 0 {
+		return nil, nil
+	}
+	pending = make([]string, 0, len(leaseIDs))
+	completed = make([]string, 0, len(leaseIDs))
+	for _, leaseID := range leaseIDs {
+		if s.isRecentlyCompletedLease(leaseID, op) {
+			completed = append(completed, leaseID)
+			continue
+		}
+		pending = append(pending, leaseID)
+	}
+	return pending, completed
+}
+
+func (s *Server) successfulLeaseIDs(leaseIDs []string, conflicts []queue.LeaseBatchConflict) []string {
+	if len(leaseIDs) == 0 {
+		return nil
+	}
+	if len(conflicts) == 0 {
+		return append([]string(nil), leaseIDs...)
+	}
+	conflictByID := make(map[string]struct{}, len(conflicts))
+	for _, conflict := range conflicts {
+		conflictByID[conflict.LeaseID] = struct{}{}
+	}
+	out := make([]string, 0, len(leaseIDs))
+	for _, leaseID := range leaseIDs {
+		if _, ok := conflictByID[leaseID]; ok {
+			continue
+		}
+		out = append(out, leaseID)
+	}
+	return out
+}
+
+func (s *Server) pruneRecentLeaseOpsLocked(now time.Time) {
+	for {
+		front := s.recentLeaseOrder.Front()
+		if front == nil {
+			return
+		}
+		entry, _ := front.Value.(*recentLeaseOpEntry)
+		if entry == nil || now.Before(entry.expiresAt) {
+			return
+		}
+		s.removeRecentLeaseOpLocked(front)
+	}
+}
+
+func (s *Server) removeRecentLeaseOpLocked(elem *list.Element) {
+	if elem == nil {
+		return
+	}
+	entry, _ := elem.Value.(*recentLeaseOpEntry)
+	if entry != nil && s.recentLeaseOps != nil {
+		delete(s.recentLeaseOps, entry.key)
+	}
+	s.recentLeaseOrder.Remove(elem)
+}
+
 func readLeaseRequest(w http.ResponseWriter, r *http.Request) (leaseRequest, bool) {
 	var req leaseRequest
 	if !decodeJSONBodyStrict(w, r, &req, false) {
@@ -364,6 +838,47 @@ func decodeJSONBodyStrict(w http.ResponseWriter, r *http.Request, dst any, allow
 		return false
 	}
 	return true
+}
+
+func normalizeLeaseIDs(req leaseRequest, maxBatch int) ([]string, bool, string) {
+	single := strings.TrimSpace(req.LeaseID)
+	if single != "" && len(req.LeaseIDs) > 0 {
+		return nil, false, "use either lease_id or lease_ids, not both"
+	}
+	if single != "" {
+		return []string{single}, false, ""
+	}
+
+	if len(req.LeaseIDs) == 0 {
+		return nil, false, "lease_id or lease_ids is required"
+	}
+
+	seen := make(map[string]struct{}, len(req.LeaseIDs))
+	out := make([]string, 0, len(req.LeaseIDs))
+	for _, raw := range req.LeaseIDs {
+		id := strings.TrimSpace(raw)
+		if id == "" {
+			continue
+		}
+		if _, ok := seen[id]; ok {
+			continue
+		}
+		seen[id] = struct{}{}
+		out = append(out, id)
+	}
+	if len(out) == 0 {
+		return nil, false, "lease_ids must include at least one non-empty lease id"
+	}
+	if maxBatch > 0 && len(out) > maxBatch {
+		return nil, false, "lease_ids exceeds max batch"
+	}
+	return out, true, ""
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
 }
 
 type errorResponse struct {

--- a/internal/queue/memory_test.go
+++ b/internal/queue/memory_test.go
@@ -184,6 +184,143 @@ func TestMemoryStore_MarkDead(t *testing.T) {
 	}
 }
 
+func TestMemoryStore_LeaseBatchMethods(t *testing.T) {
+	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
+	nowVar := now
+	s := NewMemoryStore(WithNowFunc(func() time.Time { return nowVar }))
+
+	for _, id := range []string{"evt_1", "evt_2", "evt_3"} {
+		if err := s.Enqueue(Envelope{ID: id, Route: "/r", Target: "pull", ReceivedAt: nowVar, NextRunAt: nowVar}); err != nil {
+			t.Fatalf("enqueue %s: %v", id, err)
+		}
+	}
+
+	deq, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 2, LeaseTTL: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if len(deq.Items) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(deq.Items))
+	}
+
+	ackRes, err := s.AckBatch([]string{deq.Items[0].LeaseID, "missing", deq.Items[1].LeaseID})
+	if err != nil {
+		t.Fatalf("ack batch: %v", err)
+	}
+	if ackRes.Succeeded != 2 {
+		t.Fatalf("expected 2 successful acks, got %d", ackRes.Succeeded)
+	}
+	if len(ackRes.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %#v", ackRes.Conflicts)
+	}
+	if ackRes.Conflicts[0].LeaseID != "missing" || ackRes.Conflicts[0].Expired {
+		t.Fatalf("unexpected conflict: %#v", ackRes.Conflicts[0])
+	}
+
+	deq2, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 1, LeaseTTL: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("dequeue2: %v", err)
+	}
+	if len(deq2.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(deq2.Items))
+	}
+
+	nackRes, err := s.NackBatch([]string{deq2.Items[0].LeaseID}, 5*time.Second)
+	if err != nil {
+		t.Fatalf("nack batch: %v", err)
+	}
+	if nackRes.Succeeded != 1 || len(nackRes.Conflicts) != 0 {
+		t.Fatalf("unexpected nack batch result: %#v", nackRes)
+	}
+
+	deq3, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 1})
+	if err != nil {
+		t.Fatalf("dequeue3: %v", err)
+	}
+	if len(deq3.Items) != 0 {
+		t.Fatalf("expected no items before nack delay elapsed, got %d", len(deq3.Items))
+	}
+
+	nowVar = nowVar.Add(5 * time.Second)
+	deq4, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 1, LeaseTTL: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("dequeue4: %v", err)
+	}
+	if len(deq4.Items) != 1 {
+		t.Fatalf("expected 1 item after nack delay, got %d", len(deq4.Items))
+	}
+
+	deadRes, err := s.MarkDeadBatch([]string{deq4.Items[0].LeaseID, "missing_dead"}, "no_retry")
+	if err != nil {
+		t.Fatalf("mark dead batch: %v", err)
+	}
+	if deadRes.Succeeded != 1 {
+		t.Fatalf("expected 1 successful mark dead, got %d", deadRes.Succeeded)
+	}
+	if len(deadRes.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %#v", deadRes.Conflicts)
+	}
+	if deadRes.Conflicts[0].LeaseID != "missing_dead" || deadRes.Conflicts[0].Expired {
+		t.Fatalf("unexpected conflict: %#v", deadRes.Conflicts[0])
+	}
+
+	env := s.items[deq4.Items[0].ID]
+	if env == nil {
+		t.Fatalf("expected dead item to remain in store")
+	}
+	if env.State != StateDead {
+		t.Fatalf("expected dead state, got %q", env.State)
+	}
+	if env.DeadReason != "no_retry" {
+		t.Fatalf("expected dead reason %q, got %q", "no_retry", env.DeadReason)
+	}
+}
+
+func TestMemoryStore_AckBatchExpiredRequeues(t *testing.T) {
+	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
+	nowVar := now
+	s := NewMemoryStore(WithNowFunc(func() time.Time { return nowVar }))
+
+	if err := s.Enqueue(Envelope{ID: "evt_1", Route: "/r", Target: "pull"}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	deq, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 1, LeaseTTL: time.Second})
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if len(deq.Items) != 1 {
+		t.Fatalf("expected 1 item, got %d", len(deq.Items))
+	}
+	leaseID := deq.Items[0].LeaseID
+
+	nowVar = nowVar.Add(2 * time.Second)
+	res, err := s.AckBatch([]string{leaseID})
+	if err != nil {
+		t.Fatalf("ack batch: %v", err)
+	}
+	if res.Succeeded != 0 {
+		t.Fatalf("expected 0 successful acks, got %d", res.Succeeded)
+	}
+	if len(res.Conflicts) != 1 {
+		t.Fatalf("expected 1 conflict, got %#v", res.Conflicts)
+	}
+	if res.Conflicts[0].LeaseID != leaseID || !res.Conflicts[0].Expired {
+		t.Fatalf("unexpected conflict: %#v", res.Conflicts[0])
+	}
+
+	deq2, err := s.Dequeue(DequeueRequest{Route: "/r", Target: "pull", Batch: 1, LeaseTTL: time.Second})
+	if err != nil {
+		t.Fatalf("dequeue2: %v", err)
+	}
+	if len(deq2.Items) != 1 {
+		t.Fatalf("expected requeued item, got %d", len(deq2.Items))
+	}
+	if deq2.Items[0].Attempt != 2 {
+		t.Fatalf("expected attempt=2 after expired batch ack, got %d", deq2.Items[0].Attempt)
+	}
+}
+
 func TestMemoryStore_ListDead(t *testing.T) {
 	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
 	nowVar := now

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -175,6 +175,25 @@ type AttemptListResponse struct {
 	Items []DeliveryAttempt
 }
 
+type LeaseBatchConflict struct {
+	LeaseID string
+	Expired bool
+}
+
+type LeaseBatchResult struct {
+	Succeeded int
+	Conflicts []LeaseBatchConflict
+}
+
+// LeaseBatchStore is an optional extension for batched lease operations.
+// Implementations should process the whole batch in one store transaction
+// where possible and return per-lease conflicts for not-found/expired leases.
+type LeaseBatchStore interface {
+	AckBatch(leaseIDs []string) (LeaseBatchResult, error)
+	NackBatch(leaseIDs []string, delay time.Duration) (LeaseBatchResult, error)
+	MarkDeadBatch(leaseIDs []string, reason string) (LeaseBatchResult, error)
+}
+
 type BacklogTrendSample struct {
 	CapturedAt time.Time
 	Queued     int

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,8 @@ nav:
   - Operations:
       - Security: security.md
       - Observability: observability.md
+      - Adaptive Backpressure Tuning: adaptive-backpressure.md
+      - Performance Baselines: performance.md
   - Integrations:
       - MCP Integration: mcp.md
   - Project:


### PR DESCRIPTION
## Summary
- complete issue #39 slices across pull/push throughput and saturation tuning
- add push benchmark tail-latency guardrails (`p95_ms`, `p99_ms`) and reject-reason breakdown
- finalize dispatcher fairness tuning (target-aware dequeue micro-batching, single-target batch lease mutation path with multi-target safety fallback)
- refresh docs/backlog/changelog and benchmark baselines

## Validation
- `go test ./...`
- `go vet ./...`
- `make bench-pull*` + `make bench-push-*` compare workflows

Closes #39