### PR TITLE
release: prepare v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-03-25
+
 ### Added
 
 - Provider-compatible HMAC verification: `auth hmac { provider github; secret env:SECRET }` and `auth hmac { provider gitea; secret env:SECRET }` for GitHub (`X-Hub-Signature-256`) and Gitea/Forgejo (`X-Gitea-Signature`) webhook signature formats without timestamp/nonce replay protection.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,15 +1,15 @@
 # Development Status
 
-Last updated: 2026-03-14
-Current release: v2.0.1
+Last updated: 2026-03-25
+Current release: v2.1.0
 
 Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change history: `CHANGELOG.md`. Prioritized work items: `BACKLOG.md`.
 
 ## Capabilities Overview
 
-**Ingress & Routing** - HTTP ingress with optional TLS/mTLS, HMAC signature verification (replay protection, secret rotation), Basic auth, forward auth callouts, and per-route/global rate limiting. Route matching supports path, method, host (wildcards), headers, query params, remote IP (CIDR), and named matchers. Channel types (`inbound`/`outbound`/`internal`) enforce directive constraints at compile time.
+**Ingress & Routing** - HTTP ingress with optional TLS/mTLS, HMAC signature verification (replay protection, secret rotation, provider-compatible formats for GitHub/Gitea/Forgejo), Basic auth, forward auth callouts, and per-route/global rate limiting. Route matching supports path, method, host (wildcards), headers, query params, remote IP (CIDR), and named matchers. Channel types (`inbound`/`outbound`/`internal`) enforce directive constraints at compile time.
 
-**Queue & Delivery** - SQLite/WAL and PostgreSQL durable queue backends (in-memory available for dev/tests) with lease semantics, long-poll dequeue, dead-lettering, and queue limits/retention/pruning. Push dispatcher with retry/backoff, per-route concurrency, and optional outbound HMAC signing (multi-secret rotation). Pull API (HTTP/JSON) with bearer-token auth, dequeue limits, and per-route token overrides. Optional Worker API (gRPC) mirrors Pull lease operations (`dequeue`, `ack`, `nack`, `extend`) and is intentionally scoped to pull-worker transport only.
+**Queue & Delivery** - SQLite/WAL and PostgreSQL durable queue backends (in-memory available for dev/tests) with lease semantics, long-poll dequeue, dead-lettering, and queue limits/retention/pruning. Push dispatcher with retry/backoff, per-route concurrency, custom outbound headers, and optional outbound HMAC signing (multi-secret rotation). Pull API (HTTP/JSON) with bearer-token auth, dequeue limits, and per-route token overrides. Optional Worker API (gRPC) mirrors Pull lease operations (`dequeue`, `ack`, `nack`, `extend`) and is intentionally scoped to pull-worker transport only.
 
 **Admin API** - Full queue lifecycle: DLQ management, message publish/cancel/requeue/resume (by ID and by filter), backlog drill-down (top queued, oldest, aging summary, trends with operator-action playbooks). Management model projection and endpoint mapping lifecycle with config-source-of-truth mutations. Structured JSON errors, audit headers, and publish-policy enforcement throughout.
 


### PR DESCRIPTION
## Summary

- Finalize CHANGELOG `[Unreleased]` → `[2.1.0] - 2026-03-25`
- Update STATUS.md current release to v2.1.0
- Update capability descriptions for provider HMAC and custom deliver headers

After merge, tag `v2.1.0` on the merge commit to trigger the release workflow.