### PR TITLE
ci(container): grant artifact-metadata:write for provenance attestation

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,6 +16,13 @@ jobs:
       packages: write
       id-token: write
       attestations: write
+      # actions/attest-build-provenance also writes an artifact-metadata storage
+      # record. Without this scope it warns 'Please check that the
+      # "artifact-metadata:write" permission has been included' and fails to
+      # persist the record, while still reporting the job as successful -- so the
+      # provenance is attested but its metadata record is missing. release.yml
+      # already grants it.
+      artifact-metadata: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 


### PR DESCRIPTION
## Summary

Adds `artifact-metadata: write` to the `publish-ghcr` job in `container.yml`.

The job attests build provenance with `actions/attest-build-provenance`, which — besides the attestation itself — writes an artifact-metadata storage record. Without that scope the step emits two warnings and continues:

```
! Please check that the "artifact-metadata:write" permission has been included
! Failed to create storage record: Error: Failed to persist storage record: no artifacts found
```

The job still reports **success**, and the provenance is genuinely attested and verifiable — `hookaido verify-release` against the downloaded v2.10.1 assets confirms the provenance and SBOM attestations both verify. What is missing is the metadata storage record, silently.

`release.yml` already grants the scope for the same action; `container.yml` did not. Both warnings appeared in the v2.10.1 container publish, which is where I noticed this.

`contents` stays `read` here. `release.yml` needs `contents: write` because it uploads release assets; this job only pushes to GHCR, so the difference is deliberate rather than an oversight to align.

## Related Issues

Follow-up from the v2.10.1 release.

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [x] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [ ] Added or updated tests for behavioral changes — workflow permission only
- [ ] Updated docs for user-visible changes
- [ ] Updated `CHANGELOG.md` for user-visible behavior changes — CI-only, see below
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

`container.yml` parses as YAML and the job's permissions resolve to `{contents: read, packages: write, id-token: write, attestations: write, artifact-metadata: write}`.

**No CHANGELOG entry**, deliberately: this is CI-only with no user-visible effect on the published images or on whether their attestations verify. That matches how the `test-postgres` job (#241) was handled, versus the container build fix (#245) which did get an entry because it fixed a broken publish.

**This cannot be fully verified until the next release.** `container.yml` only runs on a `v*.*.*` tag push (or `workflow_dispatch` against such a tag), so no CI run on this PR exercises it. The warnings should be gone from the next container publish — worth a glance at that run's log.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

This widens the job's token scope, so it is worth being deliberate about: `artifact-metadata: write` lets the job persist artifact metadata records for the repository. It is the scope the attestation action asks for, it is already granted to `release.yml` for the same action, and it is scoped to this one job rather than the workflow. No other permission changes.

## Notes for Reviewers

Left open as requested — not merged, and auto-merge not armed.

One adjacent thing I noticed but did **not** touch, to keep this PR to the one change: `RELEASE.md:168` says the container attestation uses `actions/attest-build-provenance@v3`, while both workflows actually pin `@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1` (line 152 of the same file correctly says `@v4` for the release workflow). Small doc drift, happy to fix it here or separately if you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
