### PR TITLE
fix(container): bump the builder image to Go 1.26.6, build the image in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,10 @@
 # Auto detect text files and perform LF normalization
 * text=auto
+
+# Shell scripts must keep LF even on Windows checkouts. docker-entrypoint.sh is
+# the container image ENTRYPOINT; with CRLF its shebang keeps a trailing
+# carriage return, the kernel looks for an interpreter that does not exist, and
+# the image fails to start with a misleading "no such file or directory". CI
+# checks out on Linux and never saw this, but a local docker build on Windows
+# produced a broken image.
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,40 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
 
+  # The container image was only ever built by the tag-triggered container
+  # workflow, so nothing checked it on a pull request. That is how the go.mod
+  # bump to 1.26.6 could land while the Dockerfile still pinned a builder image
+  # shipping 1.26.5: `go mod download` failed under GOTOOLCHAIN=local, and it
+  # surfaced for the first time when v2.10.0 was tagged -- after the GitHub
+  # Release had already published. Building here fails the PR instead.
+  #
+  # Build only, never push: publishing stays tag-driven in container.yml. One
+  # platform is enough, since what this guards against (toolchain drift, a
+  # broken Dockerfile, a missing file) is architecture-independent, and a
+  # multi-arch build under QEMU would cost minutes per PR for no added signal.
+  container-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - name: Build Image (no push)
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64
+          push: false
+          load: true
+          tags: hookaido:ci
+          build-args: |
+            VERSION=0.0.0-ci
+            COMMIT=${{ github.sha }}
+            BUILD_DATE=1970-01-01T00:00:00Z
+      # Building is not enough: a CRLF shebang or a missing file produces an
+      # image that builds and then cannot start.
+      - name: Smoke Test Image
+        run: docker run --rm hookaido:ci version --long
+
   release-package-dryrun:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.10.1] - 2026-08-18
+
+Publishes the container images for the 2.10.0 release. 2.10.0 itself is complete
+on GitHub Releases — archives, checksums, signature, SBOM and attestations all
+published — but the GHCR image build failed, so `ghcr.io/nuetzliches/hookaido`
+still points at 2.9.0. Upgrade notes for the actual changes are under
+[2.10.0](#2100---2026-08-18).
+
+### Fixed
+
+- **The container image builds again.** The Dockerfile pinned a `golang:1.26-alpine` digest shipping Go 1.26.5 by content, while 2.10.0 bumped `go.mod` to require `go >= 1.26.6` (a `govulncheck` remediation). With `GOTOOLCHAIN=local` in that image, `go mod download` refused with `go.mod requires go >= 1.26.6 (running go 1.26.5)` and the multi-arch build failed. The pin is bumped to a digest shipping 1.26.6. Nothing caught this before the tag because the image was only ever built by the tag-triggered `container` workflow — v2.9.0 published fine, since `go.mod` still asked for 1.26.4 then.
+
+- **CI now builds the container image and smoke-tests it on every pull request** (`container-build`), so toolchain drift between `go.mod` and the Dockerfile fails a PR instead of a release. Build only, never push — publishing stays tag-driven. It runs `linux/amd64` only, since what it guards against is architecture-independent and a QEMU multi-arch build would cost minutes per PR for no added signal, and it runs `hookaido version --long` inside the image afterwards: building is not enough to prove an image can start.
+
+- **`*.sh` is pinned to LF in `.gitattributes`.** `docker-entrypoint.sh` is the image `ENTRYPOINT`; on a Windows checkout `* text=auto` gave it CRLF, so its shebang kept a trailing carriage return and the locally built image died with `exec /usr/local/bin/docker-entrypoint.sh: no such file or directory`. CI checks out on Linux and never saw it, so published images were always fine — but a local `docker build` on Windows produced a broken one, which is also what blocked verifying the fix above.
+
 ## [2.10.0] - 2026-08-18
 
 A hardening release. It closes the six umbrella issues from a full code and
@@ -497,7 +513,8 @@ broken or already insecure; the compiler now says so instead of starting anyway.
 - Mixed queue backends rejected at compile time.
 - Hot reload now correctly rejects changes to `defaults.max_body`, `defaults.max_headers`, and `defaults.publish_policy` (previously silently ignored).
 
-[Unreleased]: https://github.com/nuetzliches/hookaido/compare/v2.10.0...HEAD
+[Unreleased]: https://github.com/nuetzliches/hookaido/compare/v2.10.1...HEAD
+[2.10.1]: https://github.com/nuetzliches/hookaido/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/nuetzliches/hookaido/compare/v2.9.0...v2.10.0
 [2.9.0]: https://github.com/nuetzliches/hookaido/compare/v2.8.1...v2.9.0
 [2.8.1]: https://github.com/nuetzliches/hookaido/compare/v2.8.0...v2.8.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # --- Build stage ---
-FROM golang:1.26-alpine@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2 AS build
+FROM golang:1.26-alpine@sha256:3889b425f035be855a72fb4755265311293b6d414521f0a519d819df32222d83 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Development Status
 
 Last updated: 2026-08-18
-Current release: v2.10.0
+Current release: v2.10.1
 
 Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change history: `CHANGELOG.md`. Prioritized work items: `BACKLOG.md`.
 


### PR DESCRIPTION
## Summary

**v2.10.0 published only half.** The GitHub Release is complete — archives, checksums, Ed25519 signature, SBOM and both attestation bundles all uploaded, `release` workflow green. But the `container` workflow **failed**, so `ghcr.io/nuetzliches/hookaido` still points at 2.9.0 and there is no `:2.10.0` or updated `:latest` image.

This PR fixes the cause and cuts **v2.10.1**, whose entire content is "the container image builds again". Upgrade notes for the real changes stay under 2.10.0.

### Root cause

The Dockerfile pinned `golang:1.26-alpine` **by digest**, and that digest ships Go 1.26.5. 2.10.0 bumped `go.mod` to require `go >= 1.26.6` (the `govulncheck` remediation in this release). The builder image sets `GOTOOLCHAIN=local`, so it cannot fetch a newer toolchain:

```
#25 [linux/amd64 build 4/6] RUN go mod download
#25 0.060 go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
#25 ERROR: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```

v2.9.0 published fine because `go.mod` still asked for 1.26.4 then. **The image was only ever built by the tag-triggered `container` workflow**, so the drift between `go.mod` and the Dockerfile went unnoticed from the bump until the tag — which is to say, until after the GitHub Release had already published.

### What is in this PR

- **Dockerfile builder pin bumped** to `golang:1.26-alpine@sha256:3889b425…`, which ships Go 1.26.6. I verified it is the OCI image **index** digest (`application/vnd.oci.image.index.v1+json`) via `docker buildx imagetools inspect`, not a single-platform manifest — pinning the latter would have broken the `linux/arm64` leg.
- **A `container-build` job in `ci.yml`**, which is the fix that matters. It builds the image on every pull request and then runs `hookaido version --long` **inside** it, because building is not enough to prove an image can start (see below). Build only, never push — publishing stays tag-driven in `container.yml`. `linux/amd64` only: what this guards against (toolchain drift, a broken Dockerfile, a missing file) is architecture-independent, and a QEMU multi-arch build would cost minutes per PR for no added signal. The `docker/*` action pins are the same SHAs `container.yml` already uses.
- **`*.sh text eol=lf` in `.gitattributes`.** `docker-entrypoint.sh` is the image `ENTRYPOINT`, and under `* text=auto` a Windows checkout gives it CRLF — so its shebang keeps a trailing carriage return, the kernel looks for an interpreter that does not exist, and the image dies with the famously misleading `exec /usr/local/bin/docker-entrypoint.sh: no such file or directory`. **Published images were never affected**, since CI checks out on Linux; git has always stored LF. But it is what blocked verifying the Dockerfile fix locally, and any Windows contributor building the image hits it.

## Related Issues

Follow-up to the v2.10.0 release (#244).

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [x] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [ ] Added or updated tests for behavioral changes — no Go behaviour change; the new CI job *is* the test
- [ ] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [x] Updated `BACKLOG.md` / `STATUS.md` when applicable

- `docker build` with the new pin **succeeds** locally, and `docker run --rm <image> version --long` prints `0.0.0-ci (commit=local, build_date=1970-01-01T00:00:00Z)` — so the build args reach the LDFLAGS and the entrypoint resolves. That run is exactly what the new CI step asserts.
- Both failures were reproduced before fixing: the Go version refusal in the tag's workflow log, and the CRLF entrypoint failure locally.
- `go vet ./...` and `go test -p 1 ./...` against a real Postgres 17 — green. `ci.yml` parses as YAML and the new job resolves to the intended shape.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

No runtime or configuration change. The 2.10.0 GitHub Release stays exactly as published; this adds a 2.10.1 whose artifacts are byte-identical in behaviour and whose images are the ones that were missing.

## Notes for Reviewers

- **Why a new tag rather than re-running the workflow.** `container.yml` has `workflow_dispatch`, but it validates `GITHUB_REF_NAME` against `^v[0-9]+\\.[0-9]+\\.[0-9]+$` — so dispatching against `main` fails the guardrail, and dispatching against `v2.10.0` would check out the broken Dockerfile at that tag. Moving a published tag was not on the table: the release artifacts are already attested against that commit. A patch release is the clean remedy.
- **`:latest` will point at 2.10.1**, not 2.10.0. That is correct — 2.10.1 is the newer release and contains everything 2.10.0 does.
- Worth deciding separately: `container-build` and `test-postgres` are both **non-required** status checks, so a PR with auto-merge armed still lands if either is red. For `container-build` specifically that partly defeats the purpose. Adding both to branch protection is a repo-settings change I have deliberately not made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
