### PR TITLE
docs(changelog): cut v2.7.1 (#153 healthz auth bypass)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-04-21
+
+### Fixed
+
+- Bare `GET /healthz` (no query string) now bypasses the `admin_api.auth token` guard so orchestrator liveness probes (Docker healthcheck, Kubernetes `livenessProbe`, cloud load balancers) can reach it without a bearer token ([#153](https://github.com/nuetzliches/hookaido/issues/153)). `/healthz?details=1` (and any other query string, including `?details=0`) still follows admin auth — the diagnostic payload leaks queue/backlog/ingress telemetry that must stay gated. Removes the `CMD-SHELL` Bearer-token workaround required by v2.7.0 deployments with admin auth enabled; the static `ok\n` response body exposes no deployment-sensitive information.
+
 ## [2.7.0] - 2026-04-21
 
 ### Added


### PR DESCRIPTION
## Summary

- Adds `[2.7.1] - 2026-04-21` section to [CHANGELOG.md](CHANGELOG.md) documenting the bare-`/healthz` auth-bypass fix merged in #154.
- Patch-level bump (rückwärtskompatibel — ein mitgesendeter Token wird auf `/healthz` einfach ignoriert; gleiche Response).

## Test plan

- [x] CHANGELOG entry accurately reflects the #154 scope (bare `GET /healthz` exempt, `?details=1` and other query strings still gated).
- [x] Patch-level bump is semver-correct (bug fix, backwards-compatible — existing deployments with token-based healthchecks keep working).
- [ ] After merge: tag `v2.7.1` on the CHANGELOG commit (same pattern as `v2.7.0` → `d43b3fb`), push tag, `release.yml` builds signed artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)