### PR TITLE
fix: release workflow draft-then-publish for immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,11 +84,19 @@ jobs:
           cp "${{ steps.attest_provenance.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_provenance.intoto.jsonl"
           cp "${{ steps.attest_sbom.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_sbom.attestation.json"
           cp "${{ steps.attest_sbom.outputs.bundle-path }}" "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_sbom.intoto.jsonl"
-      - name: Upload Release Assets
+      - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload "${GITHUB_REF_NAME}" dist/* --clobber
-      - name: Update Release Notes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release edit "${GITHUB_REF_NAME}" --draft=false --latest
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          # Delete any existing release (published releases are immutable
+          # and block asset uploads). The tag is preserved.
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release delete "$TAG" --yes
+          fi
+          # Create a draft release, upload assets, then publish.
+          gh release create "$TAG" dist/* \
+            --draft \
+            --title "$TAG" \
+            --generate-notes
+          gh release edit "$TAG" --draft=false --latest


### PR DESCRIPTION
## Summary

Fix release workflow to handle GitHub's immutable release policy:
1. Delete any pre-existing published release for the tag (preserves tag)
2. Create a draft release with all assets in a single `gh release create` call
3. Publish the release via `gh release edit --draft=false`

This supports the flow where `gh release create` (which org rulesets require for tag creation) creates a published release before the workflow runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)