### PR TITLE
fix(security): bump Go toolchain 1.26.4 → 1.26.6 (8 reachable stdlib vulns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Security
+
+- Bump Go toolchain `1.26.4` → `1.26.6` to remediate eight reachable standard-library vulnerabilities reported by `govulncheck`:
+  - **GO-2026-6218** (`net/url`, quadratic complexity in `resolvePath` — reachable via `dispatcher.HTTPDeliverer.Deliver` → `http.Client.Do` → `url.URL.Parse`)
+  - **GO-2026-6091** (`html/template`, JavaScript regexp context tracking — reachable via `app.serveOnListener` → `http.Server.Serve` → `template.Template.Execute`)
+  - **GO-2026-6090** (`crypto/tls`, unbounded post-handshake messages — reachable via `app.serveOnListener` → `http.Server.Serve` and `grpcworker.grpcWorkerModule.Serve` → `grpc.Server.Serve`)
+  - **GO-2026-6089** (`net/http`, `ReadHeaderTimeout` not applied during the unencrypted HTTP/2 check — reachable via `app.serveOnListener` → `http.Server.Serve`)
+  - **GO-2026-6088** (`encoding/xml`, missing recursion-depth guard during decode — reachable via `sqlite.Store.ListAttempts` → `sql.Rows.Next` → `xml.Unmarshal`)
+  - **GO-2026-5972** (`encoding/asn1`, unbounded recursion depth — reachable via `release.loadEd25519PrivateKey` → `x509.ParsePKCS8PrivateKey`)
+  - **GO-2026-5856** (`crypto/tls`, Encrypted Client Hello privacy leak — reachable via the same TLS entry points as GO-2026-6090)
+  - **GO-2026-5026** (`net/http`, `golang.org/x/net/idna` failing to reject ASCII-only Punycode-encoded labels — reachable via `dispatcher.HTTPDeliverer.Deliver` → `http.Client.Do`)
+
+  `govulncheck ./...` now reports no findings.
+
 ## [2.9.0] - 2026-07-01
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nuetzliches/hookaido/v2
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/fsnotify/fsnotify v1.10.1


### PR DESCRIPTION
## Summary

`govulncheck` has been failing on `main` — it reports **eight reachable standard-library vulnerabilities** against the pinned `go 1.26.4`. Seven are fixed in go1.26.6, one (GO-2026-5856) in go1.26.5, so bumping the `go` directive to `1.26.6` clears all of them.

| ID | Package | Issue | Reachable via |
|---|---|---|---|
| GO-2026-6218 | `net/url` | quadratic complexity in `resolvePath` | `dispatcher.HTTPDeliverer.Deliver` → `http.Client.Do` → `url.URL.Parse` |
| GO-2026-6091 | `html/template` | JavaScript regexp context tracking | `app.serveOnListener` → `http.Server.Serve` → `template.Template.Execute` |
| GO-2026-6090 | `crypto/tls` | unbounded post-handshake messages | `app.serveOnListener`, `grpcworker.grpcWorkerModule.Serve` |
| GO-2026-6089 | `net/http` | `ReadHeaderTimeout` not applied in the unencrypted HTTP/2 check | `app.serveOnListener` → `http.Server.Serve` |
| GO-2026-6088 | `encoding/xml` | missing recursion-depth guard during decode | `sqlite.Store.ListAttempts` → `sql.Rows.Next` → `xml.Unmarshal` |
| GO-2026-5972 | `encoding/asn1` | unbounded recursion depth | `release.loadEd25519PrivateKey` → `x509.ParsePKCS8PrivateKey` |
| GO-2026-5856 | `crypto/tls` | Encrypted Client Hello privacy leak | same TLS entry points as GO-2026-6090 |
| GO-2026-5026 | `net/http` | `x/net/idna` fails to reject ASCII-only Punycode labels | `dispatcher.HTTPDeliverer.Deliver` → `http.Client.Do` |

The reachability traces are not theoretical — they land on the listener path, the delivery path, the SQLite store and the release signer.

One line in `go.mod` is enough: every workflow resolves its Go version through `go-version-file: go.mod`, and the container build honours the same directive via `GOTOOLCHAIN`. No Dockerfile change needed — the `golang:1.26-alpine` digest pin is Dependabot's business (see #190).

## Related Issues

n/a — surfaced by the failing `govulncheck` job, e.g. [this run](https://github.com/nuetzliches/hookaido/actions/runs/32021614224/job/95362296985).

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [x] CI / release pipeline

## Validation

Locally on go1.26.6 (Windows):

- [x] `go test ./...` passed locally
- [x] `go build ./...` and `go vet ./...` clean
- [x] `govulncheck ./...` → **No vulnerabilities found** (was: 8 findings)
- [ ] Added or updated tests for behavioral changes — none, toolchain-only
- [ ] Updated docs for user-visible changes — `CONTRIBUTING.md` says `1.26.x`, still accurate
- [x] Updated `CHANGELOG.md` for user-visible behavior changes (`[Unreleased]` → `Security`)
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable) — two of the eight sit on TLS/auth-adjacent paths (ECH privacy leak, post-handshake message flooding)
- [x] Backward compatibility considered — patch-level toolchain bump, no language or API change

## Notes for Reviewers

Worth knowing while reviewing: **`govulncheck` is not a required status check** on `main` — required are only `test (ubuntu-latest)`, `test (windows-latest)`, `release-package-dryrun` and `CodeQL (go) (go)`. That is why #185 auto-merged earlier today with this gate already red, and why the finding sat on `main` unnoticed. Promoting `govulncheck` (and possibly `lint`) to required is a repo-settings change, deliberately left out of this PR.

If you want to reproduce the "before" state: `git stash` the `go.mod` line and run `govulncheck ./...` with a govulncheck binary built by go1.26.x — a binary built with go1.25 refuses to analyse the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)