### PR TITLE
docs(backlog): add v1.5 adaptive validation scope (#53/#54)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,6 +12,8 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 
 ## P1 - Medium Priority (v1.x)
 
+- [ ] **Adaptive backpressure A/B validation gate (#53)** — Run reproducible saturation A/B (`adaptive_backpressure` off vs on) with identical load profiles, publish side-by-side metric deltas (`adaptive_backpressure`, `queue_full`, lag/age, p95/p99), and record pass/fail outcome for v1.5.
+- [ ] **Queue-full reliance follow-up decision (#54)** — Based on #53 evidence, decide whether to keep current default behavior (`adaptive_backpressure` opt-in) with stronger guidance or ship tuned admission-control defaults/recommendations in v1.5.
 - [x] **~~Mixed-workload tail latency playbook~~** — Reproducible mixed ingress+drain benchmark workflow with p95/p99 reporting added (`bench-pull-mixed*`; moved to Completed).
 - [x] **~~Drain fairness under saturation~~** — Reproducible push saturation/skewed benchmark guardrails now include reject-reason splits plus `p95_ms`/`p99_ms`; dispatcher saturation path tuned with route-shared workers, target-aware dequeue micro-batching, and single-target lease-mutation batching with multi-target fallback (moved to Completed).
 - [x] **~~Adaptive backpressure production tuning guide~~** — Data-driven threshold tuning guidance with enterprise starting profiles published (moved to Completed).


### PR DESCRIPTION
## Summary

- add explicit open P1 backlog items for:
  - `#53` adaptive backpressure A/B validation gate for v1.5
  - `#54` queue_full reliance follow-up decision after #53 evidence
- keep planning language aligned with current issue state (`#53` = validation, `#54` = enhancement/default-behavior decision)

## Related Issues

Refs #53
Refs #54

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [x] Documentation only
- [ ] CI / release pipeline

## Validation

- [ ] `go test ./...` passed locally
- [ ] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes
- [ ] Updated `CHANGELOG.md` for user-visible behavior changes
- [x] Updated `BACKLOG.md` / `STATUS.md` when applicable

## Security and Operations

- [x] No secrets or credentials committed
- [x] Backward compatibility considered

## Notes for Reviewers

GitHub issues were updated directly in parallel:
- `#53` now includes concrete v1.5 checklist + acceptance criteria.
- `#54` has a planning note to treat it as a decision follow-up to `#53`.
