### PR TITLE
docs(release): correct the container attestation action version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -165,7 +165,7 @@ Container publish workflow is defined in `.github/workflows/container.yml`.
 - Platforms: `linux/amd64`, `linux/arm64`
 - Image tags (derived from one pushed release tag): semver (`X.Y.Z`, `X.Y`, `X`), `latest`, and short `sha-*`
 - Repository tag policy: create/push only `vX.Y.Z` git tags
-- Attestation: `actions/attest-build-provenance@v3` with `push-to-registry: true`
+- Attestation: `actions/attest-build-provenance@v4` with `push-to-registry: true`
 - Metadata: OCI labels include source URL and image description
 - Build metadata: Docker build args wire to `hookaido version --long` (`version`, `commit`, `build_date`)
 


### PR DESCRIPTION
## Summary

`RELEASE.md:168` described the container publish as using `actions/attest-build-provenance@v3`. `container.yml:88` pins `0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1`.

The release-workflow section 16 lines up (`RELEASE.md:152`) already said `@v4` correctly, so the drift was confined to this one line. Verified both pins against the workflows: `release.yml:72` and `container.yml:88` are the same v4.1.1 SHA.

Noted while reviewing #246 and deliberately left out of that PR to keep it to the single permission change.

## Related Issues

Follow-up from #246.

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [x] Documentation only
- [ ] CI / release pipeline

## Validation

- [ ] `go test ./...` passed locally — no Go code touched
- [ ] Added or updated tests for behavioral changes — prose only
- [x] Updated docs for user-visible changes
- [ ] Updated `CHANGELOG.md` for user-visible behavior changes — see below
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

**No CHANGELOG entry**, deliberately: this corrects one version number in a maintainer-facing release runbook. Nothing about the published images or their attestations changes, and no user-visible behavior is affected. Same reasoning as #246.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

## Notes for Reviewers

One line. Both `@v4` references in the file now match what the workflows actually pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)