### PR TITLE
docs: SSE endpoint documentation + CI docs-only skip

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,19 +14,43 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'Dockerfile'
+              - '.github/workflows/ci.yml'
+
   test:
+    needs: changes
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Skip (docs-only)
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Docs-only change — skipping tests"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: needs.changes.outputs.code == 'true'
       - name: Setup Go
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
       - name: Test
+        if: needs.changes.outputs.code == 'true'
         run: |
           if [ "$RUNNER_OS" = "Linux" ]; then
             go test -race -coverprofile=coverage.out ./...
@@ -35,13 +59,15 @@ jobs:
           fi
         shell: bash
       - name: Upload coverage
-        if: runner.os == 'Linux'
+        if: needs.changes.outputs.code == 'true' && runner.os == 'Linux'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: coverage.out
 
   lint:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,25 +80,36 @@ jobs:
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
 
   release-package-dryrun:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
+      - name: Skip (docs-only)
+        if: needs.changes.outputs.code != 'true'
+        run: echo "Docs-only change — skipping release dryrun"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: needs.changes.outputs.code == 'true'
       - name: Setup Go
+        if: needs.changes.outputs.code == 'true'
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
           check-latest: true
       - name: Generate Ephemeral Signing Key
+        if: needs.changes.outputs.code == 'true'
         run: openssl genpkey -algorithm ED25519 -out ci-release-signing-key.pem
       - name: Build Release Archives
+        if: needs.changes.outputs.code == 'true'
         run: go run ./internal/tools/release -version "0.0.0-ci" -commit "${GITHUB_SHA::12}" -out dist -signing-key ci-release-signing-key.pem
       - name: Verify Checksums File
+        if: needs.changes.outputs.code == 'true'
         run: test -f dist/hookaido_0.0.0-ci_checksums.txt
       - name: Verify Signed Checksums + Manifest
+        if: needs.changes.outputs.code == 'true'
         run: |
           test -f dist/hookaido_0.0.0-ci_checksums.txt.sig
           test -f dist/hookaido_0.0.0-ci_checksums.txt.pub.pem
           test -f dist/hookaido_0.0.0-ci_manifest.json
           test -f dist/hookaido_0.0.0-ci_sbom.spdx.json
       - name: Verify Release Artifacts (hookaido verify-release)
+        if: needs.changes.outputs.code == 'true'
         run: go run ./cmd/hookaido verify-release --checksums dist/hookaido_0.0.0-ci_checksums.txt --require-signature --require-sbom

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,35 @@ on:
 permissions: read-all
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - '.github/workflows/codeql.yml'
+      - id: check
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          elif [ "${{ steps.filter.outputs.code }}" = "true" ]; then
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+        shell: bash
+
   analyze:
+    needs: changes
     name: CodeQL (go)
     runs-on: ubuntu-latest
     permissions:
@@ -25,18 +53,26 @@ jobs:
         language: [go]
 
     steps:
+      - name: Skip (docs-only)
+        if: needs.changes.outputs.skip == 'true'
+        run: echo "Docs-only change — skipping CodeQL"
+
       - name: Checkout
+        if: needs.changes.outputs.skip != 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
+        if: needs.changes.outputs.skip != 'true'
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           languages: ${{ matrix.language }}
 
       - name: Autobuild
+        if: needs.changes.outputs.skip != 'true'
         uses: github/codeql-action/autobuild@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
 
       - name: Analyze
+        if: needs.changes.outputs.skip != 'true'
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13 # v4.35.1
         with:
           category: "/language:${{ matrix.language }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- SSE endpoint for Pull API (`GET {pull.path}/stream`): consumers can receive webhook messages in real-time over a persistent Server-Sent Events connection instead of polling. Each SSE message creates a lease (same semantics as dequeue); ACK/NACK remain via existing POST endpoints. Supports `batch` and `lease_ttl` query parameters, configurable keepalive interval (`sse_keepalive`, default 15s) and max connection duration (`sse_max_connection`). Multiple concurrent SSE connections act as competing consumers. New Prometheus metrics: `hookaido_pull_sse_connections_total`, `hookaido_pull_sse_messages_sent_total`, `hookaido_pull_sse_connection_active`.
+
 ### Fixed
 
 - Queue dequeue loop now uses event-driven wake-up instead of aggressive 25ms polling. Enqueue signals waiting Dequeue goroutines immediately via channel notification; polling interval raised to 1s as fallback for delayed/retry items only. Reduces idle CPU from ~26% to <1% (SQLite and PostgreSQL backends).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,23 +149,27 @@ pull_api {
   max_lease_ttl 5m           # optional upper bound for lease TTL
   default_max_wait 0         # default long-poll wait (default 0 = no wait)
   max_wait 30s               # optional upper bound for long-poll wait
+  sse_keepalive 15s          # SSE keepalive comment interval (default 15s)
+  sse_max_connection 1h      # optional max SSE connection duration (default unlimited)
 
   tls { ... }
 }
 ```
 
-| Directive           | Default      | Description                                |
-| ------------------- | ------------ | ------------------------------------------ |
-| `listen`            | `:9443`      | Bind address                               |
-| `grpc_listen`       | —            | Optional gRPC worker listener address      |
-| `prefix`            | —            | URL path prefix for all pull endpoints     |
-| `auth token`        | **required** | Bearer token allowlist (`env:`/`file:`/`vault:`/`raw:` ref) |
-| `max_batch`         | `100`        | Max items per dequeue request              |
-| `default_lease_ttl` | `30s`        | Lease TTL when client omits it             |
-| `max_lease_ttl`     | off          | Optional upper cap for effective lease TTL |
-| `default_max_wait`  | `0`          | Long-poll wait when client omits it        |
-| `max_wait`          | off          | Optional upper cap for long-poll wait      |
-| `tls`               | —            | TLS and optional mTLS configuration        |
+| Directive            | Default      | Description                                |
+| -------------------- | ------------ | ------------------------------------------ |
+| `listen`             | `:9443`      | Bind address                               |
+| `grpc_listen`        | —            | Optional gRPC worker listener address      |
+| `prefix`             | —            | URL path prefix for all pull endpoints     |
+| `auth token`         | **required** | Bearer token allowlist (`env:`/`file:`/`vault:`/`raw:` ref) |
+| `max_batch`          | `100`        | Max items per dequeue request              |
+| `default_lease_ttl`  | `30s`        | Lease TTL when client omits it             |
+| `max_lease_ttl`      | off          | Optional upper cap for effective lease TTL |
+| `default_max_wait`   | `0`          | Long-poll wait when client omits it        |
+| `max_wait`           | off          | Optional upper cap for long-poll wait      |
+| `sse_keepalive`      | `15s`        | Interval for SSE keepalive comments        |
+| `sse_max_connection` | off          | Optional max duration for SSE connections  |
+| `tls`                | —            | TLS and optional mTLS configuration        |
 
 > Pull API auth is required when pull routes are present. Deliver-only configs can omit it entirely — the Pull API server is skipped in that case.
 >

--- a/docs/pull-api.md
+++ b/docs/pull-api.md
@@ -32,8 +32,9 @@ The endpoints become:
 - `POST http://localhost:9443/pull/github/ack`
 - `POST http://localhost:9443/pull/github/nack`
 - `POST http://localhost:9443/pull/github/extend`
+- `GET  http://localhost:9443/pull/github/stream` (SSE)
 
-All requests use `Content-Type: application/json`.
+POST requests use `Content-Type: application/json`. The SSE endpoint returns `Content-Type: text/event-stream`.
 
 ## Authentication
 
@@ -273,6 +274,58 @@ All non-2xx responses return structured JSON:
 
 > Request bodies are parsed strictly: unknown JSON fields and trailing JSON documents are rejected with `400`.
 
+## SSE Streaming
+
+### `GET {endpoint}/stream`
+
+Opens a Server-Sent Events connection for real-time message delivery. Each SSE message creates a lease (same semantics as dequeue). ACK/NACK remain via the existing POST endpoints.
+
+**Query parameters:**
+
+| Parameter   | Default                      | Description                                                    |
+| ----------- | ---------------------------- | -------------------------------------------------------------- |
+| `batch`     | `1`                          | Messages to dequeue per cycle (capped by `pull_api.max_batch`) |
+| `lease_ttl` | `pull_api.default_lease_ttl` | Lease duration per message. Capped by `pull_api.max_lease_ttl` |
+
+**Request:**
+
+```bash
+curl -N -H "Authorization: Bearer $TOKEN" \
+  http://localhost:9443/pull/github/stream
+```
+
+**SSE event format:**
+
+```
+id: lease_abc123
+event: message
+data: {"id":"evt_1","lease_id":"lease_abc123","route":"/webhooks/github","received_at":"...","attempt":1,"payload_b64":"...","headers":{...}}
+
+: keepalive
+
+```
+
+- `id` is the `lease_id` — used as `Last-Event-ID` on reconnect.
+- `event: message` for queued items; `: keepalive` comments keep the connection alive through proxies.
+- The `data` JSON payload is identical to items returned by `POST /dequeue`.
+
+**Behavior:**
+
+- Auth is identical to all other Pull API endpoints (bearer token).
+- Multiple concurrent SSE connections on the same route act as competing consumers — leases prevent double-delivery.
+- On reconnect, the consumer sends `Last-Event-ID`. Since leases were already created, reconnect simply resumes dequeuing new items.
+- The server sends keepalive comments at the interval configured by `sse_keepalive` (default 15s).
+- Optionally, `sse_max_connection` limits the maximum connection duration for resource hygiene.
+
+**Error event:**
+
+If the store becomes unavailable, the server sends an error event and closes the connection:
+
+```
+event: error
+data: dequeue is temporarily unavailable
+```
+
 ## Dequeue Controls
 
 Fine-tune Pull API behavior in the config:
@@ -286,12 +339,14 @@ pull_api {
   max_lease_ttl 5m        # hard upper bound for lease TTL
   default_max_wait 0      # when client omits max_wait (default 0 = no wait)
   max_wait 30s            # hard upper bound for long-poll wait
+  sse_keepalive 15s       # SSE keepalive comment interval (default 15s)
+  sse_max_connection 1h   # optional max SSE connection duration (default unlimited)
 }
 ```
 
 ## Consumer Implementation Tips
 
-1. **Use long-polling** (`max_wait`) to reduce empty-response overhead.
+1. **Use SSE streaming** (`GET .../stream`) for zero-latency delivery, or **long-polling** (`max_wait`) as a simpler alternative.
 2. **Process in batches** — dequeue multiple messages, process in parallel, ack individually.
 3. **Extend leases proactively** — if processing takes >50% of your `lease_ttl`, extend early.
 4. **Dead-letter on permanent failures** — use `nack { dead: true, reason: "..." }` for non-retryable errors.


### PR DESCRIPTION
## Summary

- Add SSE streaming endpoint documentation to pull-api.md, configuration.md, and CHANGELOG
- Add `dorny/paths-filter` to ci.yml and codeql.yml so docs-only PRs skip Go build/test/lint/CodeQL while still reporting success to branch protection

## Test plan

- [x] Docs accurately reflect the SSE implementation from #137
- [ ] Verify this PR itself triggers the fast-path (jobs should skip Go steps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)