### PR TITLE
fix(postgres): start the AckBatch doc comment with its own name

### DIFF
--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -615,12 +615,15 @@ WHERE id = $1
 	})
 }
 
-// AckBatch, NackBatch and MarkDeadBatch acknowledge one lease per statement,
-// each in its own transaction. queue.LeaseBatchStore asks implementations to use
-// a single transaction "where possible" -- SQLite does, via withLeaseBatch, so
-// there a failed batch really did change nothing and returning a zero result is
-// accurate. Here it is not: by the time an unexpected error surfaces on lease N,
-// leases 1..N-1 are already committed.
+// AckBatch acknowledges the given leases, one per statement in its own
+// transaction. NackBatch and MarkDeadBatch below follow the same shape, and the
+// partial-result note here applies to all three.
+//
+// queue.LeaseBatchStore asks implementations to use a single transaction "where
+// possible" -- SQLite does, via withLeaseBatch, so there a failed batch really
+// did change nothing and returning a zero result is accurate. Here it is not: by
+// the time an unexpected error surfaces on lease N, leases 1..N-1 are already
+// committed.
 //
 // These used to return queue.LeaseBatchResult{} on that path, which told the
 // caller nothing had succeeded. The dispatcher treats an un-acked delivered item


### PR DESCRIPTION
## Summary

staticcheck ST1020 requires a comment on an exported method to begin with that method's name. The note added in #227 opened with "AckBatch, NackBatch and MarkDeadBatch ...", which reads fine but trips the rule.

Reworded so the first sentence documents `AckBatch`, with the shared partial-result explanation following. No behavior change — comment only.

**This is currently red on `main`.** `lint` is not one of the four required status checks, so #227 merged with it failing, and every PR opened afterwards inherits the failure. I confirmed [#229](https://github.com/nuetzliches/hookaido/pull/229) and [#230](https://github.com/nuetzliches/hookaido/pull/230) carry *only* this inherited issue and none of their own, so this unblocks all three.

## Related Issues

Follow-up to #227.

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [x] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [ ] Added or updated tests for behavioral changes
- [ ] Updated docs for user-visible changes
- [ ] Updated `CHANGELOG.md` for user-visible behavior changes
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

Verified with the same linter version CI pins (golangci-lint v2.12.2, via its Docker image): **0 issues**. No CHANGELOG entry — a comment reword is not a user-visible behavior change.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

## Notes for Reviewers

Worth noting for process: I checked only the four *required* checks before arming auto-merge on #227, so a red `lint` slipped through. Checking `gh pr checks <n>` in full — not just `--required` — is the habit that catches this.
