### PR TITLE
fix(security): bump Go 1.25.9 -> 1.26.4 to fix reachable stdlib vulns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-06-04
+
+### Security
+
+- Bump Go toolchain `1.25.9` → `1.26.4` to remediate two reachable standard-library vulnerabilities reported by `govulncheck`: **GO-2026-5039** (`net/textproto`, unescaped input in errors — reachable via `ingress.Server.ServeHTTP` → `ReadMIMEHeader`) and **GO-2026-5037** (`crypto/x509`, inefficient candidate hostname parsing — reachable via `dispatcher.HTTPDeliverer.Deliver` → `Certificate.Verify`/`VerifyHostname`). `govulncheck ./...` now reports no findings.
+
+### Changed
+
+- Routine dependency bumps since 2.8.0 (Go modules and GitHub Actions, via Dependabot `go-patch-minor` / `actions-patch-minor` groups), including the `golang:1.26-alpine` build-image digest.
+
 ## [2.8.0] - 2026-05-09
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuetzliches/hookaido/v2
 
-go 1.25.9
+go 1.26.4
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1


### PR DESCRIPTION
## Summary

- Bumps the Go toolchain directive in `go.mod` from `1.25.9` to `1.26.4`.
- Remediates two **reachable** standard-library vulnerabilities flagged by `govulncheck` (verified locally — `govulncheck ./...` now reports *No vulnerabilities found*):
  - **GO-2026-5039** (`net/textproto`): unescaped input in errors — reachable via `ingress.Server.ServeHTTP` → `ReadMIMEHeader` (`internal/ingress/http.go:108`).
  - **GO-2026-5037** (`crypto/x509`): inefficient candidate hostname parsing — reachable via `dispatcher.HTTPDeliverer.Deliver` → `Certificate.Verify`/`VerifyHostname` (`internal/dispatcher/http_deliverer.go:82`).
- Adds a `[2.8.1]` CHANGELOG entry.

CI/release build via `setup-go` with `go-version-file: go.mod`, so this bump propagates the patched toolchain to all builds.

## Test plan

- [x] `go build ./...` (toolchain auto-upgrades to go1.26.4)
- [x] `go vet ./...`
- [x] `govulncheck ./...` → No vulnerabilities found
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)