### PR TITLE
fix: release workflow compatibility with pre-created releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,8 +84,11 @@ jobs:
           cp "${{ steps.attest_provenance.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_provenance.intoto.jsonl"
           cp "${{ steps.attest_sbom.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_sbom.attestation.json"
           cp "${{ steps.attest_sbom.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_sbom.intoto.jsonl"
-      - name: Publish GitHub Release
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          files: dist/*
-          generate_release_notes: true
+      - name: Upload Release Assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${GITHUB_REF_NAME}" dist/* --clobber
+      - name: Update Release Notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --latest


### PR DESCRIPTION
## Summary

- Replace `softprops/action-gh-release` with `gh release upload --clobber` to support releases created via `gh release create` before the workflow runs
- GitHub's immutable release policy prevents asset uploads via the softprops action when a release is already published

## Context

When creating a release tag via `gh release create` (required because org rulesets block direct tag pushes), the release is published immediately. The release workflow then fails because `softprops/action-gh-release` cannot upload assets to an already-published release.

## Test plan

- [ ] Create next release via `gh release create` and verify the workflow uploads assets successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)