### PR TITLE
security: pin all dependencies by hash (Dockerfile + CI actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         shell: bash
       - name: Upload coverage
         if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: coverage
           path: coverage.out
@@ -51,7 +51,7 @@ jobs:
           go-version-file: go.mod
           check-latest: true
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9
 
   release-package-dryrun:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # --- Build stage ---
-FROM golang:1.25-alpine AS build
+FROM golang:1.26-alpine@sha256:2389ebfa5b7f43eeafbd6be0c3700cc46690ef842ad962f6c5bd6be49ed82039 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary

- Pins `golang` Docker base image by digest (`1.26-alpine@sha256:2389ebfa...`), also bumps from 1.25 to 1.26 (supersedes #103)
- Pins `actions/upload-artifact@v7` by commit SHA in `ci.yml`
- Pins `golangci/golangci-lint-action@v9` by commit SHA in `ci.yml`

## Scorecard Alerts Resolved

- **#28** (Medium): containerImage not pinned by hash
- **#56** (Medium): GitHub-owned GitHubAction not pinned by hash
- **#58** (Medium): third-party GitHubAction not pinned by hash

Supersedes #103 (golang version bump is included in the Dockerfile digest pin).