### PR TITLE
feat(metrics): backend-agnostic store runtime metric foundation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,6 +12,8 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 
 ## P1 - Medium Priority (v1.x)
 
+- [ ] **Store observability backend-agnostic metrics (#38)** — In progress: unify store runtime metric vocabulary with backend/operation labels (`hookaido_store_operation_seconds`, `hookaido_store_operation_total`, `hookaido_store_errors_total`) while keeping backend-specific compatibility series.
+- [ ] **PostgreSQL queue backend parity (#37)** — Implement `queue.backend postgres` with runtime store wiring, schema bootstrap/migrations, and behavior parity to sqlite (lease lifecycle, DLQ operations, attempts, stats), after #38 metric wiring stabilizes.
 - [x] **~~Mixed-workload tail latency playbook~~** — Reproducible mixed ingress+drain benchmark workflow with p95/p99 reporting added (`bench-pull-mixed*`; moved to Completed).
 - [x] **~~Drain fairness under saturation~~** — Reproducible push saturation/skewed benchmark guardrails now include reject-reason splits plus `p95_ms`/`p99_ms`; dispatcher saturation path tuned with route-shared workers, target-aware dequeue micro-batching, and single-target lease-mutation batching with multi-target fallback (moved to Completed).
 - [x] **~~Adaptive backpressure production tuning guide~~** — Data-driven threshold tuning guidance with enterprise starting profiles published (moved to Completed).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Ingress rejection breakdown counters via `hookaido_ingress_rejected_by_reason_total{reason,status}` now include `memory_pressure` (`status="503"`) for memory-backend pressure rejects.
 - Pull API `POST {endpoint}/ack` and `POST {endpoint}/nack` now support batch form via `lease_ids` (up to 100 IDs per request), returning aggregate success/conflict output for high-throughput worker lease operations.
 - Optional gRPC worker listener via `pull_api.grpc_listen`: starts WorkerService (`Dequeue`, `Ack`, `Nack`, `Extend`) on shared Pull operation semantics, applies `pull_api.tls` for TLS/mTLS, enforces dedicated-listener conflict guards, and keeps Pull token auth parity (global + per-route override).
+- Backend-agnostic store runtime metric families on `/metrics`: `hookaido_store_operation_seconds{backend,operation}` (histogram), `hookaido_store_operation_total{backend,operation}`, and `hookaido_store_errors_total{backend,operation,kind}` to support backend-neutral dashboards and future PostgreSQL wiring.
 - Reproducible Pull benchmark workflow docs (`docs/performance.md`) plus Make targets for baseline/current capture and `benchstat` diff (`bench-pull-baseline`, `bench-pull`, `bench-pull-compare`).
 - Isolated Extend benchmarking targets (`bench-pull-extend`, `bench-pull-extend-compare`) for lower-variance validation of active-lease Pull `extend` changes.
 - Sustained-drain Pull benchmarking targets (`bench-pull-drain-baseline`, `bench-pull-drain`, `bench-pull-drain-compare`) focused on dequeue + batch `ack` with `batch=15`.
@@ -29,6 +30,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ### Changed
 
 - Worker gRPC scope is now explicitly fixed to pull-worker lease transport (`dequeue`/`ack`/`nack`/`extend`) and documented as out-of-scope for admin/publish/control-plane and MCP lease mutation tools.
+- SQLite runtime instrumentation now populates both backend-agnostic store metric families and legacy `hookaido_store_sqlite_*` series for compatibility during dashboard migration.
 - Memory backend now emits explicit `ErrMemoryPressure` admission rejects when retained (non-active) memory footprint crosses pressure guard thresholds; ingress surfaces these as HTTP `503` with rejection reason `memory_pressure` instead of generic store-unavailable.
 - Admin health diagnostics (`GET /healthz?details=1`) now include ingress `rejected_by_reason` and memory-store runtime diagnostics (`items_by_state`, retained bytes, eviction counters, and memory pressure state) when the memory backend is active.
 - Ingress rejection breakdown metric `hookaido_ingress_rejected_by_reason_total{reason,status}` for bounded-cardinality attribution across queue pressure, adaptive backpressure, auth, routing, policy, and fallback reject paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Push saturation benchmarks now also emit reject-reason splits (`ingress_rejects_queue_full`, `ingress_rejects_adaptive_backpressure`, `ingress_rejects_memory_pressure`, `ingress_rejects_other`) for clearer ingress-vs-drain tuning under load.
 - Push saturation/skewed benchmarks now emit ingress tail-latency metrics (`p95_ms`, `p99_ms`) for queue-pressure tuning based on latency guardrails, not only throughput/reject counters.
 - Adaptive backpressure production tuning guide (`docs/adaptive-backpressure.md`) with data-driven starting profiles (`balanced`, `latency_first`, `throughput_first`), metric-driven decision matrix, and rollout guardrails for enterprise workloads.
-- Metrics schema marker `hookaido_metrics_schema_info{schema="1.2.0"}` for dashboard compatibility gating across mixed Hookaido versions.
+- Metrics schema marker `hookaido_metrics_schema_info{schema="1.3.0"}` for dashboard compatibility gating across mixed Hookaido versions.
 
 ### Changed
 

--- a/docs/adaptive-backpressure.md
+++ b/docs/adaptive-backpressure.md
@@ -87,6 +87,6 @@ Use production-like ingress load tests for threshold tuning decisions. The bench
 
 When dashboards span versions, gate adaptive panels/alerts with:
 
-- `hookaido_metrics_schema_info{schema="1.2.0"} == 1`
+- `hookaido_metrics_schema_info{schema="1.3.0"} == 1`
 
-This avoids interpreting missing pre-`1.2.0` series as zero.
+This avoids interpreting missing pre-`1.3.0` series as zero.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -153,7 +153,15 @@ Set `enabled off` to disable the metrics listener while keeping config in place.
 | `hookaido_pull_lease_active`          | gauge   | Active Pull leases currently tracked by `route`                              |
 | `hookaido_pull_lease_expired_total`   | counter | Lease expirations observed during Pull `ack`/`nack`/`extend` by `route`      |
 
-**Store/SQLite metrics:**
+**Store common metrics:**
+
+| Metric                                                  | Type      | Description                                                            |
+| ------------------------------------------------------- | --------- | ---------------------------------------------------------------------- |
+| `hookaido_store_operation_seconds{backend,operation}`   | histogram | Store operation duration by backend and operation                      |
+| `hookaido_store_operation_total{backend,operation}`     | counter   | Store operation totals by backend and operation                        |
+| `hookaido_store_errors_total{backend,operation,kind}`   | counter   | Store operation errors by backend, operation, and normalized kind      |
+
+**Store/SQLite compatibility metrics (sqlite backend):**
 
 | Metric                                           | Type      | Description                                                                |
 | ------------------------------------------------ | --------- | -------------------------------------------------------------------------- |
@@ -329,9 +337,9 @@ Use these series together:
 
 ## Dashboard Compatibility Notes
 
-When dashboards span mixed Hookaido versions (for example `v1.1.x` and `v1.2.x`), treat missing metrics as "not emitted" rather than zero:
+When dashboards span mixed Hookaido versions (for example `v1.2.x` and `v1.3.x`), treat missing metrics as "not emitted" rather than zero:
 
-- Gate rules and panels by `hookaido_metrics_schema_info{schema="1.2.0"} == 1` (or `hookaido_build_info` version labels).
+- Gate rules and panels by `hookaido_metrics_schema_info{schema="1.3.0"} == 1` (or `hookaido_build_info` version labels).
 - In PromQL, prefer compatibility-safe expressions (for example `metric OR on() vector(0)`) where appropriate.
 - Document minimum supported Hookaido version per dashboard bundle to avoid false "all good" signals from absent series.
 

--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -14,7 +14,7 @@ import (
 	"github.com/nuetzliches/hookaido/internal/queue"
 )
 
-const metricsSchemaVersion = "1.2.0"
+const metricsSchemaVersion = "1.3.0"
 
 type runtimeMetrics struct {
 	tracingEnabled                             atomic.Int64

--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -1133,6 +1133,56 @@ func newMetricsHandler(version string, start time.Time, rm *runtimeMetrics) http
 
 			if provider, ok := queueStore.(queue.RuntimeMetricsProvider); ok {
 				runtime := provider.RuntimeMetrics()
+				if len(runtime.Common.OperationDurationSeconds) > 0 {
+					durations := append([]queue.StoreOperationDurationRuntimeMetric(nil), runtime.Common.OperationDurationSeconds...)
+					sort.Slice(durations, func(i, j int) bool {
+						return durations[i].Operation < durations[j].Operation
+					})
+					_, _ = fmt.Fprintf(w, "# HELP hookaido_store_operation_seconds Store operation duration in seconds by backend and operation.\n")
+					_, _ = fmt.Fprintf(w, "# TYPE hookaido_store_operation_seconds histogram\n")
+					for _, metric := range durations {
+						labels := fmt.Sprintf("backend=%q,operation=%q", runtime.Backend, metric.Operation)
+						writePrometheusHistogramSeries(w, "hookaido_store_operation_seconds", metric.DurationSeconds, labels)
+					}
+				}
+				if len(runtime.Common.OperationTotal) > 0 {
+					counters := append([]queue.StoreOperationCounterRuntimeMetric(nil), runtime.Common.OperationTotal...)
+					sort.Slice(counters, func(i, j int) bool {
+						return counters[i].Operation < counters[j].Operation
+					})
+					_, _ = fmt.Fprintf(w, "# HELP hookaido_store_operation_total Total number of store operations by backend and operation.\n")
+					_, _ = fmt.Fprintf(w, "# TYPE hookaido_store_operation_total counter\n")
+					for _, metric := range counters {
+						_, _ = fmt.Fprintf(
+							w,
+							"hookaido_store_operation_total{backend=%q,operation=%q} %d\n",
+							runtime.Backend,
+							metric.Operation,
+							metric.Total,
+						)
+					}
+				}
+				if len(runtime.Common.ErrorsTotal) > 0 {
+					errorsTotal := append([]queue.StoreOperationErrorRuntimeMetric(nil), runtime.Common.ErrorsTotal...)
+					sort.Slice(errorsTotal, func(i, j int) bool {
+						if errorsTotal[i].Operation == errorsTotal[j].Operation {
+							return errorsTotal[i].Kind < errorsTotal[j].Kind
+						}
+						return errorsTotal[i].Operation < errorsTotal[j].Operation
+					})
+					_, _ = fmt.Fprintf(w, "# HELP hookaido_store_errors_total Total number of store operation errors by backend, operation, and kind.\n")
+					_, _ = fmt.Fprintf(w, "# TYPE hookaido_store_errors_total counter\n")
+					for _, metric := range errorsTotal {
+						_, _ = fmt.Fprintf(
+							w,
+							"hookaido_store_errors_total{backend=%q,operation=%q,kind=%q} %d\n",
+							runtime.Backend,
+							metric.Operation,
+							metric.Kind,
+							metric.Total,
+						)
+					}
+				}
 				if runtime.Memory != nil {
 					memoryMetrics := runtime.Memory
 					_, _ = fmt.Fprintf(w, "# HELP hookaido_store_memory_items Current number of in-memory store items by state.\n")
@@ -1207,11 +1257,24 @@ func newMetricsHandler(version string, start time.Time, rm *runtimeMetrics) http
 func writePrometheusHistogram(w http.ResponseWriter, name string, help string, snapshot queue.HistogramSnapshot) {
 	_, _ = fmt.Fprintf(w, "# HELP %s %s\n", name, help)
 	_, _ = fmt.Fprintf(w, "# TYPE %s histogram\n", name)
+	writePrometheusHistogramSeries(w, name, snapshot, "")
+}
+
+func writePrometheusHistogramSeries(w http.ResponseWriter, name string, snapshot queue.HistogramSnapshot, labels string) {
 	for _, bucket := range snapshot.Buckets {
-		_, _ = fmt.Fprintf(w, "%s_bucket{le=%q} %d\n", name, prometheusLe(bucket.Le), bucket.Count)
+		if labels == "" {
+			_, _ = fmt.Fprintf(w, "%s_bucket{le=%q} %d\n", name, prometheusLe(bucket.Le), bucket.Count)
+			continue
+		}
+		_, _ = fmt.Fprintf(w, "%s_bucket{%s,le=%q} %d\n", name, labels, prometheusLe(bucket.Le), bucket.Count)
 	}
-	_, _ = fmt.Fprintf(w, "%s_sum %.9f\n", name, snapshot.Sum)
-	_, _ = fmt.Fprintf(w, "%s_count %d\n", name, snapshot.Count)
+	if labels == "" {
+		_, _ = fmt.Fprintf(w, "%s_sum %.9f\n", name, snapshot.Sum)
+		_, _ = fmt.Fprintf(w, "%s_count %d\n", name, snapshot.Count)
+		return
+	}
+	_, _ = fmt.Fprintf(w, "%s_sum{%s} %.9f\n", name, labels, snapshot.Sum)
+	_, _ = fmt.Fprintf(w, "%s_count{%s} %d\n", name, labels, snapshot.Count)
 }
 
 func prometheusLe(v float64) string {

--- a/internal/app/metrics_test.go
+++ b/internal/app/metrics_test.go
@@ -384,6 +384,10 @@ func TestMetricsHandler_SQLiteStoreRuntimeMetrics(t *testing.T) {
 
 	body := rr.Body.String()
 	for _, want := range []string{
+		`hookaido_store_operation_seconds_bucket{backend="sqlite",operation="write_tx",le="+Inf"}`,
+		`hookaido_store_operation_seconds_count{backend="sqlite",operation="write_tx"} `,
+		`hookaido_store_operation_total{backend="sqlite",operation="tx_commit"} `,
+		`hookaido_store_errors_total{backend="sqlite",operation="begin_tx",kind="busy"} `,
 		`hookaido_store_sqlite_write_seconds_bucket{le="+Inf"}`,
 		`hookaido_store_sqlite_write_seconds_count `,
 		`hookaido_store_sqlite_dequeue_seconds_bucket{le="+Inf"}`,

--- a/internal/queue/memory.go
+++ b/internal/queue/memory.go
@@ -1806,10 +1806,21 @@ func (s *MemoryStore) RuntimeMetrics() StoreRuntimeMetrics {
 		retainedBytesByState[st] = n
 	}
 	evictions := make(map[string]int64, len(s.evictionsTotalByReason))
+	evictionTotal := int64(0)
 	for reason, n := range s.evictionsTotalByReason {
 		evictions[reason] = n
+		evictionTotal += n
 	}
 	pressure := s.memoryPressureStatusLocked()
+	out.Common = StoreCommonRuntimeMetrics{
+		OperationTotal: []StoreOperationCounterRuntimeMetric{
+			{Operation: "enqueue_reject", Total: pressure.RejectTotal},
+			{Operation: "evict", Total: evictionTotal},
+		},
+		ErrorsTotal: []StoreOperationErrorRuntimeMetric{
+			{Operation: "enqueue", Kind: "memory_pressure", Total: pressure.RejectTotal},
+		},
+	}
 
 	out.Memory = &MemoryRuntimeMetrics{
 		ItemsByState:           itemsByState,

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -268,6 +268,28 @@ type HistogramSnapshot struct {
 	Sum     float64
 }
 
+type StoreOperationDurationRuntimeMetric struct {
+	Operation       string
+	DurationSeconds HistogramSnapshot
+}
+
+type StoreOperationCounterRuntimeMetric struct {
+	Operation string
+	Total     int64
+}
+
+type StoreOperationErrorRuntimeMetric struct {
+	Operation string
+	Kind      string
+	Total     int64
+}
+
+type StoreCommonRuntimeMetrics struct {
+	OperationDurationSeconds []StoreOperationDurationRuntimeMetric
+	OperationTotal           []StoreOperationCounterRuntimeMetric
+	ErrorsTotal              []StoreOperationErrorRuntimeMetric
+}
+
 type SQLiteRuntimeMetrics struct {
 	WriteDurationSeconds      HistogramSnapshot
 	DequeueDurationSeconds    HistogramSnapshot
@@ -300,6 +322,7 @@ type MemoryRuntimeMetrics struct {
 
 type StoreRuntimeMetrics struct {
 	Backend string
+	Common  StoreCommonRuntimeMetrics
 	SQLite  *SQLiteRuntimeMetrics
 	Memory  *MemoryRuntimeMetrics
 }


### PR DESCRIPTION
## Summary
- add backend-agnostic store runtime metric structures in queue.StoreRuntimeMetrics
- export new /metrics families: hookaido_store_operation_seconds, hookaido_store_operation_total, hookaido_store_errors_total
- wire sqlite runtime metrics into the new common vocabulary
- wire memory runtime metrics into the new common vocabulary (evictions + memory-pressure reject mapping)
- keep existing sqlite-specific metric series for dashboard compatibility
- bump metrics schema marker to 1.3.0 and update observability docs/gating examples
- add sqlite + memory runtime metrics and /metrics handler tests for the new families
- update backlog/changelog entries for issue planning and started work

## Scope
Implementation slices for #38 and preparation for #37.

## Validation
- go test ./...

## Follow-ups
- complete #38 with postgres-side metric mapping when #37 lands
- implement #37 (queue.backend postgres) on top of the unified metric vocabulary
