### PR TITLE
feat(admin): exempt GET /healthz from admin auth for liveness probes (#153)

### DIFF
--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -25,9 +25,11 @@ admin_api {
 
 Returns `200` when the instance is healthy.
 
+> **Always unauthenticated.** Even when `admin_api.auth token ...` is configured, bare `GET /healthz` (no query string) bypasses the bearer guard so orchestrator liveness probes (Docker healthcheck, Kubernetes `livenessProbe`, cloud load balancers) can probe without credentials. The response body is the static string `ok\n` — no deployment-sensitive information is exposed. Any query string on `/healthz` (including `?details=0`) keeps the route auth-gated.
+
 ### `GET /healthz?details=1`
 
-Returns detailed JSON diagnostics:
+Returns detailed JSON diagnostics (follows `admin_api.auth` — requires bearer token when configured):
 
 ```json
 {

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -220,12 +220,21 @@ func NewServer(store queue.Store) *Server {
 }
 
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	cleanPath := path.Clean(r.URL.Path)
+
+	// Unauthenticated liveness probe: bare GET /healthz (no query string) bypasses
+	// the admin auth guard so orchestrator health checks (Docker healthcheck,
+	// Kubernetes livenessProbe, load balancers) can probe without a bearer token.
+	// /healthz with any query string (e.g. ?details=1) still follows admin auth.
+	if r.Method == http.MethodGet && cleanPath == "/healthz" && r.URL.RawQuery == "" {
+		s.handleHealthz(w, r)
+		return
+	}
+
 	if s.Authorize != nil && !s.Authorize(r) {
 		writeManagementError(w, http.StatusUnauthorized, readCodeUnauthorized, "request is not authorized")
 		return
 	}
-
-	cleanPath := path.Clean(r.URL.Path)
 	if strings.HasPrefix(cleanPath, "/applications/") {
 		s.handleApplicationResource(w, r, cleanPath)
 		return

--- a/internal/admin/http_test.go
+++ b/internal/admin/http_test.go
@@ -1689,6 +1689,89 @@ func TestServer_DLQAuth(t *testing.T) {
 	}
 }
 
+func TestServer_HealthzBypassesAuth(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("secret")})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/healthz", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 without token, got %d", rr.Code)
+	}
+	if rr.Body.String() != "ok\n" {
+		t.Fatalf("unexpected body: %q", rr.Body.String())
+	}
+}
+
+func TestServer_HealthzDetailsRequiresAuth(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("secret")})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/healthz?details=1", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for details without token, got %d", rr.Code)
+	}
+	errResp := decodeManagementError(t, rr)
+	if errResp.Code != readCodeUnauthorized {
+		t.Fatalf("expected code=%q, got %q", readCodeUnauthorized, errResp.Code)
+	}
+}
+
+func TestServer_HealthzDetailsWithAuth(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("secret")})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/healthz?details=1", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200 with token, got %d", rr.Code)
+	}
+	var out map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if ok, _ := out["ok"].(bool); !ok {
+		t.Fatalf("expected ok=true, body=%s", rr.Body.String())
+	}
+}
+
+func TestServer_HealthzEmptyQueryStringStillAuths(t *testing.T) {
+	// Guard against a regression where /healthz?details=0 (query present, value
+	// coerces to false) gets treated the same as bare /healthz. Per the acceptance
+	// criteria in issue #153, any query string keeps the route auth-gated.
+	srv := NewServer(queue.NewMemoryStore())
+	srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("secret")})
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/healthz?details=0", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for /healthz?details=0 without token, got %d", rr.Code)
+	}
+}
+
+func TestServer_HealthzPostRequiresAuth(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("secret")})
+
+	req := httptest.NewRequest(http.MethodPost, "http://example/healthz", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for POST /healthz without token, got %d", rr.Code)
+	}
+}
+
 func TestServer_ListDLQ(t *testing.T) {
 	now := time.Date(2026, 2, 4, 12, 0, 0, 0, time.UTC)
 	store := queue.NewMemoryStore(queue.WithNowFunc(func() time.Time { return now }))


### PR DESCRIPTION
## Summary

- Short-circuits bare `GET /healthz` (no query string) before the admin `Authorize` guard so Docker healthchecks, K8s `livenessProbe` and LB probes can reach it without a bearer token.
- `/healthz?details=1` (and any other query string, including `?details=0`) stays auth-gated — the diagnostic payload leaks queue/backlog/ingress telemetry that should follow `admin_api.auth`.
- Body for the bare path is the static `ok\n`; no deployment-sensitive info exposed, so the security posture matches a TCP-level port-reachability probe.

Fixes #153.

## Test plan

- [x] `go test ./internal/admin/...` — 5 new cases plus the existing 4 healthz tests all pass.
  - `HealthzBypassesAuth` — bare `/healthz` with `Authorize` set → 200 `ok\n`.
  - `HealthzDetailsRequiresAuth` — `/healthz?details=1` without token → 401 `unauthorized`.
  - `HealthzDetailsWithAuth` — `/healthz?details=1` with valid Bearer → 200 JSON.
  - `HealthzEmptyQueryStringStillAuths` — `/healthz?details=0` without token → 401 (regression guard for the acceptance-criteria decision: any query string keeps auth).
  - `HealthzPostRequiresAuth` — `POST /healthz` without token → 401 (unchanged, early-return only fires on GET).
- [x] `go test ./...` — full suite green.
- [x] `go vet ./...` — clean.
- [x] Docs updated: [docs/admin-api.md §Health](docs/admin-api.md#health) calls out the auth semantics for both variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)