### PR TITLE
fix(ingress): stop logging the raw signature header on HMAC parse failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ### Security
 
+- The `hmac_stripe_failed` / `reason=parse_incomplete` rejection log no longer contains the raw signature header. Previously the `header_value` field carried the untouched `cfg.Header` value, so a request that omitted `t=` but supplied a full `v1=<64 hex chars>` signature wrote that signature verbatim into the WARN log — an attacker-triggerable path, since malformed input is exactly what reaches it. The field is replaced by `pairs_parsed` (number of `k=v` pairs found) and `header_value_len`, which together with the already-logged, config-derived `sig_tag` still identify the realistic cause: the sender emits a different tag name than the route expects. This restores the fingerprints-only contract the other five rejection paths already followed. Reported by CodeQL as `go/clear-text-logging`.
+
 - Bump Go toolchain `1.26.4` → `1.26.6` to remediate eight reachable standard-library vulnerabilities reported by `govulncheck`:
   - **GO-2026-6218** (`net/url`, quadratic complexity in `resolvePath` — reachable via `dispatcher.HTTPDeliverer.Deliver` → `http.Client.Do` → `url.URL.Parse`)
   - **GO-2026-6091** (`html/template`, JavaScript regexp context tracking — reachable via `app.serveOnListener` → `http.Server.Serve` → `template.Template.Execute`)

--- a/internal/ingress/hmac.go
+++ b/internal/ingress/hmac.go
@@ -292,11 +292,13 @@ func (a *HMACAuth) verifyStripeLike(r *http.Request, body []byte, secrets [][]by
 	}
 
 	var tsStr, sigHex string
+	pairs := 0
 	for _, part := range strings.Split(raw, ",") {
 		kv := strings.SplitN(strings.TrimSpace(part), "=", 2)
 		if len(kv) != 2 {
 			continue
 		}
+		pairs++
 		key := strings.TrimSpace(kv[0])
 		val := strings.TrimSpace(kv[1])
 		switch key {
@@ -311,10 +313,16 @@ func (a *HMACAuth) verifyStripeLike(r *http.Request, body []byte, secrets [][]by
 		}
 	}
 	if tsStr == "" || sigHex == "" {
+		// Never log `raw` here: this path is reached with attacker-controlled
+		// input, and a header that is missing "t=" can still carry a full
+		// signature (and vice versa). `pairs_parsed` alongside the *configured*
+		// `sig_tag` pins down the realistic cause -- the sender emits a
+		// different tag name than the route expects -- without moving header
+		// material into the log.
 		slog.Warn("hmac_stripe_failed", "reason", "parse_incomplete",
 			"header", cfg.Header, "sig_tag", cfg.SigTag,
 			"ts_present", tsStr != "", "sig_present", sigHex != "",
-			"header_value", raw)
+			"pairs_parsed", pairs, "header_value_len", len(raw))
 		return ErrUnauthorized
 	}
 

--- a/internal/ingress/hmac_test.go
+++ b/internal/ingress/hmac_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -384,6 +385,51 @@ func TestHMACAuth_VerifyStripe_MalformedHeader(t *testing.T) {
 		}
 		if err := auth.Verify(req, "/webhooks/stripe", body); err == nil {
 			t.Fatalf("expected unauthorized for malformed header %q", h)
+		}
+	}
+}
+
+// The parse_incomplete rejection path must not move header material into the
+// log. A header that fails to parse can still carry a complete signature --
+// here the tag name simply does not match what the route expects. Guards the
+// diagnostic fingerprint contract documented on verifyStripeLike.
+func TestHMACAuth_VerifyStripe_ParseIncompleteDoesNotLogHeaderValue(t *testing.T) {
+	secret := []byte("stripe-webhook-secret")
+	body := []byte(`{"id":"evt_123"}`)
+	now := time.Unix(1735689600, 0).UTC()
+
+	// Valid signature under an unexpected tag and without "t=", so parsing
+	// fails while the signature itself is fully present in the header.
+	mac := hmac.New(sha256.New, secret)
+	_, _ = mac.Write([]byte("1735689600." + string(body)))
+	sigHex := hex.EncodeToString(mac.Sum(nil))
+
+	var logs bytes.Buffer
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelWarn})))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	auth := NewHMACAuth([][]byte{secret})
+	auth.Provider = "stripe"
+	auth.Now = func() time.Time { return now }
+
+	req := httptest.NewRequest(http.MethodPost, "http://example.com/webhooks/stripe", bytes.NewReader(body))
+	req.Header.Set("Stripe-Signature", "v0="+sigHex)
+
+	if err := auth.Verify(req, "/webhooks/stripe", body); err == nil {
+		t.Fatalf("expected unauthorized for header without timestamp")
+	}
+
+	out := logs.String()
+	if !strings.Contains(out, "parse_incomplete") {
+		t.Fatalf("expected parse_incomplete warning, got: %s", out)
+	}
+	if strings.Contains(out, sigHex) {
+		t.Fatalf("signature leaked into log output: %s", out)
+	}
+	for _, want := range []string{"pairs_parsed=1", "header_value_len=", "sig_present=false", "ts_present=false"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %q in log output, got: %s", want, out)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Fixes CodeQL alert **#63** (`go/clear-text-logging`, high) in `internal/ingress/hmac.go:317`.

The `reason=parse_incomplete` branch of `verifyStripeLike` logged `header_value` with the untouched signature header. A request that omits `t=` but supplies a full `v1=<64 hex chars>` signature wrote that signature verbatim into the WARN log. The path is reached with attacker-controlled input by definition — rejecting malformed headers is what it exists for — so it can be triggered at will.

It also contradicted the contract the function documents for itself ([hmac.go:282-286](https://github.com/nuetzliches/hookaido/blob/main/internal/ingress/hmac.go#L282-L286)) and that its other five rejection paths already honour:

> Diagnostic WARN logs fire on every rejection path […] with non-sensitive fingerprints (byte counts, 8-char hex prefixes — **never raw secrets or full signatures**).

**Before** (actual output from the new test run against the old code):

```
level=WARN msg=hmac_stripe_failed reason=parse_incomplete header=Stripe-Signature sig_tag=v1 ts_present=false sig_present=false header_value="v0=f4c14b89654deb57f52c8c05d78fdb277b55c667ef17da60c5351f4252ef43f0"
```

**After:**

```
level=WARN msg=hmac_stripe_failed reason=parse_incomplete header=Stripe-Signature sig_tag=v1 ts_present=false sig_present=false pairs_parsed=1 header_value_len=67
```

Neither replacement field carries header material. Together with the already-logged `sig_tag` — which is config-derived, not attacker-derived — they still pin down the realistic cause of this rejection: the sender emits a different tag name than the route expects.

### On the three sibling alerts

**#64, #65 and #66 on this same file are false positives and are deliberately not touched.** Those lines log `len(sigHex)`, 6- and 8-character prefixes via `safePrefix()`, and the failed timestamp string. CodeQL flags them because the taint originates in a header it classifies as sensitive; it does not model `safePrefix()` or a slice expression as a sanitizer. They need dismissing in the UI, not code changes.

Whether **#63 itself** closes is less certain than the fix is correct: `header_value_len` is an `int` derived from the header, and taint normally does not flow through `len()`, so the path should disappear — but if CodeQL still reports it, it joins the other three as a dismissal rather than a code problem.

## Related Issues

CodeQL alert [#63](https://github.com/nuetzliches/hookaido/security/code-scanning/63).

## Scope

- [ ] DSL / config behavior
- [x] Runtime behavior — log field contents on one rejection path
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally (go1.26.6)
- [x] `go vet ./...` clean; `gofmt` clean on both touched files
- [x] Added or updated tests for behavioral changes — `TestHMACAuth_VerifyStripe_ParseIncompleteDoesNotLogHeaderValue`, verified to **fail against the previous code** with the leaked signature visible in the failure message
- [ ] Updated docs for user-visible changes — the contract is documented in the function comment and was already worded this way
- [x] Updated `CHANGELOG.md` for user-visible behavior changes (`[Unreleased]` → `Security`)
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed — verification behaviour is unchanged; only what the rejection path logs changes. No request that previously verified now fails, and none that failed now passes.
- [x] Backward compatibility considered — see note below

## Notes for Reviewers

**Operator-visible change:** the `header_value` field disappears from `hmac_stripe_failed` events. Anyone with log-based alerting or a dashboard keyed on that field needs to move to `pairs_parsed` / `header_value_len`. That is the intended trade — the field's diagnostic value did not justify carrying signatures into log storage.

The test swaps the global `slog` default to capture output and restores it via `t.Cleanup`. No other test in this package does that; the package's tests do not run in parallel, so the global swap is contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)