### PR TITLE
chore(release): prepare v2.10.0

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,12 +4,12 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
 
 ## P1 - Medium Priority (awesome-go readiness, target: July 2026)
 
-- [ ] **Test coverage ≥80%** — Current total: 75.2% (with `HOOKAIDO_TEST_POSTGRES_DSN` set, see `make test-pg`). Focus areas:
+- [ ] **Test coverage ≥80%** — Current total: 75.9% as of v2.10.0 (with `HOOKAIDO_TEST_POSTGRES_DSN` set, see `make test-pg`). Focus areas:
   - `internal/secrets` (70.8%) — Secret resolver edge cases
   - `internal/pullapi` (73.6%) — Pull API handler coverage
   - `internal/config` (77.3%) — Config parser edge cases
   - `internal/mcp` (77.3%) — MCP server handler coverage
-- [ ] **Tag v2.8.0 and trigger Go Report Card refresh** — The module path has been updated to `github.com/nuetzliches/hookaido/v2` so `proxy.golang.org` will start resolving v2.x.x tags (it previously fell back to v1.5.1 because of the Go modules v2+ rule). Once v2.8.0 is tagged on GitHub, hit `POST /checks repo=github.com/nuetzliches/hookaido/v2` on goreportcard.com to refresh. This also unblocks pkg.go.dev visibility and the awesome-go submission.
+- [ ] **Trigger Go Report Card + pkg.go.dev refresh** — The module path is `github.com/nuetzliches/hookaido/v2`, so `proxy.golang.org` resolves v2.x.x tags (it previously fell back to v1.5.1 under the Go modules v2+ rule). v2.9.0 and v2.10.0 are tagged; hit `POST /checks repo=github.com/nuetzliches/hookaido/v2` on goreportcard.com to refresh. Needed for pkg.go.dev visibility and the awesome-go submission.
 - [ ] **pkg.go.dev doc coverage** — Ensure all public types and functions have Go-style doc comments.
 - [ ] **awesome-go PR** — Submit to [avelino/awesome-go](https://github.com/avelino/awesome-go) under "Messaging" category. Requires: ≥5 months history (eligible ~July 2026), coverage ≥80%, Go Report Card A-, pkg.go.dev docs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,68 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.10.0] - 2026-08-18
+
+A hardening release. It closes the six umbrella issues from a full code and
+documentation review ([#206](https://github.com/nuetzliches/hookaido/issues/206),
+[#207](https://github.com/nuetzliches/hookaido/issues/207),
+[#208](https://github.com/nuetzliches/hookaido/issues/208),
+[#209](https://github.com/nuetzliches/hookaido/issues/209),
+[#210](https://github.com/nuetzliches/hookaido/issues/210),
+[#211](https://github.com/nuetzliches/hookaido/issues/211)) together with seven
+security advisories, and adds the CI coverage that would have caught most of it.
+
+The importable Go API is backward compatible — nothing exported by `modules/*`,
+`cmd/*` or the root package was removed or changed — so this stays on the `/v2`
+module path. What does change is configuration validation and runtime behaviour.
+
+### Upgrade notes
+
+**Configs that used to compile may now be rejected.** Each of these was already
+broken or already insecure; the compiler now says so instead of starting anyway.
+
+- An `admin_api` with no `auth token` on a non-loopback `listen` address, or
+  co-listening with `ingress`. **The endpoint was open — treat it as disclosed
+  and add a token.** `docs/docker.md` recommended exactly this without a token
+  and has been corrected.
+- A route that an earlier, unconstrained route prefix-shadows (`/hooks/github`
+  after `/hooks`, or anything after a `/` catch-all). The shadowed route was
+  never receiving traffic; the shadowing one was. Reorder so the more specific
+  path comes first.
+- Two components whose `listen` addresses differ as strings but name one socket
+  (`:8080` vs `0.0.0.0:8080`). These never started — the failure moves from
+  `EADDRINUSE` to a compile error naming both.
+- A size value above `1024gb`, or one whose multiplication overflows.
+  `max_body 18014398509481985k` previously yielded a **1 KiB** limit.
+- An `auth hmac { }` block with no secret, and `auth basic` credentials written
+  in `env:`/`file:`/`vault:`/`raw:` reference syntax. **Rotate any basic-auth
+  credential configured that way and treat it as disclosed.**
+
+**Behaviour changes worth planning for.**
+
+- **MCP `config_apply` now requires a `reason` argument.** Existing clients
+  calling it without one are rejected. It is the same audit triple every other
+  mutating tool already takes.
+- **`pull_api.max_lease_batch` (new, default 100)** replaces the accidental use
+  of `pull_api.max_batch` as the gRPC lease-batch cap. A deployment that raised
+  `max_batch` above 100 and relied on the larger gRPC lease batch must now set
+  `max_lease_batch` explicitly. HTTP behaviour is unchanged.
+- **`Retry-After` is honoured**, so messages can sit in the queue much longer
+  before dead-lettering: `retry max` counts attempts, not elapsed time.
+- **Egress CIDR allow rules now require every resolved address**, so a hostname
+  answering with one in-range and one out-of-range address is refused. Prefer a
+  host rule (`allow "*.internal"`) for private-network targets.
+- **`dns_rebind_protection` blocks more ranges**, including `100.64.0.0/10`.
+  Delivering into CGNAT space now needs an explicit allow rule.
+- **A `max_body` smaller than the default now applies to Admin API bodies too.**
+- **Rate-limit buckets survive a reload**, so a deployment that was unknowingly
+  benefiting from the refill will see `429`s at its configured rate.
+- **Postgres batch metrics** record `enqueue_batch` / `ack_batch` / `nack_batch`
+  / `mark_dead_batch` instead of one per-item operation. Dashboards counting
+  acks through the store-operation metric need the new names.
+- **A reload can now wait up to 60s** (was 15s) before replacing the dispatcher,
+  on configs with long target timeouts.
+
 ### Security
 
 - **The Stripe/Cituro rejection log no longer carries anything derived from the secret** ([GHSA-cpfq-rj4r-hh5c](https://github.com/nuetzliches/hookaido/security/advisories/GHSA-cpfq-rj4r-hh5c)). On the `no_secret_matched` path the code recomputed `HMAC-SHA256(secrets[0], "<ts>.<body>")` and logged its first 8 hex characters as `want_prefix_first_secret`. Both halves of that message are attacker-controlled, so every rejected request handed out 32 verified bits of the correct MAC for a message of the caller's choosing — a chosen-message oracle that materially assists offline brute force of a weak secret, reachable unauthenticated and written into the runtime log sink. The field is removed entirely; a mismatch remains diagnosable from `secrets_tried`, `body_len` and `got_prefix`, none of which is secret-derived. Two related echoes are closed in the same pass: the `ts_parse_error` branch logged the unbounded attacker-supplied timestamp, and — less obviously — its `err.Error()`, since `strconv.ParseInt` returns a `*strconv.NumError` whose message embeds the entire input. Both are replaced by a length and an error classification (`not_a_number` / `out_of_range`), with no header material logged at all — matching the `parse_incomplete` path, which already reported `pairs_parsed` and `header_value_len` instead of the header value. Also resolves CodeQL alerts #66 and #68, both `go/clear-text-logging` on this line.
@@ -435,7 +497,19 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 - Mixed queue backends rejected at compile time.
 - Hot reload now correctly rejects changes to `defaults.max_body`, `defaults.max_headers`, and `defaults.publish_policy` (previously silently ignored).
 
-[Unreleased]: https://github.com/nuetzliches/hookaido/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/nuetzliches/hookaido/compare/v2.10.0...HEAD
+[2.10.0]: https://github.com/nuetzliches/hookaido/compare/v2.9.0...v2.10.0
+[2.9.0]: https://github.com/nuetzliches/hookaido/compare/v2.8.1...v2.9.0
+[2.8.1]: https://github.com/nuetzliches/hookaido/compare/v2.8.0...v2.8.1
+[2.8.0]: https://github.com/nuetzliches/hookaido/compare/v2.7.3...v2.8.0
+[2.7.1]: https://github.com/nuetzliches/hookaido/compare/v2.7.0...v2.7.1
+[2.7.0]: https://github.com/nuetzliches/hookaido/compare/v2.6.0...v2.7.0
+[2.6.0]: https://github.com/nuetzliches/hookaido/compare/v2.5.3...v2.6.0
+[2.4.0]: https://github.com/nuetzliches/hookaido/compare/v2.2.2...v2.4.0
+[2.2.2]: https://github.com/nuetzliches/hookaido/compare/v2.2.1...v2.2.2
+[2.2.1]: https://github.com/nuetzliches/hookaido/compare/v2.2.0...v2.2.1
+[2.2.0]: https://github.com/nuetzliches/hookaido/compare/v2.1.0...v2.2.0
+[2.1.0]: https://github.com/nuetzliches/hookaido/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/nuetzliches/hookaido/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/nuetzliches/hookaido/compare/v1.5.1...v2.0.0
 [1.5.1]: https://github.com/nuetzliches/hookaido/compare/v1.5.0...v1.5.1

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Development Status
 
-Last updated: 2026-07-01
-Current release: v2.9.0
+Last updated: 2026-08-18
+Current release: v2.10.0
 
 Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change history: `CHANGELOG.md`. Prioritized work items: `BACKLOG.md`.
 
@@ -9,7 +9,7 @@ Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change histo
 
 **Ingress & Routing** - HTTP ingress with optional TLS/mTLS, HMAC signature verification (replay protection, secret rotation, provider-compatible formats for GitHub/Gitea/Forgejo), Basic auth, forward auth callouts, and per-route/global rate limiting. Route matching supports path, method, host (wildcards), headers, query params, remote IP (CIDR), and named matchers. Channel types (`inbound`/`outbound`/`internal`) enforce directive constraints at compile time. Listeners default to separate ports but can opt into a single prefix-muxed port (ingress + `pull_api`/`admin_api` on the same `listen` address) for single-port deployments.
 
-**Queue & Delivery** - SQLite/WAL and PostgreSQL durable queue backends (in-memory available for dev/tests) with lease semantics, long-poll dequeue, dead-lettering, and queue limits/retention/pruning. Push dispatcher with retry/backoff, per-route concurrency, custom outbound headers, and optional outbound HMAC signing (multi-secret rotation). Pull API (HTTP/JSON) with bearer-token auth, dequeue limits, and per-route token overrides. Optional Worker API (gRPC) mirrors Pull lease operations (`dequeue`, `ack`, `nack`, `extend`) and is intentionally scoped to pull-worker transport only.
+**Queue & Delivery** - SQLite/WAL and PostgreSQL durable queue backends (in-memory available for dev/tests), held to one shared `queue.Store` contract that CI exercises against all three, with lease semantics, long-poll dequeue, dead-lettering, and queue limits/retention/pruning. Push dispatcher with retry/backoff, per-route concurrency, custom outbound headers, and optional outbound HMAC signing (multi-secret rotation). Pull API (HTTP/JSON) with bearer-token auth, dequeue limits, and per-route token overrides. Optional Worker API (gRPC) mirrors Pull lease operations (`dequeue`, `ack`, `nack`, `extend`) and is intentionally scoped to pull-worker transport only.
 
 **Admin API** - Full queue lifecycle: DLQ management, message publish/cancel/requeue/resume (by ID and by filter), backlog drill-down (top queued, oldest, aging summary, trends with operator-action playbooks). Management model projection and endpoint mapping lifecycle with config-source-of-truth mutations. Structured JSON errors, audit headers, and publish-policy enforcement throughout.
 
@@ -42,5 +42,6 @@ Current weighted implementation grade: **~95%**.
 ## What's Missing (MVP Core)
 
 - Runtime reload intentionally keeps restart-required edges for topology/startup-bound changes (listeners, API prefixes, dispatcher-affecting settings).
+- Test coverage is 75.9% against the 80% target tracked in `BACKLOG.md`; `internal/secrets`, `internal/pullapi`, `internal/config` and `internal/mcp` are the gaps.
 
 See `BACKLOG.md` for prioritized next steps.


### PR DESCRIPTION
## Summary

Release prep for **v2.10.0**, following `RELEASE.md` steps 1–2. Docs-only — no code changes.

The release closes the six umbrella issues from a full code and documentation review (#206–#211) plus seven security advisories, and adds the CI Postgres job that would have caught most of #207.

### Why 2.10.0 and not 3.0.0

The importable Go API is backward compatible. I verified that rather than assuming it: diffing `go doc -all` output for every public package (`modules/postgres`, `modules/sqlite`, `modules/otel`, `modules/mcp`, `modules/grpcworker`, root) between `v2.9.0` and `HEAD` shows **no exported symbol removed or changed** — only additions such as `EnqueueBatch`. Go's module rules therefore do not require a `/v3` path, and a v3 migration would mean rewriting imports across ~66 files plus `go.mod`, the Dockerfile LDFLAGS and the docs, and re-resolving on `proxy.golang.org` — which the `/v2` migration only just fixed.

What does change is configuration validation and runtime behaviour, and that is what the new **Upgrade notes** block is for.

### What is in this PR

- **`[Unreleased]` cut into `## [2.10.0] - 2026-08-18`**, with a fresh empty `[Unreleased]` above it. 45 changelog entries move into the release section.
- **A consolidated "Upgrade notes" block** at the top of the release section. The individual entries each carry their own "Operator action" note, but with this many breaking items an operator needs them in one place before upgrading. It separates "configs that used to compile may now be rejected" — every one of which was already broken or already insecure — from "behaviour changes worth planning for" (MCP `config_apply` now needs `reason`, the new `pull_api.max_lease_batch`, `Retry-After` extending queue residency, tightened egress allowlist and rebind ranges, `max_body` reaching admin bodies, rate-limit buckets surviving reloads, renamed Postgres batch metrics, and a drain that can now wait up to 60s).
- **CHANGELOG link refs fixed.** `[Unreleased]` still compared against `v2.0.1` — nine releases stale, so the link would have shown everything since v2.0.1. And 2.1.0 through 2.9.0 had no refs at all, so those headings were not links. Each of the twelve added refs compares against that version's actual predecessor **tag**, which matters because several tags (v2.7.2, v2.7.3, v2.5.3, v2.4.1) have no changelog heading of their own.
- **`STATUS.md`**: `Current release` → v2.10.0, `Last updated` → 2026-08-18. Two content touches, both milestone-level per `AGENTS.md` rather than per-feature: the queue-backend line now says the backends are held to one shared `queue.Store` contract that CI exercises against all three (which only became true in this release), and "What's Missing" records the 75.9% coverage against the 80% target.
- **`BACKLOG.md`**: coverage refreshed 75.2% → 75.9%, and the Go Report Card item no longer says "Tag v2.8.0" — v2.8.0, v2.8.1 and v2.9.0 all shipped since that was written.

I deliberately did **not** touch the progress matrix scores. This release raised regression coverage substantially, but inventing a number would be worse than leaving the existing one.

## Related Issues

Releases the work from #206, #207, #208, #209, #210, #211.

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [x] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [ ] Added or updated tests for behavioral changes — no behaviour change
- [x] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [x] Updated `BACKLOG.md` / `STATUS.md` when applicable

`RELEASE.md` steps 1–6 all run clean against this commit:

- `release-check` equivalent (`go vet ./...`, `go test -p 1 ./...` with a real Postgres 17, `go build ./cmd/hookaido`) — green. `make` is not on this machine, so the target's steps were run individually.
- Signed packaging dry-run: `go run ./internal/tools/release -version v2.10.0 …` produced all 11 expected artifacts (6 archives, checksums, signature, public key, manifest, SBOM), with the manifest recording `version: v2.10.0` and the right commit.
- `hookaido verify-release --require-signature --require-sbom` → 7 artifacts verified, SBOM verified, Ed25519 signature verified. `provenance` and `sbom-attestation` report "not verified", which is expected — those bundles are produced by the Actions attestation steps, not locally.
- `mkdocs build --strict` clean.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

The dry-run signing key was generated outside the repo, in a scratch directory, and neither it nor `dist/` is in this commit (`/dist/` is gitignored regardless).

## Notes for Reviewers

- **Nothing is tagged yet.** `AGENTS.md` treats tagging as a production action, and the tag triggers two publishing workflows — signed artifacts to the GitHub Release and multi-arch images to `ghcr.io` including `:latest`. Per `RELEASE.md` step 10 the tag is created from merged, up-to-date `origin/main`, so it comes after this PR lands.
- Please read the **Upgrade notes** block as the thing most likely to need your judgement. I wrote it from the individual entries, but you know the deployments; if something there understates the impact for a real installation, that is worth catching before it ships.
- Unrelated, but I noticed it while working and it is easy to lose: there is a **git stash from 2026-03-30** on this checkout (`WIP on main: 40d2ae7`, touching `internal/app/run_test.go` and `internal/dispatcher/push.go`). I left it untouched. Worth a look before it gets forgotten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
