### PR TITLE
ci(release): replace actions/attest-sbom with actions/attest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,7 @@ jobs:
           subject-checksums: "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_checksums.txt"
       - name: Attest SBOM
         id: attest_sbom
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-checksums: "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_checksums.txt"
           sbom-path: "dist/hookaido_${{ steps.version_meta.outputs.safe_version }}_sbom.spdx.json"

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -149,8 +149,8 @@ Tag-based release workflow is defined in `.github/workflows/release.yml`.
 - Build: signed artifacts via `internal/tools/release`
 - Verify: `hookaido verify-release --require-signature --require-sbom` must pass before publish
 - Attestations:
-  - `actions/attest-build-provenance@v3` for release artifacts (`subject-checksums`)
-  - `actions/attest-sbom@v3` bound to `hookaido_<version>_sbom.spdx.json`
+  - `actions/attest-build-provenance@v4` for release artifacts (`subject-checksums`)
+  - `actions/attest@v4` with `sbom-path` bound to `hookaido_<version>_sbom.spdx.json` (predicate type `https://spdx.dev/Document/v2.3`)
 - Exported attestation bundles:
   - `hookaido_<version>_provenance.intoto.jsonl`
   - `hookaido_<version>_sbom.intoto.jsonl`


### PR DESCRIPTION
## Summary

Swaps the SBOM attestation step in `.github/workflows/release.yml` from `actions/attest-sbom` to `actions/attest`.

`actions/attest-sbom` has stalled at v4.1.0, while `actions/attest` — the generic attestation action GitHub actively maintains — has continued to v4.2.2 and runs on `node24`. It still accepts the same `subject-checksums` + `sbom-path` input pair, so this is a drop-in replacement:

- SBOM predicate type stays `https://spdx.dev/Document/v2.3`, which is exactly what `internal/app/verify_release_cmd.go` (`sbomAttestPredicateType`) checks for.
- The `attest_sbom` step id and its `bundle-path` output are unchanged, so `hookaido_<version>_sbom.attestation.json` and `hookaido_<version>_sbom.intoto.jsonl` keep their names and contents.
- Pinned by SHA (`1e69f48acb82d1966a394da916b4c1698aa569d6` = v4.2.2), consistent with the rest of the workflow.

Also refreshes the `RELEASE.md` attestation section, which still documented `@v3` for both attest actions while the workflow already pins v4.

## Related Issues

n/a

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [x] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally — n/a, no Go code touched; `release-package-dryrun` covers the workflow
- [ ] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes (`RELEASE.md`)
- [ ] Updated `CHANGELOG.md` for user-visible behavior changes — no user-visible behavior change
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable) — attestation predicate type and `id-token`/`attestations` permissions unchanged
- [x] Backward compatibility considered — bundle filenames and predicate type unchanged, so previously published attestations stay verifiable

## Notes for Reviewers

The real proof runs on the next `v*.*.*` tag, since `release.yml` is tag-triggered. `release-package-dryrun` validates the packaging path but not the attest step itself. If the SBOM attestation were to regress, `hookaido verify-release --require-sbom` would catch it — that step runs *before* attestation, so verification of the published bundle is the manual check worth doing on the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)