### PR TITLE
perf: batch single-target push lease mutations up to dequeue size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Push route workers now lease small dequeue micro-batches (single-target routes: bounded by route concurrency, capped at 4; multi-target routes: capped at 2) to balance throughput and fairness under saturation.
 - Push dispatcher now applies batched lease mutations (`ack`/`nack`/`mark dead`) on single-target routes when the backend supports `LeaseBatchStore`, with automatic fallback to per-lease mutations and multi-target safety guardrails to avoid skewed-route regressions.
 - Push single-target lease mutations now batch up to the route dequeue micro-batch size (capped at 4) instead of a fixed size of 2, reducing store roundtrips on saturated single-target routes.
+- Push dispatcher lease TTL now scales with route dequeue micro-batch size, reducing avoidable lease-expiry conflicts/requeues when single route workers process slow target batches sequentially.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Push dispatcher runtime now uses route-shared dequeue workers across all push routes (single- and multi-target), enforcing `deliver_concurrency` as a shared route budget and allowing idle-target capacity to drain active-target backlog under saturation.
 - Push route workers now lease small dequeue micro-batches (single-target routes: bounded by route concurrency, capped at 4; multi-target routes: capped at 2) to balance throughput and fairness under saturation.
 - Push dispatcher now applies batched lease mutations (`ack`/`nack`/`mark dead`) on single-target routes when the backend supports `LeaseBatchStore`, with automatic fallback to per-lease mutations and multi-target safety guardrails to avoid skewed-route regressions.
+- Push single-target lease mutations now batch up to the route dequeue micro-batch size (capped at 4) instead of a fixed size of 2, reducing store roundtrips on saturated single-target routes.
 
 ### Fixed
 

--- a/internal/dispatcher/push.go
+++ b/internal/dispatcher/push.go
@@ -156,7 +156,12 @@ func routeMutationBatch(dequeueBatch int) int {
 	if dequeueBatch <= 1 {
 		return 1
 	}
-	return 2
+	// Single-target routes can safely apply lease mutations in the same batch
+	// size as dequeue (bounded by routeDequeueBatch) to cut store roundtrips.
+	if dequeueBatch > 4 {
+		return 4
+	}
+	return dequeueBatch
 }
 
 type leaseActionKind int

--- a/internal/dispatcher/push.go
+++ b/internal/dispatcher/push.go
@@ -98,9 +98,9 @@ func (d *PushDispatcher) Start() {
 		if concurrency <= 0 {
 			concurrency = 1
 		}
-		routeLeaseTTL := routeLeaseTTL(rt.Targets, leaseSlack)
-		targetsByURL := targetConfigByURL(rt.Targets)
 		dequeueBatch := routeDequeueBatch(concurrency, len(rt.Targets))
+		routeLeaseTTL := routeLeaseTTL(rt.Targets, leaseSlack, dequeueBatch)
+		targetsByURL := targetConfigByURL(rt.Targets)
 		for w := 0; w < concurrency; w++ {
 			d.wg.Add(1)
 			go d.runRoute(logger, rt.Route, targetsByURL, maxWait, routeLeaseTTL, dequeueBatch)
@@ -116,7 +116,11 @@ func targetConfigByURL(targets []TargetConfig) map[string]TargetConfig {
 	return byURL
 }
 
-func routeLeaseTTL(targets []TargetConfig, leaseSlack time.Duration) time.Duration {
+func routeLeaseTTL(targets []TargetConfig, leaseSlack time.Duration, dequeueBatch int) time.Duration {
+	if dequeueBatch <= 0 {
+		dequeueBatch = 1
+	}
+
 	maxTimeout := time.Duration(0)
 	for _, target := range targets {
 		timeout := target.Timeout
@@ -127,7 +131,9 @@ func routeLeaseTTL(targets []TargetConfig, leaseSlack time.Duration) time.Durati
 			maxTimeout = timeout
 		}
 	}
-	ttl := maxTimeout + leaseSlack
+	// Scale TTL by dequeue batch so the first leased item in a sequential
+	// micro-batch has enough time budget before lease expiry.
+	ttl := (maxTimeout * time.Duration(dequeueBatch)) + leaseSlack
 	if ttl < 30*time.Second {
 		ttl = 30 * time.Second
 	}

--- a/internal/dispatcher/push_test.go
+++ b/internal/dispatcher/push_test.go
@@ -995,8 +995,9 @@ func TestRouteMutationBatch(t *testing.T) {
 	}{
 		{name: "single", dequeueBatch: 1, want: 1},
 		{name: "two", dequeueBatch: 2, want: 2},
-		{name: "three maps to two", dequeueBatch: 3, want: 2},
-		{name: "four maps to two", dequeueBatch: 4, want: 2},
+		{name: "three", dequeueBatch: 3, want: 3},
+		{name: "four", dequeueBatch: 4, want: 4},
+		{name: "cap at four", dequeueBatch: 8, want: 4},
 	}
 
 	for _, tc := range cases {

--- a/internal/dispatcher/push_test.go
+++ b/internal/dispatcher/push_test.go
@@ -984,12 +984,18 @@ func TestRouteLeaseTTL(t *testing.T) {
 		{URL: "https://fast", Timeout: 2 * time.Second},
 		{URL: "https://slow", Timeout: 9 * time.Second},
 	}
-	if got := routeLeaseTTL(targets, 30*time.Second); got != 39*time.Second {
+	if got := routeLeaseTTL(targets, 30*time.Second, 1); got != 39*time.Second {
 		t.Fatalf("routeLeaseTTL=%s, want 39s", got)
 	}
+	if got := routeLeaseTTL(targets, 30*time.Second, 4); got != 66*time.Second {
+		t.Fatalf("routeLeaseTTL batched=%s, want 66s", got)
+	}
 
-	if got := routeLeaseTTL([]TargetConfig{{URL: "https://default"}}, 5*time.Second); got != 30*time.Second {
+	if got := routeLeaseTTL([]TargetConfig{{URL: "https://default"}}, 5*time.Second, 1); got != 30*time.Second {
 		t.Fatalf("routeLeaseTTL default=%s, want 30s floor", got)
+	}
+	if got := routeLeaseTTL([]TargetConfig{{URL: "https://default"}}, 5*time.Second, 3); got != 35*time.Second {
+		t.Fatalf("routeLeaseTTL default batched=%s, want 35s", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- increase `routeMutationBatch` for single-target push routes from fixed `2` to `min(route dequeue batch, 4)`
- keep `batch=1` behavior unchanged and preserve the existing upper cap at 4
- scale route lease TTL by dequeue micro-batch size to reduce lease-expiry conflicts/requeues while workers process slow sequential batches
- update `TestRouteMutationBatch` and `TestRouteLeaseTTL` coverage for the new batching + TTL behavior
- document the runtime tuning under `Unreleased` in `CHANGELOG.md`

## Validation
- go test ./internal/dispatcher
- go test ./...

Closes #56
