### PR TITLE
fix(ingress): cituro parses t= as milliseconds

### DIFF
--- a/internal/ingress/hmac.go
+++ b/internal/ingress/hmac.go
@@ -168,12 +168,15 @@ func (a *HMACAuth) verifyProvider(r *http.Request, body []byte) error {
 	case "gitea":
 		return a.verifyGitea(r, body, secrets)
 	case "stripe":
-		return a.verifyStripe(r, body, secrets, "Stripe-Signature", "v1")
+		return a.verifyStripe(r, body, secrets, "Stripe-Signature", "v1", time.Second)
 	case "cituro":
 		// Cituro uses the same "t=<ts>,<tag>=<hex>" header format and
 		// "<ts>.<body>" signed-payload scheme as Stripe, but with a
-		// different header name and signature tag.
-		return a.verifyStripe(r, body, secrets, "X-CITURO-SIGNATURE", "s")
+		// different header name, signature tag, and timestamp unit:
+		// Cituro emits t= as Unix milliseconds (13-digit), Stripe as
+		// Unix seconds (10-digit). The PDF's truncated "t=1592..." example
+		// hid the unit; confirmed from live X-CITURO-SIGNATURE headers.
+		return a.verifyStripe(r, body, secrets, "X-CITURO-SIGNATURE", "s", time.Millisecond)
 	default:
 		return ErrUnauthorized
 	}
@@ -235,12 +238,19 @@ func (a *HMACAuth) verifyGitea(r *http.Request, body []byte, secrets [][]byte) e
 // same scheme with different header + tag names — e.g. Cituro uses
 // `X-CITURO-SIGNATURE` with sigTag "s".)
 //
-// String-to-sign: "<ts>.<body>" (HMAC-SHA256, lowercase hex).
+// String-to-sign: "<ts>.<body>" (HMAC-SHA256, lowercase hex). The ts used
+// in the signed payload is the *raw string* from the header, so senders
+// that emit ms-precision timestamps and senders emitting second-precision
+// both work as long as their Hookaido-side tsUnit matches.
+//
+// tsUnit selects how the numeric t= value is interpreted for the
+// tolerance check: time.Second for Stripe (10-digit unix seconds),
+// time.Millisecond for Cituro (13-digit unix milliseconds).
 //
 // Replay protection: the timestamp must be within a.Tolerance of the current
 // time (default 5m). No nonce — retries within the tolerance window are
 // accepted, which matches Stripe/Cituro semantics.
-func (a *HMACAuth) verifyStripe(r *http.Request, body []byte, secrets [][]byte, headerName, sigTag string) error {
+func (a *HMACAuth) verifyStripe(r *http.Request, body []byte, secrets [][]byte, headerName, sigTag string, tsUnit time.Duration) error {
 	raw := strings.TrimSpace(r.Header.Get(headerName))
 	if raw == "" {
 		slog.Warn("hmac_stripe_failed", "reason", "header_missing", "header", headerName)
@@ -289,11 +299,14 @@ func (a *HMACAuth) verifyStripe(r *http.Request, body []byte, secrets [][]byte, 
 	if a.Now != nil {
 		now = a.Now
 	}
-	t := time.Unix(ts, 0).UTC()
+	// Convert the raw numeric ts into absolute time via the provider-specific
+	// unit (seconds for stripe, milliseconds for cituro). time.Unix(0, ns)
+	// takes nanoseconds so we multiply by tsUnit (a time.Duration = int64 ns).
+	t := time.Unix(0, ts*int64(tsUnit)).UTC()
 	if d := now().UTC().Sub(t); d < -tolerance || d > tolerance {
 		slog.Warn("hmac_stripe_failed", "reason", "ts_out_of_tolerance",
-			"header", headerName, "ts_unix", ts, "delta_seconds", d.Seconds(),
-			"tolerance_seconds", tolerance.Seconds())
+			"header", headerName, "ts_unix", ts, "ts_unit", tsUnit.String(),
+			"delta_seconds", d.Seconds(), "tolerance_seconds", tolerance.Seconds())
 		return ErrUnauthorized
 	}
 

--- a/internal/ingress/hmac_test.go
+++ b/internal/ingress/hmac_test.go
@@ -388,7 +388,8 @@ func TestHMACAuth_VerifyStripe_MalformedHeader(t *testing.T) {
 	}
 }
 
-// Cituro reuses the Stripe scheme with a different header and sig tag.
+// Cituro reuses the Stripe scheme with a different header and sig tag,
+// plus millisecond-precision timestamps instead of seconds.
 func TestHMACAuth_VerifyCituro(t *testing.T) {
 	secret := []byte("whs_cituro_abc123")
 	body := []byte(`{"eventId":"11f0","type":"booking.created"}`)
@@ -399,10 +400,30 @@ func TestHMACAuth_VerifyCituro(t *testing.T) {
 	auth.Now = func() time.Time { return now }
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/webhooks/cituro", bytes.NewReader(body))
-	req.Header.Set("X-CITURO-SIGNATURE", signStripe(now.Unix(), body, secret, "s"))
+	req.Header.Set("X-CITURO-SIGNATURE", signStripe(now.UnixMilli(), body, secret, "s"))
 
 	if err := auth.Verify(req, "/webhooks/cituro", body); err != nil {
 		t.Fatalf("expected verify ok for cituro alias, got %v", err)
+	}
+}
+
+func TestHMACAuth_VerifyCituro_RejectsSecondsTimestamp(t *testing.T) {
+	// Regression guard: a second-precision timestamp (Stripe-style) against
+	// the cituro provider must be rejected as out-of-tolerance (interpreted
+	// as 1970-era after the ms->ns conversion).
+	secret := []byte("whs_cituro_abc123")
+	body := []byte(`{"type":"booking.created"}`)
+	now := time.Unix(1735689600, 0).UTC()
+
+	auth := NewHMACAuth([][]byte{secret})
+	auth.Provider = "cituro"
+	auth.Now = func() time.Time { return now }
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/webhooks/cituro", bytes.NewReader(body))
+	req.Header.Set("X-CITURO-SIGNATURE", signStripe(now.Unix(), body, secret, "s"))
+
+	if err := auth.Verify(req, "/webhooks/cituro", body); err == nil {
+		t.Fatalf("expected unauthorized when seconds-precision ts is used with cituro provider")
 	}
 }
 
@@ -416,7 +437,7 @@ func TestHMACAuth_VerifyCituro_InvalidSignature(t *testing.T) {
 	auth.Now = func() time.Time { return now }
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/webhooks/cituro", bytes.NewReader(body))
-	req.Header.Set("X-CITURO-SIGNATURE", signStripe(now.Unix(), body, []byte("wrong"), "s"))
+	req.Header.Set("X-CITURO-SIGNATURE", signStripe(now.UnixMilli(), body, []byte("wrong"), "s"))
 
 	if err := auth.Verify(req, "/webhooks/cituro", body); err == nil {
 		t.Fatalf("expected unauthorized for invalid cituro signature")
@@ -435,7 +456,7 @@ func TestHMACAuth_VerifyCituro_WrongTag(t *testing.T) {
 	auth.Now = func() time.Time { return now }
 
 	req := httptest.NewRequest(http.MethodPost, "http://example.com/webhooks/cituro", bytes.NewReader(body))
-	req.Header.Set("X-CITURO-SIGNATURE", signStripe(now.Unix(), body, secret, "v1"))
+	req.Header.Set("X-CITURO-SIGNATURE", signStripe(now.UnixMilli(), body, secret, "v1"))
 
 	if err := auth.Verify(req, "/webhooks/cituro", body); err == nil {
 		t.Fatalf("expected unauthorized when sig tag doesn't match provider")


### PR DESCRIPTION
## Summary

Cituro's \`X-CITURO-SIGNATURE\` header emits \`t=\` as Unix milliseconds (13 digits), not seconds. \`verifyStripe\` assumed seconds, so every Cituro webhook produced \`ts_out_of_tolerance\` (~56,000-year drift) and 401.

## Evidence

From the diagnostic WARN added in #156:
\`\`\`json
{
  \"level\": \"WARN\",
  \"msg\": \"hmac_stripe_failed\",
  \"reason\": \"ts_out_of_tolerance\",
  \"header\": \"X-CITURO-SIGNATURE\",
  \"ts_unix\": 1776778623592,
  \"delta_seconds\": -9223372036.854776,
  \"tolerance_seconds\": 300
}
\`\`\`
\`1776778623592\` / 1000 = valid 2026-04-21 unix-seconds. The PDF (§7.3) showed a truncated \`t=1592…\` — the digit count hid the unit.

## Change

- \`verifyStripe\` gains a \`tsUnit time.Duration\` parameter. Stripe stays on \`time.Second\`, Cituro switches to \`time.Millisecond\`.
- Raw \`tsStr\` in the signed payload unchanged — signatures stay compatible with what Cituro actually signs.
- \`ts_unit\` added to \`ts_out_of_tolerance\` WARN log; future unit mismatches diagnosed in a single glance.

## Tests

- Updated cituro tests to use \`UnixMilli()\`.
- New regression test \`TestHMACAuth_VerifyCituro_RejectsSecondsTimestamp\` — seconds-ts against cituro must be rejected.
- \`go test ./internal/ingress/\`: all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)