### PR TITLE
feat: SSE endpoint for Pull API (GET {pull.path}/stream)

### DIFF
--- a/internal/app/metrics.go
+++ b/internal/app/metrics.go
@@ -68,13 +68,16 @@ type runtimeMetrics struct {
 }
 
 type pullRouteMetrics struct {
-	dequeueByStatus   map[string]int64
-	ackedTotal        int64
-	nackedTotal       int64
-	ackConflictTotal  int64
-	nackConflictTotal int64
-	leaseActive       int64
-	leaseExpiredTotal int64
+	dequeueByStatus      map[string]int64
+	ackedTotal           int64
+	nackedTotal          int64
+	ackConflictTotal     int64
+	nackConflictTotal    int64
+	leaseActive          int64
+	leaseExpiredTotal    int64
+	sseConnectionsTotal  int64
+	sseMessagesSentTotal int64
+	sseConnectionActive  int64
 }
 
 type pullLease struct {
@@ -83,13 +86,16 @@ type pullLease struct {
 }
 
 type pullRouteSnapshot struct {
-	dequeueByStatus   map[string]int64
-	ackedTotal        int64
-	nackedTotal       int64
-	ackConflictTotal  int64
-	nackConflictTotal int64
-	leaseActive       int64
-	leaseExpiredTotal int64
+	dequeueByStatus      map[string]int64
+	ackedTotal           int64
+	nackedTotal          int64
+	ackConflictTotal     int64
+	nackConflictTotal    int64
+	leaseActive          int64
+	leaseExpiredTotal    int64
+	sseConnectionsTotal  int64
+	sseMessagesSentTotal int64
+	sseConnectionActive  int64
 }
 
 func newRuntimeMetrics() *runtimeMetrics {
@@ -443,6 +449,38 @@ func (m *runtimeMetrics) observePullExtend(route string, statusCode int, leaseID
 	}
 }
 
+func (m *runtimeMetrics) observePullSSEConnect(route string) {
+	if m == nil {
+		return
+	}
+
+	route = normalizePullRoute(route)
+
+	m.pullMu.Lock()
+	defer m.pullMu.Unlock()
+
+	metrics := m.pullRouteLocked(route)
+	metrics.sseConnectionsTotal++
+	metrics.sseConnectionActive++
+}
+
+func (m *runtimeMetrics) observePullSSEDisconnect(route string, statusCode int, messagesSent int, duration time.Duration) {
+	if m == nil {
+		return
+	}
+
+	route = normalizePullRoute(route)
+
+	m.pullMu.Lock()
+	defer m.pullMu.Unlock()
+
+	metrics := m.pullRouteLocked(route)
+	metrics.sseMessagesSentTotal += int64(messagesSent)
+	if metrics.sseConnectionActive > 0 {
+		metrics.sseConnectionActive--
+	}
+}
+
 func (m *runtimeMetrics) pullSnapshot() map[string]pullRouteSnapshot {
 	if m == nil {
 		return nil
@@ -466,13 +504,16 @@ func (m *runtimeMetrics) pullSnapshot() map[string]pullRouteSnapshot {
 			byStatus[status] = n
 		}
 		out[route] = pullRouteSnapshot{
-			dequeueByStatus:   byStatus,
-			ackedTotal:        metrics.ackedTotal,
-			nackedTotal:       metrics.nackedTotal,
-			ackConflictTotal:  metrics.ackConflictTotal,
-			nackConflictTotal: metrics.nackConflictTotal,
-			leaseActive:       metrics.leaseActive,
-			leaseExpiredTotal: metrics.leaseExpiredTotal,
+			dequeueByStatus:      byStatus,
+			ackedTotal:           metrics.ackedTotal,
+			nackedTotal:          metrics.nackedTotal,
+			ackConflictTotal:     metrics.ackConflictTotal,
+			nackConflictTotal:    metrics.nackConflictTotal,
+			leaseActive:          metrics.leaseActive,
+			leaseExpiredTotal:    metrics.leaseExpiredTotal,
+			sseConnectionsTotal:  metrics.sseConnectionsTotal,
+			sseMessagesSentTotal: metrics.sseMessagesSentTotal,
+			sseConnectionActive:  metrics.sseConnectionActive,
 		}
 	}
 	return out
@@ -1157,6 +1198,12 @@ func newMetricsHandler(version string, start time.Time, rm *runtimeMetrics) http
 		_, _ = fmt.Fprintf(w, "# TYPE hookaido_pull_lease_active gauge\n")
 		_, _ = fmt.Fprintf(w, "# HELP hookaido_pull_lease_expired_total Total number of Pull lease expirations observed during ack/nack/extend operations.\n")
 		_, _ = fmt.Fprintf(w, "# TYPE hookaido_pull_lease_expired_total counter\n")
+		_, _ = fmt.Fprintf(w, "# HELP hookaido_pull_sse_connections_total Total number of SSE connections established by route.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE hookaido_pull_sse_connections_total counter\n")
+		_, _ = fmt.Fprintf(w, "# HELP hookaido_pull_sse_messages_sent_total Total number of messages sent over SSE by route.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE hookaido_pull_sse_messages_sent_total counter\n")
+		_, _ = fmt.Fprintf(w, "# HELP hookaido_pull_sse_connection_active Current number of active SSE connections by route.\n")
+		_, _ = fmt.Fprintf(w, "# TYPE hookaido_pull_sse_connection_active gauge\n")
 		for _, route := range sortedRoutes(pullSnapshot) {
 			metrics := pullSnapshot[route]
 			for _, status := range orderedPullStatuses(metrics.dequeueByStatus) {
@@ -1174,6 +1221,9 @@ func newMetricsHandler(version string, start time.Time, rm *runtimeMetrics) http
 			_, _ = fmt.Fprintf(w, "hookaido_pull_nack_conflict_total{route=%q} %d\n", route, metrics.nackConflictTotal)
 			_, _ = fmt.Fprintf(w, "hookaido_pull_lease_active{route=%q} %d\n", route, metrics.leaseActive)
 			_, _ = fmt.Fprintf(w, "hookaido_pull_lease_expired_total{route=%q} %d\n", route, metrics.leaseExpiredTotal)
+			_, _ = fmt.Fprintf(w, "hookaido_pull_sse_connections_total{route=%q} %d\n", route, metrics.sseConnectionsTotal)
+			_, _ = fmt.Fprintf(w, "hookaido_pull_sse_messages_sent_total{route=%q} %d\n", route, metrics.sseMessagesSentTotal)
+			_, _ = fmt.Fprintf(w, "hookaido_pull_sse_connection_active{route=%q} %d\n", route, metrics.sseConnectionActive)
 		}
 
 		// --- Queue depth (on-scrape from store) ---

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1797,6 +1797,14 @@ func startServers(
 	pullHandler.MaxLeaseTTL = compiled.PullAPI.MaxLeaseTTL
 	pullHandler.DefaultMaxWait = compiled.PullAPI.DefaultMaxWait
 	pullHandler.MaxWait = compiled.PullAPI.MaxWait
+	pullHandler.SSEKeepalive = compiled.PullAPI.SSEKeepalive
+	pullHandler.SSEMaxConnection = compiled.PullAPI.SSEMaxConnection
+	pullHandler.ObserveSSEConnect = func(route string) {
+		appMetrics.observePullSSEConnect(route)
+	}
+	pullHandler.ObserveSSEDisconnect = func(route string, statusCode int, messagesSent int, duration time.Duration) {
+		appMetrics.observePullSSEDisconnect(route, statusCode, messagesSent, duration)
+	}
 	pullHandler.ObserveDequeue = func(route string, statusCode int, items []queue.Envelope) {
 		appMetrics.observePullDequeue(route, statusCode, items)
 	}

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -190,8 +190,10 @@ type APIConfig struct {
 	MaxBatch        int
 	DefaultLeaseTTL time.Duration
 	MaxLeaseTTL     time.Duration
-	DefaultMaxWait  time.Duration
-	MaxWait         time.Duration
+	DefaultMaxWait   time.Duration
+	MaxWait          time.Duration
+	SSEKeepalive     time.Duration
+	SSEMaxConnection time.Duration
 }
 
 type CompiledRoute struct {
@@ -2774,6 +2776,24 @@ func compileAPI(name string, in *APIBlock, defaultListen string) (APIConfig, Val
 		}
 		if in.DefaultMaxWaitSet && in.MaxWaitSet && out.MaxWait > 0 && out.DefaultMaxWait > out.MaxWait {
 			res.Errors = append(res.Errors, "pull_api.default_max_wait must not exceed pull_api.max_wait")
+		}
+		if in.SSEKeepaliveSet {
+			raw := strings.TrimSpace(resolveValue(in.SSEKeepalive, "pull_api.sse_keepalive", &res))
+			d, off, err := parseDurationValue(raw)
+			if err != nil {
+				res.Errors = append(res.Errors, fmt.Sprintf("pull_api.sse_keepalive %s", err.Error()))
+			} else if !off {
+				out.SSEKeepalive = d
+			}
+		}
+		if in.SSEMaxConnectionSet {
+			raw := strings.TrimSpace(resolveValue(in.SSEMaxConnection, "pull_api.sse_max_connection", &res))
+			d, off, err := parseDurationValue(raw)
+			if err != nil {
+				res.Errors = append(res.Errors, fmt.Sprintf("pull_api.sse_max_connection %s", err.Error()))
+			} else if !off {
+				out.SSEMaxConnection = d
+			}
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -129,6 +129,14 @@ type APIBlock struct {
 	MaxWait       string
 	MaxWaitQuoted bool
 	MaxWaitSet    bool
+
+	SSEKeepalive       string
+	SSEKeepaliveQuoted bool
+	SSEKeepaliveSet    bool
+
+	SSEMaxConnection       string
+	SSEMaxConnectionQuoted bool
+	SSEMaxConnectionSet    bool
 }
 
 type ObservabilityBlock struct {

--- a/internal/config/format.go
+++ b/internal/config/format.go
@@ -343,6 +343,12 @@ func writeAPIBlock(b *bytes.Buffer, name string, api *APIBlock) {
 		if api.MaxWaitSet {
 			fmt.Fprintf(b, "  max_wait %s\n", formatValue(api.MaxWait, api.MaxWaitQuoted))
 		}
+		if api.SSEKeepaliveSet {
+			fmt.Fprintf(b, "  sse_keepalive %s\n", formatValue(api.SSEKeepalive, api.SSEKeepaliveQuoted))
+		}
+		if api.SSEMaxConnectionSet {
+			fmt.Fprintf(b, "  sse_max_connection %s\n", formatValue(api.SSEMaxConnection, api.SSEMaxConnectionQuoted))
+		}
 	}
 	if api.TLS != nil {
 		writeTLSBlock(b, api.TLS)

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -992,6 +992,34 @@ func (p *parser) parseAPIBlock(name string) (*APIBlock, error) {
 			out.MaxWait = v
 			out.MaxWaitQuoted = quoted
 			out.MaxWaitSet = true
+		case "sse_keepalive":
+			if name != "pull_api" {
+				return nil, p.errAt(dirTok.pos, "unknown %s directive %q", name, dirTok.text)
+			}
+			if out.SSEKeepaliveSet {
+				return nil, p.errAt(dirTok.pos, "duplicate %s sse_keepalive", name)
+			}
+			v, quoted, err := p.parseValue()
+			if err != nil {
+				return nil, err
+			}
+			out.SSEKeepalive = v
+			out.SSEKeepaliveQuoted = quoted
+			out.SSEKeepaliveSet = true
+		case "sse_max_connection":
+			if name != "pull_api" {
+				return nil, p.errAt(dirTok.pos, "unknown %s directive %q", name, dirTok.text)
+			}
+			if out.SSEMaxConnectionSet {
+				return nil, p.errAt(dirTok.pos, "duplicate %s sse_max_connection", name)
+			}
+			v, quoted, err := p.parseValue()
+			if err != nil {
+				return nil, err
+			}
+			out.SSEMaxConnection = v
+			out.SSEMaxConnectionQuoted = quoted
+			out.SSEMaxConnectionSet = true
 		case "tls":
 			if out.TLS != nil {
 				return nil, p.errAt(dirTok.pos, "duplicate %s tls block", name)

--- a/internal/pullapi/http.go
+++ b/internal/pullapi/http.go
@@ -42,8 +42,12 @@ type Server struct {
 	MaxBatch        int
 	MaxLeaseBatch   int
 	MaxLeaseTTL     time.Duration
-	DefaultMaxWait  time.Duration
-	MaxWait         time.Duration
+	DefaultMaxWait   time.Duration
+	MaxWait          time.Duration
+	SSEKeepalive        time.Duration
+	SSEMaxConnection    time.Duration
+	ObserveSSEConnect   func(route string)
+	ObserveSSEDisconnect func(route string, statusCode int, messagesSent int, duration time.Duration)
 
 	RecentLeaseOpTTL time.Duration
 	RecentLeaseOpCap int
@@ -79,6 +83,31 @@ type recentLeaseOpEntry struct {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	cleanPath := path.Clean(r.URL.Path)
+	op := path.Base(cleanPath)
+	endpoint := strings.TrimSuffix(cleanPath, "/"+op)
+	if endpoint == "" {
+		endpoint = "/"
+	}
+
+	if r.Method == http.MethodGet {
+		if op != "stream" {
+			writeError(w, http.StatusMethodNotAllowed, pullErrMethodNotAllowed, "method must be POST")
+			return
+		}
+		if s.Authorize != nil && !s.Authorize(r) {
+			writeError(w, http.StatusUnauthorized, pullErrUnauthorized, "request is not authorized")
+			return
+		}
+		route, ok := s.resolveRoute(endpoint)
+		if !ok {
+			writeError(w, http.StatusNotFound, pullErrRouteNotFound, "pull endpoint is not configured")
+			return
+		}
+		s.handleSSE(w, r, route)
+		return
+	}
+
 	if r.Method != http.MethodPost {
 		writeError(w, http.StatusMethodNotAllowed, pullErrMethodNotAllowed, "method must be POST")
 		return
@@ -87,13 +116,6 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if s.Authorize != nil && !s.Authorize(r) {
 		writeError(w, http.StatusUnauthorized, pullErrUnauthorized, "request is not authorized")
 		return
-	}
-
-	cleanPath := path.Clean(r.URL.Path)
-	op := path.Base(cleanPath)
-	endpoint := strings.TrimSuffix(cleanPath, "/"+op)
-	if endpoint == "" {
-		endpoint = "/"
 	}
 
 	route, ok := s.resolveRoute(endpoint)
@@ -110,6 +132,8 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		s.handleNack(w, r, route)
 	case "extend":
 		s.handleExtend(w, r, route)
+	case "stream":
+		writeError(w, http.StatusMethodNotAllowed, pullErrMethodNotAllowed, "stream requires GET method")
 	default:
 		writeError(w, http.StatusNotFound, pullErrOperationNotFound, "pull operation was not found")
 	}

--- a/internal/pullapi/sse.go
+++ b/internal/pullapi/sse.go
@@ -1,0 +1,176 @@
+package pullapi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/nuetzliches/hookaido/internal/queue"
+)
+
+const (
+	defaultSSEKeepalive = 15 * time.Second
+	sseFallbackPoll     = time.Second
+)
+
+func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeError(w, http.StatusInternalServerError, pullErrInternal, "streaming not supported")
+		return
+	}
+
+	batch := 1
+	if v := r.URL.Query().Get("batch"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, pullErrInvalidBody, "batch must be a positive integer")
+			return
+		}
+		batch = n
+		if s.MaxBatch > 0 && batch > s.MaxBatch {
+			batch = s.MaxBatch
+		}
+	}
+
+	leaseTTL := s.DefaultLeaseTTL
+	if v := r.URL.Query().Get("lease_ttl"); v != "" {
+		d, ok := parseDuration(v)
+		if !ok || d <= 0 {
+			writeError(w, http.StatusBadRequest, pullErrInvalidBody, "lease_ttl must be a valid positive duration")
+			return
+		}
+		leaseTTL = d
+		if s.MaxLeaseTTL > 0 && leaseTTL > s.MaxLeaseTTL {
+			leaseTTL = s.MaxLeaseTTL
+		}
+	}
+
+	ctx := r.Context()
+	if s.SSEMaxConnection > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, s.SSEMaxConnection)
+		defer cancel()
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	keepalive := s.SSEKeepalive
+	if keepalive <= 0 {
+		keepalive = defaultSSEKeepalive
+	}
+
+	// Determine notification source.
+	var notifyCh func() <-chan struct{}
+	if sn, ok := s.Store.(queue.StoreNotifier); ok {
+		notifyCh = sn.NotifyCh
+	}
+
+	s.observeSSEConnect(route)
+	start := time.Now()
+	messagesSent := 0
+	keepaliveTicker := time.NewTicker(keepalive)
+	defer keepaliveTicker.Stop()
+
+	for {
+		// Non-blocking dequeue.
+		outcome, opErr := s.Dequeue(route, DequeueParams{
+			Batch:       batch,
+			MaxWait:     0,
+			HasMaxWait:  true,
+			LeaseTTL:    leaseTTL,
+			HasLeaseTTL: true,
+		})
+		if opErr != nil {
+			// Store unavailable — write an SSE error event and close.
+			fmt.Fprintf(w, "event: error\ndata: %s\n\n", opErr.Detail)
+			flusher.Flush()
+			s.observeSSEDisconnect(route, opErr.StatusCode, messagesSent, time.Since(start))
+			return
+		}
+
+		if len(outcome.Items) > 0 {
+			for _, it := range outcome.Items {
+				item := dequeueItem{
+					ID:         it.ID,
+					LeaseID:    it.LeaseID,
+					ReceivedAt: it.ReceivedAt,
+					Attempt:    it.Attempt,
+					NextRunAt:  it.NextRunAt,
+					Route:      it.Route,
+					PayloadB64: base64.StdEncoding.EncodeToString(it.Payload),
+					Headers:    it.Headers,
+					Trace:      it.Trace,
+				}
+				data, _ := json.Marshal(item)
+				fmt.Fprintf(w, "id: %s\nevent: message\ndata: %s\n\n", it.LeaseID, data)
+				messagesSent++
+			}
+			flusher.Flush()
+			// Reset keepalive timer after activity.
+			keepaliveTicker.Reset(keepalive)
+			continue
+		}
+
+		// No items available — wait for notification, keepalive, or cancellation.
+		if notifyCh != nil {
+			ch := notifyCh()
+			select {
+			case <-ch:
+				continue
+			case <-keepaliveTicker.C:
+				if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+					s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
+					return
+				}
+				flusher.Flush()
+			case <-ctx.Done():
+				s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
+				return
+			}
+		} else {
+			// Fallback: short poll.
+			fallback := time.NewTimer(sseFallbackPoll)
+			select {
+			case <-fallback.C:
+				continue
+			case <-keepaliveTicker.C:
+				if !fallback.Stop() {
+					<-fallback.C
+				}
+				if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
+					s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
+					return
+				}
+				flusher.Flush()
+			case <-ctx.Done():
+				if !fallback.Stop() {
+					<-fallback.C
+				}
+				s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
+				return
+			}
+		}
+	}
+}
+
+func (s *Server) observeSSEConnect(route string) {
+	if s.ObserveSSEConnect != nil {
+		s.ObserveSSEConnect(route)
+	}
+}
+
+func (s *Server) observeSSEDisconnect(route string, statusCode int, messagesSent int, duration time.Duration) {
+	if s.ObserveSSEDisconnect != nil {
+		s.ObserveSSEDisconnect(route, statusCode, messagesSent, duration)
+	}
+}

--- a/internal/pullapi/sse_test.go
+++ b/internal/pullapi/sse_test.go
@@ -1,0 +1,388 @@
+package pullapi
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/internal/queue"
+)
+
+func newSSETestServer(t *testing.T) (*Server, *queue.MemoryStore) {
+	t.Helper()
+	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+	store := queue.NewMemoryStore(queue.WithNowFunc(func() time.Time { return now }))
+	srv := NewServer(store)
+	srv.SSEKeepalive = 100 * time.Millisecond
+	srv.ResolveRoute = func(endpoint string) (string, bool) {
+		if endpoint == "/pull/github" {
+			return "/webhooks/github", true
+		}
+		return "", false
+	}
+	return srv, store
+}
+
+func enqueueTestMsg(t *testing.T, store *queue.MemoryStore, id string) {
+	t.Helper()
+	now := time.Date(2026, 4, 16, 12, 0, 0, 0, time.UTC)
+	if err := store.Enqueue(queue.Envelope{
+		ID:         id,
+		Route:      "/webhooks/github",
+		Target:     "pull",
+		ReceivedAt: now,
+		NextRunAt:  now,
+		Payload:    []byte(fmt.Sprintf(`{"id":%q}`, id)),
+	}); err != nil {
+		t.Fatalf("enqueue %s: %v", id, err)
+	}
+}
+
+// readSSEEvent reads one SSE event (terminated by blank line) or a comment line.
+// Returns event lines joined by newline and whether it's a comment.
+func readSSEEvent(scanner *bufio.Scanner) (lines []string, isComment bool, eof bool) {
+	for scanner.Scan() {
+		line := scanner.Text()
+		if line == "" {
+			// End of event block.
+			if len(lines) > 0 {
+				return lines, false, false
+			}
+			continue
+		}
+		if strings.HasPrefix(line, ":") {
+			return []string{line}, true, false
+		}
+		lines = append(lines, line)
+	}
+	return lines, false, true
+}
+
+func TestSSE_BasicStream(t *testing.T) {
+	srv, store := newSSETestServer(t)
+	enqueueTestMsg(t, store, "evt_1")
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream", nil)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("SSE request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("expected text/event-stream, got %q", ct)
+	}
+
+	scanner := bufio.NewScanner(resp.Body)
+	lines, isComment, eof := readSSEEvent(scanner)
+	if eof || isComment {
+		t.Fatalf("expected SSE event, got eof=%v comment=%v", eof, isComment)
+	}
+
+	// Parse SSE fields.
+	var eventID, eventType, eventData string
+	for _, l := range lines {
+		if strings.HasPrefix(l, "id: ") {
+			eventID = strings.TrimPrefix(l, "id: ")
+		}
+		if strings.HasPrefix(l, "event: ") {
+			eventType = strings.TrimPrefix(l, "event: ")
+		}
+		if strings.HasPrefix(l, "data: ") {
+			eventData = strings.TrimPrefix(l, "data: ")
+		}
+	}
+
+	if eventType != "message" {
+		t.Fatalf("expected event type 'message', got %q", eventType)
+	}
+	if eventID == "" {
+		t.Fatal("expected non-empty event id (lease_id)")
+	}
+
+	var item dequeueItem
+	if err := json.Unmarshal([]byte(eventData), &item); err != nil {
+		t.Fatalf("unmarshal SSE data: %v", err)
+	}
+	if item.ID != "evt_1" {
+		t.Fatalf("expected item ID 'evt_1', got %q", item.ID)
+	}
+	if item.LeaseID != eventID {
+		t.Fatalf("SSE id (%q) != data lease_id (%q)", eventID, item.LeaseID)
+	}
+
+	cancel()
+}
+
+func TestSSE_Keepalive(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream", nil)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("SSE request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	scanner := bufio.NewScanner(resp.Body)
+	lines, isComment, eof := readSSEEvent(scanner)
+	if eof {
+		t.Fatal("unexpected eof before keepalive")
+	}
+	if !isComment {
+		t.Fatalf("expected keepalive comment, got event: %v", lines)
+	}
+	if len(lines) != 1 || !strings.Contains(lines[0], "keepalive") {
+		t.Fatalf("expected keepalive comment, got %v", lines)
+	}
+
+	cancel()
+}
+
+func TestSSE_Auth(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+	srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("secret")})
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	// Without token.
+	resp, err := ts.Client().Get(ts.URL + "/pull/github/stream")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without token, got %d", resp.StatusCode)
+	}
+
+	// With token.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp2, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("request with token: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 with token, got %d", resp2.StatusCode)
+	}
+	cancel()
+}
+
+func TestSSE_MaxConnection(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+	srv.SSEMaxConnection = 200 * time.Millisecond
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	start := time.Now()
+	resp, err := ts.Client().Get(ts.URL + "/pull/github/stream")
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read until EOF (server closes connection).
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		// drain
+	}
+
+	elapsed := time.Since(start)
+	if elapsed > 2*time.Second {
+		t.Fatalf("connection should have closed within ~200ms, took %v", elapsed)
+	}
+}
+
+func TestSSE_MethodRouting(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+
+	// GET on /dequeue should return 405.
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/github/dequeue", nil)
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("GET /dequeue: expected 405, got %d", rr.Code)
+	}
+
+	// POST on /stream should return 405.
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "http://example/pull/github/stream", strings.NewReader("{}"))
+	srv.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /stream: expected 405, got %d", rr2.Code)
+	}
+}
+
+func TestSSE_CompetingConsumers(t *testing.T) {
+	srv, store := newSSETestServer(t)
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	enqueueTestMsg(t, store, "evt_a")
+	enqueueTestMsg(t, store, "evt_b")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	received := make(chan string, 4)
+
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream", nil)
+			resp, err := ts.Client().Do(req)
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+
+			scanner := bufio.NewScanner(resp.Body)
+			for {
+				lines, isComment, eof := readSSEEvent(scanner)
+				if eof {
+					return
+				}
+				if isComment {
+					continue
+				}
+				for _, l := range lines {
+					if strings.HasPrefix(l, "data: ") {
+						var item dequeueItem
+						if err := json.Unmarshal([]byte(strings.TrimPrefix(l, "data: ")), &item); err == nil {
+							received <- item.ID
+						}
+					}
+				}
+			}
+		}()
+	}
+
+	// Wait a bit for both consumers to get their messages.
+	timeout := time.After(2 * time.Second)
+	ids := make(map[string]bool)
+	for len(ids) < 2 {
+		select {
+		case id := <-received:
+			ids[id] = true
+		case <-timeout:
+			cancel()
+			wg.Wait()
+			t.Fatalf("timed out, only received %d messages: %v", len(ids), ids)
+		}
+	}
+
+	cancel()
+	wg.Wait()
+
+	if !ids["evt_a"] || !ids["evt_b"] {
+		t.Fatalf("expected both evt_a and evt_b, got %v", ids)
+	}
+}
+
+func TestSSE_BatchParam(t *testing.T) {
+	srv, store := newSSETestServer(t)
+	enqueueTestMsg(t, store, "evt_1")
+	enqueueTestMsg(t, store, "evt_2")
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream?batch=5", nil)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("SSE request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var items []string
+	scanner := bufio.NewScanner(resp.Body)
+	// Collect events until keepalive or timeout.
+	for {
+		lines, isComment, eof := readSSEEvent(scanner)
+		if eof || isComment {
+			break
+		}
+		for _, l := range lines {
+			if strings.HasPrefix(l, "data: ") {
+				var item dequeueItem
+				if err := json.Unmarshal([]byte(strings.TrimPrefix(l, "data: ")), &item); err == nil {
+					items = append(items, item.ID)
+				}
+			}
+		}
+	}
+	cancel()
+
+	if len(items) != 2 {
+		t.Fatalf("expected 2 items with batch=5, got %d: %v", len(items), items)
+	}
+}
+
+func TestSSE_InvalidBatchParam(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+
+	rr := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/github/stream?batch=0", nil)
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for batch=0, got %d", rr.Code)
+	}
+
+	rr2 := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	req2 := httptest.NewRequest(http.MethodGet, "http://example/pull/github/stream?batch=abc", nil)
+	srv.ServeHTTP(rr2, req2)
+	if rr2.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for batch=abc, got %d", rr2.Code)
+	}
+}
+
+func TestSSE_RouteNotFound(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+
+	rr := &flusherRecorder{ResponseRecorder: httptest.NewRecorder()}
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/unknown/stream", nil)
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+// flusherRecorder wraps httptest.ResponseRecorder to implement http.Flusher.
+type flusherRecorder struct {
+	*httptest.ResponseRecorder
+}
+
+func (f *flusherRecorder) Flush() {}

--- a/internal/queue/memory.go
+++ b/internal/queue/memory.go
@@ -96,6 +96,14 @@ func NewMemoryStore(opts ...MemoryOption) *MemoryStore {
 	return s
 }
 
+// NotifyCh returns a channel that is closed when new items become available.
+// After the channel fires, callers must call NotifyCh again to get the next signal.
+func (s *MemoryStore) NotifyCh() <-chan struct{} {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.notify
+}
+
 // WithMemoryPressureLimits overrides memory pressure limits for the in-memory
 // backend. Positive values enable explicit thresholds.
 func WithMemoryPressureLimits(retainedItems int, retainedBytes int64) MemoryOption {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -227,6 +227,14 @@ type BatchEnqueuer interface {
 	EnqueueBatch(items []Envelope) (int, error)
 }
 
+// StoreNotifier is an optional extension for stores that support
+// event-driven notification when new items become available.
+// The returned channel is closed when one or more items are enqueued,
+// after which a fresh channel must be obtained by calling NotifyCh again.
+type StoreNotifier interface {
+	NotifyCh() <-chan struct{}
+}
+
 const statsTopBacklogLimit = 10
 
 const (

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -258,6 +258,10 @@ func (s *Store) waitCh() <-chan struct{} {
 	return s.notify
 }
 
+// NotifyCh returns a channel that is closed when new items become available.
+// After the channel fires, callers must call NotifyCh again to get the next signal.
+func (s *Store) NotifyCh() <-chan struct{} { return s.waitCh() }
+
 func (s *Store) Enqueue(env queue.Envelope) error {
 	return s.runStoreOperation("enqueue", func() error {
 		if s == nil || s.db == nil {

--- a/modules/sqlite/sqlite.go
+++ b/modules/sqlite/sqlite.go
@@ -2945,6 +2945,10 @@ func (s *Store) waitCh() <-chan struct{} {
 	return s.notify
 }
 
+// NotifyCh returns a channel that is closed when new items become available.
+// After the channel fires, callers must call NotifyCh again to get the next signal.
+func (s *Store) NotifyCh() <-chan struct{} { return s.waitCh() }
+
 type sqliteTxClass int
 
 const (


### PR DESCRIPTION
## Summary

- Add Server-Sent Events endpoint (`GET .../stream`) to the Pull API for zero-latency message delivery
- Expose `StoreNotifier` interface on all three store backends (memory, sqlite, postgres) for event-driven wake-up
- Add `sse_keepalive` and `sse_max_connection` config directives to the `pull_api` block
- Add Prometheus metrics: `sse_connections_total`, `sse_messages_sent_total`, `sse_connection_active` per route

## Test plan

- [x] 9 new SSE-specific tests (basic stream, keepalive, auth, max connection, method routing, competing consumers, batch param, invalid params, route not found)
- [x] Full test suite passes (25 packages)
- [ ] Manual: `curl -N GET http://localhost:PORT/prefix/path/stream -H "Authorization: Bearer TOKEN"` → observe SSE events on webhook delivery

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)