### PR TITLE
ci: run the Postgres-backed tests against a service container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,45 @@ jobs:
           name: coverage
           path: coverage.out
 
+  # The Postgres backend is the production recommendation, but its tests skip
+  # silently without HOOKAIDO_TEST_POSTGRES_DSN -- including the cross-backend
+  # queue.Store contract tests, which are the ones that establish parity with
+  # sqlite and memory. Without this job they only ever ran against those two
+  # here, which is how several Postgres-only divergences reached main (#207).
+  #
+  # Service containers are Linux-only, so this cannot be folded into the
+  # matrixed `test` job that also covers Windows.
+  test-postgres:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17-alpine
+        env:
+          POSTGRES_USER: hookaido
+          POSTGRES_PASSWORD: hookaido
+          POSTGRES_DB: hookaido
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U hookaido"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Setup Go
+        uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
+          check-latest: true
+      # -p 1 matters: the packages below share one database, so running their
+      # tests in parallel makes them race on the same tables. This is what
+      # `make test-pg` does.
+      - name: Test (Postgres backend)
+        env:
+          HOOKAIDO_TEST_POSTGRES_DSN: postgres://hookaido:hookaido@127.0.0.1:5432/hookaido?sslmode=disable
+        run: go test -race -p 1 ./internal/queue/ ./internal/secrets/ ./modules/postgres/
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

The infrastructure prerequisite for #207. The Postgres backend is the production recommendation, but its tests skip silently without `HOOKAIDO_TEST_POSTGRES_DSN`, and CI never set it — so the cross-backend `queue.Store` contract tests in `internal/queue/store_contract_test.go`, the very tests that establish parity with sqlite and memory, only ever ran against those two here. The #207 review names this as the reason several Postgres-only divergences reached `main`, and it is why the remaining #207 items are not verifiable in CI as things stand.

A new ubuntu-only `test-postgres` job brings up `postgres:17-alpine` as a service container and runs the three packages that read the DSN — `internal/queue`, `internal/secrets`, `modules/postgres` — with `-race` and `-p 1`.

Two details worth knowing:

- **Service containers are Linux-only**, so this cannot be folded into the matrixed `test` job, which also covers Windows. Hence a separate job rather than a service block on the existing one.
- **`-p 1` is required.** Those packages share a single database and would otherwise race on the same tables. This mirrors what `make test-pg` already does.

## Related Issues

Refs #207

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [x] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [ ] Added or updated tests for behavioral changes — no behaviour change; this makes existing tests run
- [ ] Updated docs for user-visible changes
- [ ] Updated `CHANGELOG.md` for user-visible behavior changes — CI-only
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

Verified before pushing, so this does not land a red job:

- The full suite against a real Postgres (`go test -p 1 ./...` with the DSN set) is green on current `main` — nothing latent turns this job red on arrival.
- The **exact** command the job runs, `go test -race -count=1 -p 1 ./internal/queue/ ./internal/secrets/ ./modules/postgres/`, was run inside a `golang:1.26` Linux container against a real Postgres 17 (my machine has no cgo, so `-race` needs the container). Green.
- The workflow parses as YAML and the job resolves to the intended shape (ubuntu runner, the service image, three steps).

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

The DSN is a throwaway localhost credential for an ephemeral service container, so it is inline rather than a secret.

## Notes for Reviewers

**This job is not a required status check, and that limits what it buys you.** Branch protection currently requires only `test (ubuntu-latest)`, `test (windows-latest)`, `release-package-dryrun` and `CodeQL (go) (go)`. So a PR with auto-merge armed will land even if `test-postgres` is red — exactly the failure mode that let a red `lint` reach `main` in #227. Adding it to the required set is a branch-protection change, which is your call rather than mine; I have deliberately not touched repo settings. Until then, `gh pr checks <n>` without `--required` is the way to see it.

Two smaller judgement calls:

- The image is pinned by tag (`postgres:17-alpine`) rather than digest, matching how `docs.yml` and `lint.yml` pin their images. Actions in this repo are SHA-pinned; container images are not. Happy to pin by digest if you would rather be consistent with the actions instead.
- The job runs the three DSN-reading packages rather than `./...`. Running everything would duplicate the whole matrix leg — including the e2e binary build — to no benefit, since no other package changes behaviour based on the DSN. If a fourth package starts reading it, this list needs extending; the grep that finds them is `grep -rl HOOKAIDO_TEST_POSTGRES_DSN --include=*.go .`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
