### PR TITLE
docs: clarify branch protection and release tag policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,6 +69,7 @@ Project: Hookaido (Webhook ingress queue, Caddy-style).
 ## Git & Release Workflow
 
 - `main` is protected: no direct pushes, no local-only merges to `main`; use PRs.
+- Keep `main` protection hardening enabled: no branch deletion and no force-push.
 - SemVer tags are strict `vX.Y.Z` only. Never create `vX.Y` tags.
 - Create release tags only from the merged/up-to-date `origin/main` state.
 - Container/release publishing is tag-driven; treat tagging as a production action.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,10 @@ go test ./...
    - following [the PR template](.github/PULL_REQUEST_TEMPLATE.md).
 
 PRs must pass CI and branch protection checks before merge.
+
+## Branch + Tag Policy
+
+- `main` is protected: no direct pushes and no direct local merges.
+- `main` protection must keep force-push and deletion disabled.
+- Release tags are strict SemVer `vX.Y.Z` only (no `vX.Y`).
+- For releases, push only the explicit tag (for example `git push origin v1.5.0`), not `--tags`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -163,7 +163,8 @@ Container publish workflow is defined in `.github/workflows/container.yml`.
 - Trigger: `push` tag matching `v*.*.*` (and manual `workflow_dispatch`) with strict guardrail `^v[0-9]+\.[0-9]+\.[0-9]+$`
 - Registry: GHCR (`ghcr.io/nuetzliches/hookaido`)
 - Platforms: `linux/amd64`, `linux/arm64`
-- Tags: semver tags (`X.Y.Z`, `X.Y`, `X`), `latest`, and short `sha-*`
+- Image tags (derived from one pushed release tag): semver (`X.Y.Z`, `X.Y`, `X`), `latest`, and short `sha-*`
+- Repository tag policy: create/push only `vX.Y.Z` git tags
 - Attestation: `actions/attest-build-provenance@v3` with `push-to-registry: true`
 - Metadata: OCI labels include source URL and image description
 - Build metadata: Docker build args wire to `hookaido version --long` (`version`, `commit`, `build_date`)
@@ -200,8 +201,8 @@ For each release, verify that:
 
 1. Create release commit with finalized `CHANGELOG.md`.
 2. Push release tag:
-   - `git tag v0.1.0`
-   - `git push origin main --tags`
+   - `git tag -a v0.1.0 -m "v0.1.0"`
+   - `git push origin v0.1.0`
 3. Confirm workflow `release` succeeded and uploaded:
    - archives
    - checksums


### PR DESCRIPTION
## Summary
- document explicit `main` protection expectations (no deletion, no force-push)
- document strict release tag policy (`vX.Y.Z` only)
- clarify release command to push only the intended tag (`git push origin vX.Y.Z`)
- clarify that container `X.Y`/`X` tags are derived image tags, not additional git tag requirements

## Validation
- docs-only change
