### PR TITLE
perf: add mixed pull ACK conflict guardrail workflow

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -12,7 +12,6 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 
 ## P1 - Medium Priority (v1.x)
 
-- [ ] **Mixed Pull ACK conflict guardrail (#55)** — Keep mixed-workload guardrail on `pull_ack_conflict_total / pull_acked_total` (with per-route drill-down) and use it as acceptance criteria for contention/fairness tuning/regression detection.
 - [x] **~~Mixed-workload tail latency playbook~~** — Reproducible mixed ingress+drain benchmark workflow with p95/p99 reporting added (`bench-pull-mixed*`; moved to Completed).
 - [x] **~~Drain fairness under saturation~~** — Reproducible push saturation/skewed benchmark guardrails now include reject-reason splits plus `p95_ms`/`p99_ms`; dispatcher saturation path tuned with route-shared workers, target-aware dequeue micro-batching, and single-target lease-mutation batching with multi-target fallback (moved to Completed).
 - [x] **~~Adaptive backpressure production tuning guide~~** — Data-driven threshold tuning guidance with enterprise starting profiles published (moved to Completed).
@@ -40,6 +39,7 @@ Prioritized work items for Hookaido v1.x. Items are grouped by priority tier and
 
 ## Completed (move here when done)
 
+- [x] **Mixed Pull ACK conflict guardrail (#55)** — Added reproducible guardrail validation via `scripts/adaptive-guardrail.sh` + Make targets (`adaptive-ab-guardrail-check`, `adaptive-ab-mixed-guardrail`) with acceptance thresholds on `pull_ack_conflict_ratio_percent` and per-route drill-down tables from `final-metrics.txt` for mixed A/B regression checks.
 - [x] **Adaptive backpressure mixed decision slice (#53/#54)** — Reproducible mixed `adaptive off` vs `on` saturation runs completed (including calibrated high-pressure profile), artifacts captured, and v1.5 decision recorded: keep runtime default `enabled off`; recommended opt-in enterprise start profile `min_total 400`, `queued_percent 88`, `ready_lag 45s`, `oldest_queued_age 90s`, `sustained_growth on`; hardware results treated as relative same-host evidence, not universal default proof.
 - [x] **Store observability backend-agnostic metrics (#38)** — Unified store runtime metric vocabulary with backend/operation labels (`hookaido_store_operation_seconds`, `hookaido_store_operation_total`, `hookaido_store_errors_total`) across `sqlite`, `memory`, and `postgres`, while retaining SQLite compatibility series.
 - [x] **Optional gRPC worker API (Phase 2)** — Added worker transport contract and handlers, shared Pull operation core, opt-in runtime listener/config wiring via `pull_api.grpc_listen` with listener guardrails, auth parity (global + route override), integration/E2E parity coverage, and docs for operations. Scope is fixed to pull-worker lease transport (`dequeue`/`ack`/`nack`/`extend`) with explicit MCP non-goal for worker lease ops.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Adaptive backpressure production tuning guide (`docs/adaptive-backpressure.md`) with data-driven starting profiles (`balanced`, `latency_first`, `throughput_first`), metric-driven decision matrix, and rollout guardrails for enterprise workloads.
 - Reproducible adaptive backpressure A/B runtime harness (`scripts/adaptive-ab.sh`) plus Make targets (`adaptive-ab`, `adaptive-ab-all`, `adaptive-ab-pull`, `adaptive-ab-mixed`) to capture `final-metrics.txt`/`final-health.json`/`monitor-output.log` artifacts, generate side-by-side comparison tables for `adaptive off` vs `on`, and report Pull contention metrics (`hookaido_pull_acked_total`, `hookaido_pull_ack_conflict_total`, `hookaido_pull_nack_conflict_total`, `pull_ack_conflict_ratio_percent`).
 - Calibrated mixed saturation target (`make adaptive-ab-mixed-saturation`) for issue validation (`#53/#54/#55`) with fixed high-pressure profile (`duration=30s`, `ingress_workers=256`, `mixed_drain_workers=8`, `dequeue_batch=5`, `queue_max_depth=2000`).
+- Mixed Pull ACK conflict guardrail workflow for issue `#55`: `scripts/adaptive-guardrail.sh` and Make targets (`adaptive-ab-guardrail-check`, `adaptive-ab-mixed-guardrail`) validate aggregate `pull_ack_conflict_ratio_percent` thresholds and emit per-route drill-down tables from final metrics.
 - Metrics schema marker `hookaido_metrics_schema_info{schema="1.3.0"}` for dashboard compatibility gating across mixed Hookaido versions.
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ PUSH_SKEWED_BASELINE := $(BENCH_DIR)/push-skewed-baseline.txt
 PUSH_SKEWED_COMPARE := $(BENCH_DIR)/push-skewed-compare.txt
 BENCHSTAT_CMD := golang.org/x/perf/cmd/benchstat@v0.0.0-20260211190930-8161c38c6cdc
 ADAPTIVE_AB_SCRIPT := scripts/adaptive-ab.sh
+ADAPTIVE_GUARDRAIL_SCRIPT := scripts/adaptive-guardrail.sh
 ADAPTIVE_AB_ROOT := .artifacts/adaptive-ab
 ADAPTIVE_AB_BACKEND ?= sqlite
 ADAPTIVE_AB_DURATION ?= 120
@@ -43,8 +44,12 @@ ADAPTIVE_AB_MIXED_SAT_INGRESS_WORKERS ?= 256
 ADAPTIVE_AB_MIXED_SAT_DRAIN_WORKERS ?= 8
 ADAPTIVE_AB_MIXED_SAT_DEQUEUE_BATCH ?= 5
 ADAPTIVE_AB_MIXED_SAT_QUEUE_MAX_DEPTH ?= 2000
+ADAPTIVE_ACK_CONFLICT_MAX_RATIO ?= 5.0
+ADAPTIVE_ACK_CONFLICT_MIN_ACKED ?= 100
+ADAPTIVE_ROUTE_ACK_CONFLICT_MAX_RATIO ?= 5.0
+ADAPTIVE_ROUTE_ACK_CONFLICT_MIN_ACKED ?= 50
 
-.PHONY: build test fmt lint check proto-worker bench-pull bench-pull-baseline bench-pull-compare bench-pull-extend bench-pull-extend-compare bench-pull-drain bench-pull-drain-baseline bench-pull-drain-compare bench-pull-contention bench-pull-contention-baseline bench-pull-contention-compare bench-pull-mixed bench-pull-mixed-baseline bench-pull-mixed-compare bench-push-mixed bench-push-mixed-baseline bench-push-mixed-compare bench-push-skewed bench-push-skewed-baseline bench-push-skewed-compare adaptive-ab adaptive-ab-all adaptive-ab-pull adaptive-ab-mixed adaptive-ab-mixed-saturation release-check dist dist-signed dist-verify
+.PHONY: build test fmt lint check proto-worker bench-pull bench-pull-baseline bench-pull-compare bench-pull-extend bench-pull-extend-compare bench-pull-drain bench-pull-drain-baseline bench-pull-drain-compare bench-pull-contention bench-pull-contention-baseline bench-pull-contention-compare bench-pull-mixed bench-pull-mixed-baseline bench-pull-mixed-compare bench-push-mixed bench-push-mixed-baseline bench-push-mixed-compare bench-push-skewed bench-push-skewed-baseline bench-push-skewed-compare adaptive-ab adaptive-ab-all adaptive-ab-pull adaptive-ab-mixed adaptive-ab-mixed-saturation adaptive-ab-guardrail-check adaptive-ab-mixed-guardrail release-check dist dist-signed dist-verify
 
 build:
 	@mkdir -p "$(BINDIR)"
@@ -216,6 +221,36 @@ adaptive-ab-mixed-saturation:
 		--mixed-drain-workers "$(ADAPTIVE_AB_MIXED_SAT_DRAIN_WORKERS)" \
 		--dequeue-batch "$(ADAPTIVE_AB_MIXED_SAT_DEQUEUE_BATCH)" \
 		--queue-max-depth "$(ADAPTIVE_AB_MIXED_SAT_QUEUE_MAX_DEPTH)"
+
+adaptive-ab-guardrail-check:
+	@test -n "$(RUN_ROOT)" || (echo "RUN_ROOT is required, e.g. make adaptive-ab-guardrail-check RUN_ROOT=.artifacts/adaptive-ab/<run-id>" && exit 1)
+	"$(ADAPTIVE_GUARDRAIL_SCRIPT)" \
+		--run-root "$(RUN_ROOT)" \
+		--scenario mixed \
+		--max-ack-conflict-ratio "$(ADAPTIVE_ACK_CONFLICT_MAX_RATIO)" \
+		--min-acked-total "$(ADAPTIVE_ACK_CONFLICT_MIN_ACKED)" \
+		--max-route-ack-conflict-ratio "$(ADAPTIVE_ROUTE_ACK_CONFLICT_MAX_RATIO)" \
+		--min-route-acked-total "$(ADAPTIVE_ROUTE_ACK_CONFLICT_MIN_ACKED)"
+
+adaptive-ab-mixed-guardrail:
+	@RUN_ID="$$(date -u +%Y%m%d-%H%M%S)"; \
+	"$(ADAPTIVE_AB_SCRIPT)" \
+		--scenario mixed \
+		--output-root "$(ADAPTIVE_AB_ROOT)" \
+		--backend "$(ADAPTIVE_AB_BACKEND)" \
+		--duration-seconds "$(ADAPTIVE_AB_MIXED_SAT_DURATION)" \
+		--ingress-workers "$(ADAPTIVE_AB_MIXED_SAT_INGRESS_WORKERS)" \
+		--mixed-drain-workers "$(ADAPTIVE_AB_MIXED_SAT_DRAIN_WORKERS)" \
+		--dequeue-batch "$(ADAPTIVE_AB_MIXED_SAT_DEQUEUE_BATCH)" \
+		--queue-max-depth "$(ADAPTIVE_AB_MIXED_SAT_QUEUE_MAX_DEPTH)" \
+		--run-id "$$RUN_ID"; \
+	"$(ADAPTIVE_GUARDRAIL_SCRIPT)" \
+		--run-root "$(ADAPTIVE_AB_ROOT)/$$RUN_ID" \
+		--scenario mixed \
+		--max-ack-conflict-ratio "$(ADAPTIVE_ACK_CONFLICT_MAX_RATIO)" \
+		--min-acked-total "$(ADAPTIVE_ACK_CONFLICT_MIN_ACKED)" \
+		--max-route-ack-conflict-ratio "$(ADAPTIVE_ROUTE_ACK_CONFLICT_MAX_RATIO)" \
+		--min-route-acked-total "$(ADAPTIVE_ROUTE_ACK_CONFLICT_MIN_ACKED)"
 
 release-check: check build
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -202,6 +202,18 @@ make adaptive-ab-all
 make adaptive-ab-mixed-saturation
 ```
 
+Guardrail checks on an existing mixed run:
+
+```bash
+make adaptive-ab-guardrail-check RUN_ROOT=.artifacts/adaptive-ab/<run-id>
+```
+
+One-shot calibrated run + guardrail check:
+
+```bash
+make adaptive-ab-mixed-guardrail
+```
+
 `make adaptive-ab-all` executes:
 
 - `pull-off`, `pull-on` (reference profile)
@@ -236,6 +248,7 @@ Comparison tables are generated as:
 - `./.artifacts/adaptive-ab/<run-id>/comparison-pull.md`
 - `./.artifacts/adaptive-ab/<run-id>/comparison-mixed.md`
 - `./.artifacts/adaptive-ab/<run-id>/comparison.md`
+- `./.artifacts/adaptive-ab/<run-id>/guardrail-mixed.md` (when guardrail target/script is used)
 
 The comparison table includes:
 
@@ -250,6 +263,12 @@ The comparison table includes:
 - `hookaido_pull_ack_conflict_total` (sum across routes)
 - `hookaido_pull_nack_conflict_total` (sum across routes)
 - `pull_ack_conflict_ratio_percent` (`ack_conflict / acked * 100`)
+
+Guardrail defaults for `#55`:
+
+- aggregate `pull_ack_conflict_ratio_percent <= 5.0`
+- minimum aggregate `pull_acked_total >= 100` per mode (`mixed-off`, `mixed-on`)
+- per-route `pull_ack_conflict_ratio_percent <= 5.0` when route `pull_acked_total >= 50`
 
 ## Reproducibility Defaults
 
@@ -277,6 +296,7 @@ This reduces host variance and gives stable median trends across runs.
 - For push skewed-target runs, track `p95_ms`/`p99_ms`, `deliveries_slow`, and `ingress_rejects_queue_full`; improving slow-target drain without growing queue-full rejects or tail latency indicates better cross-target fairness.
 - For adaptive A/B runs, first confirm `adaptive_applied_total=0` in `off`, then compare `queue_full` delta and latency/rate trade-offs in `on`.
 - For mixed A/B (`#55`), track `pull_ack_conflict_ratio_percent` alongside ingress metrics; large conflict-ratio regressions can hide behind stable ingress acceptance.
+- For `#55` regression acceptance, use `guardrail-mixed.md` as the pass/fail artifact and inspect the per-route drill-down section to localize conflict spikes.
 - Keep policy decisions tied to workload SLOs: same-host gains do not imply cross-environment default changes.
 
 ## Notes

--- a/scripts/adaptive-guardrail.sh
+++ b/scripts/adaptive-guardrail.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ROOT=""
+SCENARIO="mixed"
+MAX_ACK_CONFLICT_RATIO_PERCENT="5.0"
+MIN_ACKED_TOTAL="100"
+MAX_ROUTE_ACK_CONFLICT_RATIO_PERCENT="5.0"
+MIN_ROUTE_ACKED_TOTAL="50"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  scripts/adaptive-guardrail.sh --run-root <path> [options]
+
+Validates mixed/pull A/B guardrail metrics produced by scripts/adaptive-ab.sh.
+
+Required:
+  --run-root <path>                     Path like ./.artifacts/adaptive-ab/<run-id>
+
+Options:
+  --scenario <mixed|pull>               Scenario to evaluate (default: mixed)
+  --max-ack-conflict-ratio <percent>    Maximum allowed pull_ack_conflict_ratio_percent (default: 5.0)
+  --min-acked-total <n>                 Minimum pull_acked_total required per mode (default: 100)
+  --max-route-ack-conflict-ratio <pct>  Maximum allowed per-route pull_ack_conflict_ratio_percent (default: 5.0)
+  --min-route-acked-total <n>           Minimum pull_acked_total required per route for threshold checks (default: 50)
+  --help                                Show this help
+
+Exit codes:
+  0  Guardrail passed for both off/on modes
+  1  Guardrail failed
+  2  Invalid arguments or missing artifacts
+EOF
+}
+
+fail() {
+	printf 'guardrail fail: %s\n' "$*" >&2
+	exit 1
+}
+
+arg_error() {
+	printf 'guardrail error: %s\n' "$*" >&2
+	exit 2
+}
+
+parse_args() {
+	while [ "$#" -gt 0 ]; do
+		case "$1" in
+		--run-root)
+			shift
+			RUN_ROOT="${1:-}"
+			;;
+		--scenario)
+			shift
+			SCENARIO="${1:-}"
+			;;
+		--max-ack-conflict-ratio)
+			shift
+			MAX_ACK_CONFLICT_RATIO_PERCENT="${1:-}"
+			;;
+		--min-acked-total)
+			shift
+			MIN_ACKED_TOTAL="${1:-}"
+			;;
+		--max-route-ack-conflict-ratio)
+			shift
+			MAX_ROUTE_ACK_CONFLICT_RATIO_PERCENT="${1:-}"
+			;;
+		--min-route-acked-total)
+			shift
+			MIN_ROUTE_ACKED_TOTAL="${1:-}"
+			;;
+		--help|-h)
+			usage
+			exit 0
+			;;
+		*)
+			arg_error "unknown argument: $1"
+			;;
+		esac
+		shift || true
+	done
+}
+
+validate_args() {
+	[ -n "${RUN_ROOT}" ] || arg_error "--run-root is required"
+	[ -d "${RUN_ROOT}" ] || arg_error "run root does not exist: ${RUN_ROOT}"
+	case "${SCENARIO}" in
+	mixed|pull) ;;
+	*) arg_error "--scenario must be mixed|pull (got: ${SCENARIO})" ;;
+	esac
+	[[ "${MAX_ACK_CONFLICT_RATIO_PERCENT}" =~ ^[0-9]+([.][0-9]+)?$ ]] || arg_error "--max-ack-conflict-ratio must be numeric"
+	[[ "${MIN_ACKED_TOTAL}" =~ ^[0-9]+$ ]] || arg_error "--min-acked-total must be an integer"
+	[[ "${MAX_ROUTE_ACK_CONFLICT_RATIO_PERCENT}" =~ ^[0-9]+([.][0-9]+)?$ ]] || arg_error "--max-route-ack-conflict-ratio must be numeric"
+	[[ "${MIN_ROUTE_ACKED_TOTAL}" =~ ^[0-9]+$ ]] || arg_error "--min-route-acked-total must be an integer"
+}
+
+summary_get() {
+	local summary_file="$1"
+	local key="$2"
+	sed -n "s/^${key}=//p" "${summary_file}" | head -n1
+}
+
+extract_route_rows() {
+	local metrics_file="$1"
+	local rows_file="$2"
+	awk '
+		function route_from_sample(sample, out) {
+			if (match(sample, /route="[^"]+"/) == 0) {
+				return ""
+			}
+			out = substr(sample, RSTART + 7, RLENGTH - 8)
+			return out
+		}
+		$1 ~ /^hookaido_pull_acked_total\{/ {
+			route = route_from_sample($1)
+			if (route != "") {
+				acked[route] = $2 + 0
+				routes[route] = 1
+			}
+		}
+		$1 ~ /^hookaido_pull_ack_conflict_total\{/ {
+			route = route_from_sample($1)
+			if (route != "") {
+				conflicts[route] = $2 + 0
+				routes[route] = 1
+			}
+		}
+		END {
+			for (route in routes) {
+				acked_total = acked[route] + 0
+				conflict_total = conflicts[route] + 0
+				ratio = 0
+				if (acked_total > 0) {
+					ratio = (conflict_total * 100.0) / acked_total
+				}
+				printf "%s\t%.0f\t%.0f\t%.3f\n", route, acked_total, conflict_total, ratio
+			}
+		}
+	' "${metrics_file}" | sort >"${rows_file}"
+}
+
+validate_route_rows() {
+	local mode="$1"
+	local rows_file="$2"
+	local route
+	local acked
+	local conflicts
+	local ratio
+	local ratio_ok
+
+	while IFS=$'\t' read -r route acked conflicts ratio; do
+		[ -n "${route}" ] || continue
+		[[ "${acked}" =~ ^[0-9]+$ ]] || arg_error "invalid per-route pull_acked_total for ${SCENARIO}-${mode} route ${route}: ${acked}"
+		[[ "${conflicts}" =~ ^[0-9]+$ ]] || arg_error "invalid per-route pull_ack_conflict_total for ${SCENARIO}-${mode} route ${route}: ${conflicts}"
+		[[ "${ratio}" =~ ^[0-9]+([.][0-9]+)?$ ]] || arg_error "invalid per-route ratio for ${SCENARIO}-${mode} route ${route}: ${ratio}"
+		if [ "${acked}" -lt "${MIN_ROUTE_ACKED_TOTAL}" ]; then
+			continue
+		fi
+		ratio_ok="$(
+			awk -v ratio="${ratio}" -v max="${MAX_ROUTE_ACK_CONFLICT_RATIO_PERCENT}" 'BEGIN { if ((ratio+0) <= (max+0)) print "yes"; else print "no" }'
+		)"
+		if [ "${ratio_ok}" != "yes" ]; then
+			fail "${SCENARIO}-${mode}: route ${route} pull_ack_conflict_ratio_percent ${ratio} exceeds per-route threshold ${MAX_ROUTE_ACK_CONFLICT_RATIO_PERCENT}"
+		fi
+	done <"${rows_file}"
+}
+
+render_route_rows_markdown() {
+	local rows_file="$1"
+	local route
+	local acked
+	local conflicts
+	local ratio
+
+	if [ ! -s "${rows_file}" ]; then
+		printf '| (none) | 0 | 0 | 0.000 |\n'
+		return
+	fi
+
+	while IFS=$'\t' read -r route acked conflicts ratio; do
+		[ -n "${route}" ] || continue
+		printf '| `%s` | %s | %s | %s |\n' "${route}" "${acked}" "${conflicts}" "${ratio}"
+	done <"${rows_file}"
+}
+
+validate_mode() {
+	local mode="$1"
+	local route_rows_file="$2"
+	local summary_file="${RUN_ROOT}/${SCENARIO}-${mode}/summary.env"
+	local metrics_file="${RUN_ROOT}/${SCENARIO}-${mode}/final-metrics.txt"
+	local acked
+	local conflicts
+	local ratio
+	local ratio_ok
+
+	[ -f "${summary_file}" ] || arg_error "missing summary file: ${summary_file}"
+	[ -f "${metrics_file}" ] || arg_error "missing metrics file: ${metrics_file}"
+
+	acked="$(summary_get "${summary_file}" "pull_acked_total")"
+	conflicts="$(summary_get "${summary_file}" "pull_ack_conflict_total")"
+	ratio="$(summary_get "${summary_file}" "pull_ack_conflict_ratio_percent")"
+
+	[[ "${acked}" =~ ^[0-9]+$ ]] || arg_error "invalid pull_acked_total in ${summary_file}: ${acked}"
+	[[ "${conflicts}" =~ ^[0-9]+$ ]] || arg_error "invalid pull_ack_conflict_total in ${summary_file}: ${conflicts}"
+	[[ "${ratio}" =~ ^[0-9]+([.][0-9]+)?$ ]] || arg_error "invalid pull_ack_conflict_ratio_percent in ${summary_file}: ${ratio}"
+
+	if [ "${acked}" -lt "${MIN_ACKED_TOTAL}" ]; then
+		fail "${SCENARIO}-${mode}: insufficient pull_acked_total (${acked} < ${MIN_ACKED_TOTAL})"
+	fi
+
+	ratio_ok="$(
+		awk -v ratio="${ratio}" -v max="${MAX_ACK_CONFLICT_RATIO_PERCENT}" 'BEGIN { if ((ratio+0) <= (max+0)) print "yes"; else print "no" }'
+	)"
+	if [ "${ratio_ok}" != "yes" ]; then
+		fail "${SCENARIO}-${mode}: pull_ack_conflict_ratio_percent ${ratio} exceeds threshold ${MAX_ACK_CONFLICT_RATIO_PERCENT}"
+	fi
+
+	extract_route_rows "${metrics_file}" "${route_rows_file}"
+	validate_route_rows "${mode}" "${route_rows_file}"
+
+	printf '%s\t%s\t%s\t%s\n' "${SCENARIO}-${mode}" "${acked}" "${conflicts}" "${ratio}"
+}
+
+main() {
+	parse_args "$@"
+	validate_args
+
+	local report_file="${RUN_ROOT}/guardrail-${SCENARIO}.md"
+	local route_rows_off_file
+	local route_rows_on_file
+	local route_rows_off
+	local route_rows_on
+	local row_off
+	local row_on
+
+	route_rows_off_file="$(mktemp)"
+	route_rows_on_file="$(mktemp)"
+	trap 'rm -f "${route_rows_off_file:-}" "${route_rows_on_file:-}"' EXIT
+
+	row_off="$(validate_mode "off" "${route_rows_off_file}")"
+	row_on="$(validate_mode "on" "${route_rows_on_file}")"
+	route_rows_off="$(render_route_rows_markdown "${route_rows_off_file}")"
+	route_rows_on="$(render_route_rows_markdown "${route_rows_on_file}")"
+
+	cat >"${report_file}" <<EOF
+# Pull ACK Conflict Guardrail (${SCENARIO})
+
+- run root: \`${RUN_ROOT}\`
+- max ratio threshold: \`${MAX_ACK_CONFLICT_RATIO_PERCENT}%\`
+- minimum acked per mode: \`${MIN_ACKED_TOTAL}\`
+- max per-route ratio threshold: \`${MAX_ROUTE_ACK_CONFLICT_RATIO_PERCENT}%\`
+- minimum acked per route for threshold checks: \`${MIN_ROUTE_ACKED_TOTAL}\`
+
+| Mode | pull_acked_total | pull_ack_conflict_total | pull_ack_conflict_ratio_percent |
+| --- | ---: | ---: | ---: |
+| $(printf '%s' "${row_off}" | awk -F '\t' '{print $1}') | $(printf '%s' "${row_off}" | awk -F '\t' '{print $2}') | $(printf '%s' "${row_off}" | awk -F '\t' '{print $3}') | $(printf '%s' "${row_off}" | awk -F '\t' '{print $4}') |
+| $(printf '%s' "${row_on}" | awk -F '\t' '{print $1}') | $(printf '%s' "${row_on}" | awk -F '\t' '{print $2}') | $(printf '%s' "${row_on}" | awk -F '\t' '{print $3}') | $(printf '%s' "${row_on}" | awk -F '\t' '{print $4}') |
+
+## Route Drill-down (${SCENARIO}-off)
+
+| Route | pull_acked_total | pull_ack_conflict_total | pull_ack_conflict_ratio_percent |
+| --- | ---: | ---: | ---: |
+${route_rows_off}
+
+## Route Drill-down (${SCENARIO}-on)
+
+| Route | pull_acked_total | pull_ack_conflict_total | pull_ack_conflict_ratio_percent |
+| --- | ---: | ---: | ---: |
+${route_rows_on}
+EOF
+
+	printf 'guardrail pass: %s (report: %s)\n' "${SCENARIO}" "${report_file}"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add `scripts/adaptive-guardrail.sh` to validate mixed/pull adaptive A/B artifacts (`off` vs `on`) from `scripts/adaptive-ab.sh`
- enforce aggregate acceptance checks on `pull_ack_conflict_ratio_percent` with minimum `pull_acked_total`
- add per-route drill-down extraction from `final-metrics.txt` and optional per-route threshold checks
- wire Make targets:
  - `adaptive-ab-guardrail-check`
  - `adaptive-ab-mixed-guardrail`
- update docs/changelog/backlog for #55 closure criteria

## Validation
- `bash -n scripts/adaptive-guardrail.sh`
- `scripts/adaptive-guardrail.sh --run-root .artifacts/adaptive-ab/20260214-232844 --scenario mixed --max-ack-conflict-ratio 5.0 --min-acked-total 100 --max-route-ack-conflict-ratio 5.0 --min-route-acked-total 50`
- `make adaptive-ab-guardrail-check RUN_ROOT=.artifacts/adaptive-ab/20260214-232844`

Closes #55.
