### PR TITLE
feat(metrics): backend-agnostic store metrics with postgres runtime coverage

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,6 +12,7 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 
 ## P1 - Medium Priority (v1.x)
 
+- [ ] **Store observability backend-agnostic metrics (#38)** — In progress: unify store runtime metric vocabulary with backend/operation labels (`hookaido_store_operation_seconds`, `hookaido_store_operation_total`, `hookaido_store_errors_total`) while keeping backend-specific compatibility series.
 - [x] **~~Mixed-workload tail latency playbook~~** — Reproducible mixed ingress+drain benchmark workflow with p95/p99 reporting added (`bench-pull-mixed*`; moved to Completed).
 - [x] **~~Drain fairness under saturation~~** — Reproducible push saturation/skewed benchmark guardrails now include reject-reason splits plus `p95_ms`/`p99_ms`; dispatcher saturation path tuned with route-shared workers, target-aware dequeue micro-batching, and single-target lease-mutation batching with multi-target fallback (moved to Completed).
 - [x] **~~Adaptive backpressure production tuning guide~~** — Data-driven threshold tuning guidance with enterprise starting profiles published (moved to Completed).

--- a/docs/adaptive-backpressure.md
+++ b/docs/adaptive-backpressure.md
@@ -87,6 +87,6 @@ Use production-like ingress load tests for threshold tuning decisions. The bench
 
 When dashboards span versions, gate adaptive panels/alerts with:
 
-- `hookaido_metrics_schema_info{schema="1.2.0"} == 1`
+- `hookaido_metrics_schema_info{schema="1.3.0"} == 1`
 
-This avoids interpreting missing pre-`1.2.0` series as zero.
+This avoids interpreting missing pre-`1.3.0` series as zero.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -153,7 +153,17 @@ Set `enabled off` to disable the metrics listener while keeping config in place.
 | `hookaido_pull_lease_active`          | gauge   | Active Pull leases currently tracked by `route`                              |
 | `hookaido_pull_lease_expired_total`   | counter | Lease expirations observed during Pull `ack`/`nack`/`extend` by `route`      |
 
-**Store/SQLite metrics:**
+**Store common metrics:**
+
+| Metric                                                  | Type      | Description                                                            |
+| ------------------------------------------------------- | --------- | ---------------------------------------------------------------------- |
+| `hookaido_store_operation_seconds{backend,operation}`   | histogram | Store operation duration by backend and operation                      |
+| `hookaido_store_operation_total{backend,operation}`     | counter   | Store operation totals by backend and operation                        |
+| `hookaido_store_errors_total{backend,operation,kind}`   | counter   | Store operation errors by backend, operation, and normalized kind      |
+
+The common families are emitted by all first-party queue backends (`sqlite`, `memory`, `postgres`).
+
+**Store/SQLite compatibility metrics (sqlite backend):**
 
 | Metric                                           | Type      | Description                                                                |
 | ------------------------------------------------ | --------- | -------------------------------------------------------------------------- |
@@ -329,9 +339,9 @@ Use these series together:
 
 ## Dashboard Compatibility Notes
 
-When dashboards span mixed Hookaido versions (for example `v1.1.x` and `v1.2.x`), treat missing metrics as "not emitted" rather than zero:
+When dashboards span mixed Hookaido versions (for example `v1.2.x` and `v1.3.x`), treat missing metrics as "not emitted" rather than zero:
 
-- Gate rules and panels by `hookaido_metrics_schema_info{schema="1.2.0"} == 1` (or `hookaido_build_info` version labels).
+- Gate rules and panels by `hookaido_metrics_schema_info{schema="1.3.0"} == 1` (or `hookaido_build_info` version labels).
 - In PromQL, prefer compatibility-safe expressions (for example `metric OR on() vector(0)`) where appropriate.
 - Document minimum supported Hookaido version per dashboard bundle to avoid false "all good" signals from absent series.
 

--- a/internal/queue/memory.go
+++ b/internal/queue/memory.go
@@ -1806,10 +1806,21 @@ func (s *MemoryStore) RuntimeMetrics() StoreRuntimeMetrics {
 		retainedBytesByState[st] = n
 	}
 	evictions := make(map[string]int64, len(s.evictionsTotalByReason))
+	evictionTotal := int64(0)
 	for reason, n := range s.evictionsTotalByReason {
 		evictions[reason] = n
+		evictionTotal += n
 	}
 	pressure := s.memoryPressureStatusLocked()
+	out.Common = StoreCommonRuntimeMetrics{
+		OperationTotal: []StoreOperationCounterRuntimeMetric{
+			{Operation: "enqueue_reject", Total: pressure.RejectTotal},
+			{Operation: "evict", Total: evictionTotal},
+		},
+		ErrorsTotal: []StoreOperationErrorRuntimeMetric{
+			{Operation: "enqueue", Kind: "memory_pressure", Total: pressure.RejectTotal},
+		},
+	}
 
 	out.Memory = &MemoryRuntimeMetrics{
 		ItemsByState:           itemsByState,

--- a/internal/queue/postgres_test.go
+++ b/internal/queue/postgres_test.go
@@ -3,6 +3,7 @@ package queue
 import (
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestNewPostgresStore_EmptyDSN(t *testing.T) {
@@ -12,5 +13,70 @@ func TestNewPostgresStore_EmptyDSN(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "empty postgres dsn") {
 		t.Fatalf("error = %v, want contains %q", err, "empty postgres dsn")
+	}
+}
+
+func TestPostgresStore_RuntimeMetrics_OperationAndErrorCounters(t *testing.T) {
+	store := &PostgresStore{metrics: newPostgresRuntimeMetrics()}
+
+	store.observeStoreOperation("enqueue", time.Now().Add(-10*time.Millisecond), nil)
+	store.observeStoreOperation("enqueue", time.Now().Add(-5*time.Millisecond), ErrQueueFull)
+	store.observeStoreOperation("dequeue", time.Now().Add(-3*time.Millisecond), ErrLeaseNotFound)
+
+	runtime := store.RuntimeMetrics()
+	if runtime.Backend != "postgres" {
+		t.Fatalf("backend = %q, want postgres", runtime.Backend)
+	}
+
+	durationByOperation := make(map[string]HistogramSnapshot)
+	for _, metric := range runtime.Common.OperationDurationSeconds {
+		durationByOperation[metric.Operation] = metric.DurationSeconds
+	}
+	if got := durationByOperation["enqueue"].Count; got != 2 {
+		t.Fatalf("enqueue duration count = %d, want 2", got)
+	}
+	if got := durationByOperation["dequeue"].Count; got != 1 {
+		t.Fatalf("dequeue duration count = %d, want 1", got)
+	}
+
+	totalByOperation := make(map[string]int64)
+	for _, metric := range runtime.Common.OperationTotal {
+		totalByOperation[metric.Operation] = metric.Total
+	}
+	if got := totalByOperation["enqueue"]; got != 2 {
+		t.Fatalf("enqueue total = %d, want 2", got)
+	}
+	if got := totalByOperation["dequeue"]; got != 1 {
+		t.Fatalf("dequeue total = %d, want 1", got)
+	}
+
+	errorsByOperationKind := make(map[string]int64)
+	for _, metric := range runtime.Common.ErrorsTotal {
+		key := metric.Operation + "|" + metric.Kind
+		errorsByOperationKind[key] = metric.Total
+	}
+	if got := errorsByOperationKind["enqueue|queue_full"]; got != 1 {
+		t.Fatalf("enqueue queue_full errors = %d, want 1", got)
+	}
+	if got := errorsByOperationKind["dequeue|lease_not_found"]; got != 1 {
+		t.Fatalf("dequeue lease_not_found errors = %d, want 1", got)
+	}
+}
+
+func TestPostgresStore_RuntimeMetrics_NilStore(t *testing.T) {
+	var store *PostgresStore
+
+	runtime := store.RuntimeMetrics()
+	if runtime.Backend != "postgres" {
+		t.Fatalf("backend = %q, want postgres", runtime.Backend)
+	}
+	if len(runtime.Common.OperationDurationSeconds) != 0 {
+		t.Fatalf("operation durations should be empty, got %d", len(runtime.Common.OperationDurationSeconds))
+	}
+	if len(runtime.Common.OperationTotal) != 0 {
+		t.Fatalf("operation totals should be empty, got %d", len(runtime.Common.OperationTotal))
+	}
+	if len(runtime.Common.ErrorsTotal) != 0 {
+		t.Fatalf("error totals should be empty, got %d", len(runtime.Common.ErrorsTotal))
 	}
 }

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -268,6 +268,28 @@ type HistogramSnapshot struct {
 	Sum     float64
 }
 
+type StoreOperationDurationRuntimeMetric struct {
+	Operation       string
+	DurationSeconds HistogramSnapshot
+}
+
+type StoreOperationCounterRuntimeMetric struct {
+	Operation string
+	Total     int64
+}
+
+type StoreOperationErrorRuntimeMetric struct {
+	Operation string
+	Kind      string
+	Total     int64
+}
+
+type StoreCommonRuntimeMetrics struct {
+	OperationDurationSeconds []StoreOperationDurationRuntimeMetric
+	OperationTotal           []StoreOperationCounterRuntimeMetric
+	ErrorsTotal              []StoreOperationErrorRuntimeMetric
+}
+
 type SQLiteRuntimeMetrics struct {
 	WriteDurationSeconds      HistogramSnapshot
 	DequeueDurationSeconds    HistogramSnapshot
@@ -300,6 +322,7 @@ type MemoryRuntimeMetrics struct {
 
 type StoreRuntimeMetrics struct {
 	Backend string
+	Common  StoreCommonRuntimeMetrics
 	SQLite  *SQLiteRuntimeMetrics
 	Memory  *MemoryRuntimeMetrics
 }


### PR DESCRIPTION
## Summary

This PR completes backend-agnostic store observability wiring for issue #38.

- Adds common store runtime metric model (`operation_seconds`, `operation_total`, `errors_total`) to queue runtime contracts.
- Exports common store metric families on `/metrics` with backend and operation labels.
- Keeps existing SQLite compatibility metric series (`hookaido_store_sqlite_*`).
- Extends memory backend runtime metrics into the common families.
- Adds PostgreSQL runtime instrumentation and exports common runtime metrics with normalized error kinds.
- Updates observability/docs/changelog/backlog entries and schema marker guidance to `1.3.0`.

## Related Issues

Closes #38

## Scope

- [ ] DSL / config behavior
- [x] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [x] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [x] Updated `BACKLOG.md` / `STATUS.md` when applicable

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

## Notes for Reviewers

- `hookaido_store_operation_*` and `hookaido_store_errors_total` are now the backend-neutral primary series.
- Existing SQLite dashboards remain compatible via `hookaido_store_sqlite_*` compatibility metrics.
- PostgreSQL series are operation-driven runtime counters/histograms from store code paths (no schema/database migration required).
