### PR TITLE
fix: address Go Report Card findings

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -2,9 +2,22 @@
 
 Prioritized work items for Hookaido. Items are grouped by priority tier and roughly ordered within each tier.
 
-## P1 - Medium Priority
+## P1 - Medium Priority (awesome-go readiness, target: July 2026)
 
-_No open items._
+- [ ] **Test coverage ≥80%** — Current total: 70.6%. Focus areas:
+  - `modules/postgres` (14.4%) — Integration tests for Postgres queue backend
+  - `modules/otel` (18.4%) — Unit tests for OpenTelemetry module wrapper
+  - `modules/mcp` (24.5%) — Unit tests for MCP module wrapper
+  - `internal/tools/release` (32.4%) — Release tooling tests
+  - `internal/app` (58.8%) — App startup/wiring tests
+  - `internal/release/sbom` (67.6%) — SBOM generator tests
+  - `internal/secrets` (70.8%) — Secret resolver edge cases
+  - `internal/pullapi` (73.6%) — Pull API handler coverage
+  - `internal/config` (77.3%) — Config parser edge cases
+  - `internal/mcp` (77.3%) — MCP server handler coverage
+- [ ] **Go Report Card A-** — Verify grade at https://goreportcard.com/report/github.com/nuetzliches/hookaido. Fix any lint/vet/fmt issues.
+- [ ] **pkg.go.dev doc coverage** — Ensure all public types and functions have Go-style doc comments.
+- [ ] **awesome-go PR** — Submit to [avelino/awesome-go](https://github.com/avelino/awesome-go) under "Messaging" category. Requires: ≥5 months history (eligible ~July 2026), coverage ≥80%, Go Report Card A-, pkg.go.dev docs.
 
 ## P2 - Nice to Have
 

--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -919,11 +919,11 @@ func (m *runtimeMetrics) healthDiagnostics() map[string]any {
 			"adaptive_backpressure_by_reason":     ingressAdaptiveByReasonAny,
 		},
 		"delivery": map[string]any{
-			"attempt_total":   m.deliveryAttemptTotal.Load(),
-			"acked_total":     m.deliveryAckedTotal.Load(),
-			"retry_total":     m.deliveryRetryTotal.Load(),
-			"dead_total":      m.deliveryDeadTotal.Load(),
-			"dead_by_reason":  deliveryDeadByReasonAny,
+			"attempt_total":  m.deliveryAttemptTotal.Load(),
+			"acked_total":    m.deliveryAckedTotal.Load(),
+			"retry_total":    m.deliveryRetryTotal.Load(),
+			"dead_total":     m.deliveryDeadTotal.Load(),
+			"dead_by_reason": deliveryDeadByReasonAny,
 		},
 		"pull": pullDiagnostics(pullSnapshot),
 	}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -157,7 +157,7 @@ func TestE2E_IngressPullRoundTrip(t *testing.T) {
 		t.Fatalf("stats: %v", err)
 	}
 	if stats.ByState[queue.StateQueued] != 0 {
-		t.Fatalf("queued items remainig: %d", stats.ByState[queue.StateQueued])
+		t.Fatalf("queued items remaining: %d", stats.ByState[queue.StateQueued])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fix misspelling `remainig` → `remaining` in e2e_test.go (misspell check)
- Apply `gofmt -s` to metrics.go (alignment simplification)

Addresses 2 of 3 findings from [Go Report Card](https://goreportcard.com/report/github.com/nuetzliches/hookaido). The `ineffassign` finding on sqlite.go:630 appears to be a false positive from the old file path (pre-modular architecture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)