### PR TITLE
fix(postgres): treat empty Route/Target in Dequeue as a wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **Push delivery never fired on the Postgres queue backend** ([#200](https://github.com/nuetzliches/hookaido/issues/200)). `Dequeue` filtered unconditionally on `route = $1 AND target = $2`, while the memory and SQLite backends treat an empty field as "any". The push dispatcher relies on that wildcard — it dequeues per route without naming a target and resolves the target per item afterwards — so on Postgres the query resolved to `target = ''` and matched nothing. Ingress enqueued normally, nothing was ever delivered, and the backlog grew until `max_depth` began rejecting, with no error logged because the queue simply looked empty to the dispatcher. Pull routes were unaffected, since those pass an explicit target. The `WHERE` clause is now built conditionally, matching the other two backends and the existing `ListMessages` query in the same file. A new `queue.Store` contract case covers all three wildcard combinations — every pre-existing contract test named both fields explicitly, which is why the divergence went unnoticed.
+
 ### Security
 
 - The `hmac_stripe_failed` / `reason=parse_incomplete` rejection log no longer contains the raw signature header. Previously the `header_value` field carried the untouched `cfg.Header` value, so a request that omitted `t=` but supplied a full `v1=<64 hex chars>` signature wrote that signature verbatim into the WARN log — an attacker-triggerable path, since malformed input is exactly what reaches it. The field is replaced by `pairs_parsed` (number of `k=v` pairs found) and `header_value_len`, which together with the already-logged, config-derived `sig_tag` still identify the realistic cause: the sender emits a different tag name than the route expects. This restores the fingerprints-only contract the other five rejection paths already followed. Reported by CodeQL as `go/clear-text-logging`.

--- a/internal/queue/store_contract_test.go
+++ b/internal/queue/store_contract_test.go
@@ -109,6 +109,54 @@ func TestStoreContract_DequeueAck(t *testing.T) {
 	}
 }
 
+// An empty Route or Target in a DequeueRequest means "any". The push
+// dispatcher relies on this: it dequeues per route without naming a target
+// and resolves the target per item afterwards. Every other contract test
+// names both fields explicitly, so this is the only coverage of the wildcard.
+func TestStoreContract_DequeueEmptyRouteOrTargetIsWildcard(t *testing.T) {
+	cases := []struct {
+		name string
+		req  queue.DequeueRequest
+	}{
+		{name: "target_wildcard", req: queue.DequeueRequest{Route: "/r"}},
+		{name: "route_wildcard", req: queue.DequeueRequest{Target: "https://example.com/hook"}},
+		{name: "both_wildcard", req: queue.DequeueRequest{}},
+	}
+
+	for _, factory := range contractStoreFactories() {
+		t.Run(factory.name, func(t *testing.T) {
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					now := time.Date(2026, 2, 14, 21, 0, 0, 0, time.UTC)
+					store := factory.new(t, &now)
+
+					if err := store.Enqueue(queue.Envelope{ID: "evt_1", Route: "/r", Target: "https://example.com/hook"}); err != nil {
+						t.Fatalf("enqueue: %v", err)
+					}
+
+					req := tc.req
+					req.Batch = 1
+					req.LeaseTTL = 30 * time.Second
+					resp, err := store.Dequeue(req)
+					if err != nil {
+						t.Fatalf("dequeue: %v", err)
+					}
+					if len(resp.Items) != 1 {
+						t.Fatalf("dequeue with route=%q target=%q returned %d items, want 1",
+							tc.req.Route, tc.req.Target, len(resp.Items))
+					}
+					if got := resp.Items[0].ID; got != "evt_1" {
+						t.Fatalf("dequeued id=%q, want evt_1", got)
+					}
+					if got := resp.Items[0].Target; got != "https://example.com/hook" {
+						t.Fatalf("dequeued target=%q, want https://example.com/hook", got)
+					}
+				})
+			}
+		})
+	}
+}
+
 func TestStoreContract_NackDelayRequeue(t *testing.T) {
 	for _, factory := range contractStoreFactories() {
 		t.Run(factory.name, func(t *testing.T) {

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -472,24 +472,33 @@ func (s *Store) dequeueOnce(req queue.DequeueRequest, batch int, leaseTTL time.D
 		return queue.DequeueResponse{}, err
 	}
 
-	rows, err := tx.QueryContext(ctx, `
+	// An empty Route or Target means "any", matching the memory and SQLite
+	// backends. The push dispatcher depends on it: it dequeues per route
+	// without naming a target and resolves the target per item afterwards.
+	query := `
 SELECT id, route, target, state, received_at, attempt, next_run_at,
        payload, headers_json, trace_json, dead_reason, schema_version
 FROM queue_items
-WHERE route = $1
-  AND target = $2
-  AND state = $3
-  AND next_run_at <= $4
-ORDER BY next_run_at ASC, received_at ASC, id ASC
-LIMIT $5
+WHERE state = $1
+  AND next_run_at <= $2
+`
+	args := make([]any, 0, 5)
+	args = append(args, string(queue.StateQueued), now)
+	if req.Route != "" {
+		query += fmt.Sprintf("  AND route = $%d\n", len(args)+1)
+		args = append(args, req.Route)
+	}
+	if req.Target != "" {
+		query += fmt.Sprintf("  AND target = $%d\n", len(args)+1)
+		args = append(args, req.Target)
+	}
+	query += fmt.Sprintf(`ORDER BY next_run_at ASC, received_at ASC, id ASC
+LIMIT $%d
 FOR UPDATE SKIP LOCKED
-`,
-		req.Route,
-		req.Target,
-		string(queue.StateQueued),
-		now,
-		batch,
-	)
+`, len(args)+1)
+	args = append(args, batch)
+
+	rows, err := tx.QueryContext(ctx, query, args...)
 	if err != nil {
 		return queue.DequeueResponse{}, err
 	}


### PR DESCRIPTION
## Summary

Fixes #200 — push delivery never fired when the queue backend was Postgres.

`dequeueOnce` filtered unconditionally on `route = $1 AND target = $2` (`modules/postgres/postgres.go:479`). Memory (`internal/queue/memory.go:621`) and SQLite (`modules/sqlite/sqlite.go:1358`) only add those predicates when the field is non-empty — an empty field means "any".

The push dispatcher relies on that wildcard: `internal/dispatcher/push.go:223` issues `DequeueRequest{Route, Batch, MaxWait, LeaseTTL}` with no `Target` and resolves `targetsByURL[env.Target]` per item afterwards. On Postgres the query therefore resolved to `target = ''`, and since `Enqueue` requires a non-empty target, it matched zero rows.

Ingress enqueued normally. Nothing was ever delivered. The backlog grew until `max_depth` started rejecting, and nothing was logged — from the dispatcher's side the queue simply looked empty. Pull routes were unaffected; they pass an explicit target.

The `WHERE` clause is now built conditionally, in the same style `ListMessages` already uses a few hundred lines down in the same file — which is part of why this reads as an oversight rather than a deliberate difference.

## Verification

Ran against Postgres 17 in Docker, since this cannot be reproduced without a live database.

New contract case `TestStoreContract_DequeueEmptyRouteOrTargetIsWildcard`, covering all three wildcard combinations:

| backend | before | after |
|---|---|---|
| memory | 3/3 pass | 3/3 pass |
| sqlite | 3/3 pass | 3/3 pass |
| **postgres** | **0/3 pass** | **3/3 pass** |

Failure output on the previous code:

```
dequeue with route="/r" target="" returned 0 items, want 1
dequeue with route="" target="https://example.com/hook" returned 0 items, want 1
dequeue with route="" target="" returned 0 items, want 1
```

Full suite green with `go test -p 1 ./...` and `HOOKAIDO_TEST_POSTGRES_DSN` set, so the rest of the Postgres integration tests ran too. `go vet` and `gofmt` clean.

## Related Issues

Closes #200

## Scope

- [ ] DSL / config behavior
- [x] Runtime behavior — push delivery on the Postgres backend
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally (and `-p 1` with a live Postgres DSN)
- [x] Added or updated tests for behavioral changes — see above
- [ ] Updated docs for user-visible changes — no documented behavior changes; this restores what was already documented
- [x] Updated `CHANGELOG.md` for user-visible behavior changes (`[Unreleased]` → `Fixed`)
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed — none; this is a query predicate
- [x] Backward compatibility considered — strictly widens what `Dequeue` matches on Postgres, in the direction the contract already specified. Callers that pass both fields are unaffected.

## Notes for Reviewers

**Why this was never caught:** every pre-existing contract test in `internal/queue/store_contract_test.go` passes `Route` and `Target` explicitly. The wildcard path — the one the push dispatcher actually uses — had no coverage on any backend. The new test closes that specifically.

**Worth considering separately:** Postgres integration tests skip silently without `HOOKAIDO_TEST_POSTGRES_DSN`, which is unset in CI, so the shared contract tests only ever run against memory and sqlite. A Postgres service container in the CI workflow would have caught this and would guard the other backend-parity gaps collected in #207. I have not changed CI here — that felt like a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
