### PR TITLE
fix: release workflow uses --cleanup-tag for immutable releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,14 +89,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${GITHUB_REF_NAME}"
-          # Delete any existing release (published releases are immutable
-          # and block asset uploads). The tag is preserved.
+          COMMIT="${GITHUB_SHA}"
+          # Clean up any pre-existing release AND tag. Published releases
+          # are immutable (org rulesets) so both must be removed first.
           if gh release view "$TAG" >/dev/null 2>&1; then
-            gh release delete "$TAG" --yes
+            gh release delete "$TAG" --yes --cleanup-tag
           fi
-          # Create a draft release, upload assets, then publish.
+          # Recreate tag + release with assets in one atomic step.
           gh release create "$TAG" dist/* \
-            --draft \
+            --target "$COMMIT" \
             --title "$TAG" \
             --generate-notes
-          gh release edit "$TAG" --draft=false --latest


### PR DESCRIPTION
## Summary

Use `gh release delete --cleanup-tag` to remove both release AND tag before recreating. This avoids the immutable release error from org rulesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)