### PR TITLE
fix(app): set read and idle timeouts on every HTTP listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Security
+
+- **Every HTTP listener now sets `ReadHeaderTimeout` and `IdleTimeout`** ([#203](https://github.com/nuetzliches/hookaido/issues/203)). Both `http.Server` constructions — the shared/per-component ingress, pull_api and admin_api servers, and the metrics server — were built without any timeout, so a client dribbling one header byte at a time pinned a goroutine and a file descriptor indefinitely (Slowloris). Ingress is the component most likely to face the open internet, and nothing else bounded header read time. Servers are now built through a single `newHTTPServer` helper with a 15s header-read and 120s idle timeout, and a test guards that no listener is constructed around it. `ReadTimeout` and `WriteTimeout` remain deliberately unset — a write deadline would truncate the Pull API's SSE stream, and a read deadline would cap the time available to receive a legitimate `max_body`-sized payload over a slow link.
+
 ### Fixed
 
 - **Push delivery never fired on the Postgres queue backend** ([#200](https://github.com/nuetzliches/hookaido/issues/200)). `Dequeue` filtered unconditionally on `route = $1 AND target = $2`, while the memory and SQLite backends treat an empty field as "any". The push dispatcher relies on that wildcard — it dequeues per route without naming a target and resolves the target per item afterwards — so on Postgres the query resolved to `target = ''` and matched nothing. Ingress enqueued normally, nothing was ever delivered, and the backlog grew until `max_depth` began rejecting, with no error logged because the queue simply looked empty to the dispatcher. Pull routes were unaffected, since those pass an explicit target. The `WHERE` clause is now built conditionally, matching the other two backends and the existing `ListMessages` query in the same file. A new `queue.Store` contract case covers all three wildcard combinations — every pre-existing contract test named both fields explicitly, which is why the divergence went unnoticed.

--- a/internal/app/http_server_test.go
+++ b/internal/app/http_server_test.go
@@ -1,0 +1,87 @@
+package app
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestNewHTTPServer_SetsReadAndIdleTimeouts(t *testing.T) {
+	srv := newHTTPServer(":8080", http.NotFoundHandler())
+
+	if srv.ReadHeaderTimeout != httpReadHeaderTimeout {
+		t.Fatalf("ReadHeaderTimeout=%s, want %s -- without it a client can hold a connection "+
+			"open indefinitely by dribbling header bytes", srv.ReadHeaderTimeout, httpReadHeaderTimeout)
+	}
+	if srv.IdleTimeout != httpIdleTimeout {
+		t.Fatalf("IdleTimeout=%s, want %s", srv.IdleTimeout, httpIdleTimeout)
+	}
+	if srv.Addr != ":8080" {
+		t.Fatalf("Addr=%q, want :8080", srv.Addr)
+	}
+	if srv.Handler == nil {
+		t.Fatal("Handler is nil")
+	}
+
+	// Deliberately unset, not an oversight: WriteTimeout would truncate the
+	// Pull API's SSE stream, and ReadTimeout would cap the time available to
+	// read a legitimate max_body-sized payload over a slow link.
+	if srv.WriteTimeout != 0 {
+		t.Fatalf("WriteTimeout=%s, want 0 -- a write deadline truncates the SSE stream", srv.WriteTimeout)
+	}
+	if srv.ReadTimeout != 0 {
+		t.Fatalf("ReadTimeout=%s, want 0 -- a read deadline caps large-body uploads over slow links", srv.ReadTimeout)
+	}
+}
+
+// Every listener in this package must be built through newHTTPServer so it
+// inherits the timeouts above. A bare &http.Server{} literal elsewhere would
+// silently reintroduce the unbounded-read exposure the helper exists to close,
+// which is exactly how the original gap arose: two constructions, neither with
+// a timeout, and nothing pointing that out.
+func TestNoBareHTTPServerLiteralsOutsideHelper(t *testing.T) {
+	fset := token.NewFileSet()
+	// Test files are exempt: they stand up throwaway servers to exercise
+	// serveOnListener and have no exposure to bound.
+	pkgs, err := parser.ParseDir(fset, ".", func(fi fs.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("parse package: %v", err)
+	}
+
+	for _, pkg := range pkgs {
+		for _, file := range pkg.Files {
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok {
+					continue
+				}
+				if fn.Name.Name == "newHTTPServer" {
+					continue
+				}
+				ast.Inspect(fn, func(n ast.Node) bool {
+					lit, ok := n.(*ast.CompositeLit)
+					if !ok {
+						return true
+					}
+					sel, ok := lit.Type.(*ast.SelectorExpr)
+					if !ok {
+						return true
+					}
+					ident, ok := sel.X.(*ast.Ident)
+					if !ok || ident.Name != "http" || sel.Sel.Name != "Server" {
+						return true
+					}
+					t.Errorf("%s: %s constructs http.Server directly; use newHTTPServer so the "+
+						"read and idle timeouts are applied", fset.Position(lit.Pos()), fn.Name.Name)
+					return true
+				})
+			}
+		}
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -46,6 +46,43 @@ const backlogTrendCaptureInterval = time.Minute
 // windows can file a follow-up if the constant is too slack or too eager.
 const secretGCInterval = 5 * time.Minute
 
+// HTTP server timeouts, applied to every listener this process creates via
+// newHTTPServer.
+//
+// httpReadHeaderTimeout is the one that matters for exposure: without it a
+// client dribbling one header byte at a time pins a goroutine and a file
+// descriptor indefinitely (Slowloris), and ingress is the component most likely
+// to face the open internet. Headers are small, so 15s is generous even over a
+// bad link.
+//
+// httpIdleTimeout bounds how long a keep-alive connection may sit between
+// requests. It does not affect an in-flight response, so the Pull API's SSE
+// stream is unaffected.
+//
+// ReadTimeout and WriteTimeout are deliberately left unset. WriteTimeout would
+// truncate that SSE stream, which is long-lived by design, and ReadTimeout
+// would cap the time available to read a legitimate max_body-sized payload over
+// a slow link. Neither is needed for the exhaustion case the two timeouts above
+// close. Intentionally not configurable — file a follow-up if a deployment
+// needs different values.
+const (
+	httpReadHeaderTimeout = 15 * time.Second
+	httpIdleTimeout       = 120 * time.Second
+)
+
+// newHTTPServer builds an http.Server with the timeouts every listener in this
+// process shares. Construct servers through this helper rather than with a
+// bare &http.Server{} literal, so a new listener cannot silently ship without
+// them.
+func newHTTPServer(addr string, handler http.Handler) *http.Server {
+	return &http.Server{
+		Addr:              addr,
+		Handler:           handler,
+		ReadHeaderTimeout: httpReadHeaderTimeout,
+		IdleTimeout:       httpIdleTimeout,
+	}
+}
+
 func run() int {
 	fs := flag.NewFlagSet("run", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
@@ -2394,7 +2431,7 @@ func startServers(
 		}
 		entries = append(entries, serverEntry{
 			name: groupName(members),
-			srv:  &http.Server{Addr: addr, Handler: handler},
+			srv:  newHTTPServer(addr, handler),
 			ln:   ln,
 		})
 	}
@@ -2458,10 +2495,7 @@ func startServers(
 		if accessLogger != nil {
 			metricsHandler = withAccessLog(accessLogger.With(slog.String("component", "metrics")), metricsHandler)
 		}
-		metricsSrv := &http.Server{
-			Addr:    compiled.Observability.Metrics.Listen,
-			Handler: metricsHandler,
-		}
+		metricsSrv := newHTTPServer(compiled.Observability.Metrics.Listen, metricsHandler)
 		servers = append(servers, metricsSrv)
 		serveOnListener(runtimeLogger, "metrics", metricsSrv, metricsLn, cancel)
 	}


### PR DESCRIPTION
## Summary

Fixes #203 — no `http.Server` in the codebase set any timeout.

Both constructions were bare: the shared/per-component ingress, pull_api and admin_api servers (`internal/app/run.go:2397`) and the metrics server (`:2461`). A repo-wide grep for `ReadHeaderTimeout`, `ReadTimeout`, `WriteTimeout` and `IdleTimeout` returned nothing.

Without a header-read deadline, a client dribbling one header byte at a time pins a goroutine and a file descriptor indefinitely. Ingress is the component most likely to face the open internet, and nothing else bounded that. `gosec` (G112) is not among the linters enabled in `.golangci.yml`, so CI never flagged it.

Servers are now built through a `newHTTPServer` helper with a **15s** header-read and **120s** idle timeout.

## Why `ReadTimeout` and `WriteTimeout` stay unset

Deliberate, not partial:

- **`WriteTimeout` would truncate the Pull API's SSE stream** (`GET {pull.path}/stream`), which is a long-lived response by design.
- **`ReadTimeout` would cap the time available to read a legitimate `max_body`-sized payload** over a slow link.

Neither is needed for the exhaustion case the other two close. `IdleTimeout` only applies between requests on a keep-alive connection, so it does not touch an in-flight SSE response either.

The test pins both at zero, so a later "these timeouts look incomplete" change cannot silently break SSE without someone reading the reasoning first.

## The second test

`TestNoBareHTTPServerLiteralsOutsideHelper` walks the package AST and fails if anything outside `newHTTPServer` constructs an `http.Server`.

A helper guarantees nothing if the next listener bypasses it — and that is precisely how this gap arose: two constructions, neither with a timeout, and nothing pointing it out. Test files are exempt; they stand up throwaway servers with no exposure to bound.

Verified it catches a real violation rather than just passing: temporarily adding a bare literal to `logging.go` produced

```
logging.go:151:47: probeBareServer constructs http.Server directly; use newHTTPServer
so the read and idle timeouts are applied
```

**This one is worth a second opinion.** An AST-scanning test is unusual, and if it reads as too much machinery it can be dropped without touching the fix. The alternative would be enabling `gosec` in golangci-lint, which catches G112 generically — a broader change with its own noise budget, so I did not fold it in here.

## Verification

Full suite green, `go vet` and `gofmt` clean.

## Related Issues

Closes #203

## Scope

- [ ] DSL / config behavior
- [x] Runtime behavior — HTTP listener connection handling
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [x] Added or updated tests for behavioral changes
- [ ] Updated docs for user-visible changes — the timeouts are not configurable, so there is no config surface to document
- [x] Updated `CHANGELOG.md` for user-visible behavior changes (`[Unreleased]` → `Security`)
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed — none; this bounds connection lifetime, not authorization
- [x] Backward compatibility considered — see below

## Notes for Reviewers

**Operator-visible behavior change.** Connections that previously hung around forever are now closed: a client taking more than 15s to send its request headers gets dropped, and idle keep-alive connections are closed after 120s. Both are generous — headers are small, and 120s idle is a common default — but a deployment behind an unusually slow or high-latency link should know the numbers. They are constants, not configuration; the constant carries a comment saying to file a follow-up if that turns out to be too rigid.

**Related but not addressed:** #209 notes that the unbounded read window also widened the reload race it describes (route resolved against the old table, auth looked up in the new one). These timeouts shorten that window considerably but do not close it — the fix there is a consistent per-request snapshot, which is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
