### PR TITLE
fix(config): remove empty else-if branch (SA9003)

### DIFF
--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -1795,6 +1795,10 @@ func compileSecrets(in *SecretsBlock) (map[string]SecretConfig, ValidationResult
 
 		maxVersions := 0
 		if s.MaxVersionsSet {
+			if !runtime {
+				res.Errors = append(res.Errors, fmt.Sprintf("secret %q max_versions is only valid when runtime = true", id))
+				continue
+			}
 			rawMax := strings.TrimSpace(resolveValue(s.MaxVersions, fmt.Sprintf("secret %q max_versions", id), &res))
 			n, err := strconv.Atoi(rawMax)
 			if err != nil || n < 1 {
@@ -1802,13 +1806,6 @@ func compileSecrets(in *SecretsBlock) (map[string]SecretConfig, ValidationResult
 				continue
 			}
 			maxVersions = n
-		} else if !runtime {
-			// Non-runtime pools keep the legacy single-version behaviour; MaxVersions is irrelevant.
-		}
-
-		if !runtime && s.MaxVersionsSet {
-			res.Errors = append(res.Errors, fmt.Sprintf("secret %q max_versions is only valid when runtime = true", id))
-			continue
 		}
 
 		// value + valid_from: required when not runtime, optional (as bootstrap seed) when runtime.


### PR DESCRIPTION
## Summary

Fixes the staticcheck SA9003 lint failure introduced by [#148](https://github.com/nuetzliches/hookaido/pull/148). The empty `else if !runtime { /* comment */ }` branch was dead code; merging the guard into the same `if s.MaxVersionsSet` block makes the intent clearer and satisfies the linter.

No behavioural change — the `max_versions is only valid when runtime = true` error path is preserved and still covered by `TestCompile_MaxVersionsOnlyWithRuntime`.

## Test plan

- [x] `go test ./internal/config/...` green
- [x] `go vet ./...` clean
- [ ] CI lint passes this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)