### PR TITLE
fix: harden sqlite dequeue allocation and prepare v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-03-09
+
 ### Added
 
 - Postgres queue backend (`queue { backend postgres }` / `queue postgres`) with durable queue semantics parity (lease lifecycle, message management, attempts, retention, and batch lease mutation support) plus runtime wiring via `hookaido run --postgres-dsn` (or `HOOKAIDO_POSTGRES_DSN`).
@@ -62,6 +64,7 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Memory backend retention safety: with `delivered_retention` enabled, `queue_limits.max_depth` now also caps `queued + leased + delivered` items so sustained pull/ack traffic cannot grow delivered retention unbounded in RAM.
 - Push retry exhaustion semantics now align with docs: `deliver.retry.max` is treated as maximum retry attempts (not total attempts), so `max 1` allows one retry before `max_retries` dead-lettering.
 - SQLite pull ack hot-path contention under sustained pull traffic: `Ack` now uses a direct lease-scoped update/delete path with expired-lease fallback requeue, reducing write-lock time and queue-full backpressure spikes at high ingest rates.
+- SQLite dequeue candidate collection no longer preallocates slice capacity directly from request-sized batch input, while preserving the existing hard cap of 100 items per dequeue.
 
 ## [1.1.0] - 2026-02-12
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Development Status
 
-Last updated: 2026-02-15
-Current release: v1.4.0
+Last updated: 2026-03-09
+Current release: v2.0.0
 
 Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change history: `CHANGELOG.md`. Prioritized work items: `BACKLOG.md`.
 

--- a/modules/sqlite/sqlite.go
+++ b/modules/sqlite/sqlite.go
@@ -1359,7 +1359,8 @@ LIMIT ?;
 	}
 	defer rows.Close()
 
-	ids := make([]string, 0, batch)
+	const dequeueCandidatePrealloc = 16
+	ids := make([]string, 0, dequeueCandidatePrealloc)
 	for rows.Next() {
 		var id string
 		if err := rows.Scan(&id); err != nil {

--- a/modules/sqlite/sqlite_test.go
+++ b/modules/sqlite/sqlite_test.go
@@ -363,6 +363,32 @@ func TestStore_AckBatchExpiredRequeues(t *testing.T) {
 	}
 }
 
+func TestStore_DequeueClampsOversizedBatch(t *testing.T) {
+	s := newStoreForTest(t, time.Now)
+
+	for i := 0; i < 120; i++ {
+		receivedAt := time.Unix(int64(i), 0)
+		if err := s.Enqueue(queue.Envelope{
+			ID:         fmt.Sprintf("evt_%03d", i),
+			Route:      "/r",
+			Target:     "pull",
+			State:      queue.StateQueued,
+			ReceivedAt: receivedAt,
+			NextRunAt:  receivedAt,
+		}); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	resp, err := s.Dequeue(queue.DequeueRequest{Route: "/r", Target: "pull", Batch: 1000, LeaseTTL: 30 * time.Second})
+	if err != nil {
+		t.Fatalf("dequeue: %v", err)
+	}
+	if len(resp.Items) != 100 {
+		t.Fatalf("expected clamped batch size of 100, got %d", len(resp.Items))
+	}
+}
+
 func TestStore_ListDead(t *testing.T) {
 	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
 	nowVar := now


### PR DESCRIPTION
## Summary\n- avoid request-sized preallocation in sqlite dequeue candidate collection\n- add regression coverage for oversized dequeue batches\n- update changelog and status for the v2.0.0 release cut\n\n## Validation\n- go test ./...\n- make release-check