### PR TITLE
fix(config): keep unknown escapes, report lexer errors, stop the Admin API deleting comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **Quoted values keep their backslashes.** An unknown escape sequence dropped the backslash and kept only the escaped character, so `cert_file "C:\certs\server.pem"` parsed as `C:certsserver.pem` and `"^/hooks/\d+$"` as `^/hooks/d+$` — silently, with the failure surfacing later as a missing file or a matcher that never matches. `config fmt` and Admin API config rewrites then wrote the corrupted value back. `\\`, `\"`, `\n`, `\t` and `\r` are unchanged; every other backslash is now preserved, and the formatter re-escapes it so values survive any number of format cycles.
+
+- **Admin API managed-endpoint mutations no longer delete the comments in your Hookaidofile.** Every applied upsert or delete rewrote the file through the formatter, which regenerates it from a parse tree that keeps comments only above the first statement — one admin call erased every route annotation and rotation note in the file the project declares the source of truth. Mutations now splice just the `application`/`endpoint_name` directives into the existing file, leaving comments, blank lines and formatting untouched, and verify the spliced result against the canonical form before writing. `config fmt` still regenerates the file (documented under [Values, Quoting and Comments](docs/configuration.md#values-quoting-and-comments)).
+
+- **Parse errors in a value position report what actually went wrong.** An unterminated string or invalid UTF-8 was reported as `expected value` at position `0:0` — a position that cannot exist, since lines are 1-based — instead of `unterminated string at 12:18`.
+
 ## [2.10.1] - 2026-08-18
 
 Publishes the container images for the 2.10.0 release. 2.10.0 itself is complete

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,28 @@ internal {
 
 Route paths can be quoted or unquoted but must start with `/`.
 
+## Values, Quoting and Comments
+
+Values are bare words or double-quoted strings. Quote a value when it contains
+whitespace, `#`, `{`, `}`, or `"`.
+
+Inside a quoted string, `\\`, `\"`, `\n`, `\t` and `\r` are escape sequences.
+Any other backslash is kept verbatim, so `"^/hooks/\d+$"` is the regex you wrote
+and `"C:\certs\server.pem"` is the path you wrote.
+
+The escapes that do exist still apply, so a Windows path whose next character is
+`n`, `t`, `r`, `"` or `\` needs the backslash doubled — `"C:\new\tools"` contains
+a newline and a tab. Writing `"C:\\new\\tools"` (or using forward slashes, which
+Windows accepts) avoids the question entirely. `config fmt` re-escapes
+backslashes when it writes a value back, so a value survives any number of
+format cycles unchanged.
+
+`#` starts a comment that runs to the end of the line. Comments are preserved by
+Admin API config rewrites, which splice only the directive they change.
+`config fmt` regenerates the file from the parsed config and keeps only the
+comments above the first statement — run it on a file whose comments you intend
+to keep, and review the diff.
+
 ## Channel Types
 
 Routes are organized into three channel types that control which directives are allowed:

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -1729,7 +1729,28 @@ func mutateManagedEndpointConfig(
 		return admin.ManagementEndpointMutationResult{}, running, errors.New(config.FormatValidationText(res))
 	}
 
-	if err := writeFileAtomic(path, formatted); err != nil {
+	// Write a source-preserving splice when one is available. Format
+	// regenerates the file from the AST, which keeps comments only in the
+	// preamble, so writing its output on every applied managed-endpoint
+	// mutation deleted every in-body comment (route annotations, rotation
+	// notes) from the file the project declares the source of truth -- an
+	// Admin API call silently rewriting an operator's file is a different
+	// thing from an explicit `config fmt`. RewriteManagedEndpoints touches
+	// only the two managed-endpoint directives and verifies its own output
+	// against the canonical form, so falling back to `formatted` stays
+	// correct, just lossy; the warning is there so the loss is never silent.
+	payload := formatted
+	if spliced, rewriteErr := config.RewriteManagedEndpoints(data, cfg); rewriteErr == nil {
+		payload = spliced
+	} else if config.HasInBodyComments(data) {
+		logger.Warn("config_rewrite_dropped_comments",
+			slog.String("path", path),
+			slog.String("trigger", trigger),
+			slog.Any("err", rewriteErr),
+		)
+	}
+
+	if err := writeFileAtomic(path, payload); err != nil {
 		return admin.ManagementEndpointMutationResult{}, running, err
 	}
 

--- a/internal/app/run_test.go
+++ b/internal/app/run_test.go
@@ -1369,6 +1369,84 @@ func TestApplyManagedEndpointDelete_ConflictWhenCurrentRouteHasActiveBacklog(t *
 	}
 }
 
+// An Admin API managed-endpoint mutation rewrites the Hookaidofile. It used to
+// do that through Format, which regenerates the file from an AST that keeps
+// comments only in the preamble -- so one admin call deleted every route
+// annotation in the file the project declares the source of truth.
+func TestMutateManagedEndpointConfig_PreservesInBodyComments(t *testing.T) {
+	src := `# Hookaidofile for the billing DMZ.
+pull_api { auth token "raw:t" }
+
+# Invoice sink. Do not repoint without telling the billing team.
+"/a" {
+  # mapped by the Admin API
+  application "billing"
+  endpoint_name "invoice.created"
+  pull { path "/e1" }
+}
+
+# Spare route, kept for the cutover.
+"/b" {
+  pull { path "/e2" }
+}
+`
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "Hookaidofile")
+	if err := os.WriteFile(cfgPath, []byte(src), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	running := compileForReloadTest(t, src)
+	state := newRuntimeState(running)
+	if err := state.loadAuth(running); err != nil {
+		t.Fatalf("loadAuth: %v", err)
+	}
+
+	if _, _, err := mutateManagedEndpointConfig(
+		cfgPath,
+		running,
+		state,
+		slog.Default(),
+		func(cfg *config.Config, compiled config.Compiled) (admin.ManagementEndpointMutationResult, error) {
+			return applyManagedEndpointUpsert(cfg, compiled, admin.ManagementEndpointUpsertRequest{
+				Application:  "billing",
+				EndpointName: "invoice.created",
+				Route:        "/b",
+			}, nil)
+		},
+		"test_mutation",
+	); err != nil {
+		t.Fatalf("mutate config: %v", err)
+	}
+
+	written, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	got := string(written)
+	for _, comment := range []string{
+		"# Hookaidofile for the billing DMZ.",
+		"# Invoice sink. Do not repoint without telling the billing team.",
+		"# mapped by the Admin API",
+		"# Spare route, kept for the cutover.",
+	} {
+		if !strings.Contains(got, comment) {
+			t.Fatalf("admin mutation dropped comment %q:\n%s", comment, got)
+		}
+	}
+
+	cfg, err := config.Parse(written)
+	if err != nil {
+		t.Fatalf("parse written config: %v", err)
+	}
+	if cfg.Routes[0].ApplicationSet || cfg.Routes[0].EndpointNameSet {
+		t.Fatalf("managed endpoint was not cleared on /a:\n%s", got)
+	}
+	if cfg.Routes[1].Application != "billing" || cfg.Routes[1].EndpointName != "invoice.created" {
+		t.Fatalf("managed endpoint was not set on /b:\n%s", got)
+	}
+}
+
 func TestMutateManagedEndpointConfig_UpsertAndReload(t *testing.T) {
 	src := `
 pull_api { auth token "raw:t" }

--- a/internal/config/edit.go
+++ b/internal/config/edit.go
@@ -1,0 +1,380 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"slices"
+	"strings"
+)
+
+// ErrRewriteUnsupported reports that a source-preserving rewrite could not be
+// produced for this edit. Callers fall back to Format, which is always correct
+// but regenerates the file from the AST and therefore drops in-body comments,
+// blank lines and operator formatting.
+var ErrRewriteUnsupported = errors.New("config: source-preserving rewrite not supported for this edit")
+
+// RewriteManagedEndpoints returns src with the `application` and
+// `endpoint_name` directives of every route adjusted to match updated, leaving
+// every other byte of the file untouched.
+//
+// This exists because the Admin API rewrites the Hookaidofile on every applied
+// managed-endpoint mutation. Doing that through Format regenerates the file
+// from the AST, and the AST keeps comments only in Config.Preamble -- so a
+// single admin call used to delete every in-body comment (route annotations,
+// rotation notes) from the file the project declares the source of truth.
+//
+// The rewrite is deliberately narrow. It only ever touches the two managed
+// endpoint directives, and it verifies its own output: the spliced source is
+// reparsed and its canonical form compared against the canonical form of
+// updated. Any difference -- an edit this function does not model, an
+// unexpected source shape -- yields ErrRewriteUnsupported rather than a file
+// that does not match the intended config.
+//
+// src is normalized the way Parse normalizes it (BOM stripped, CRLF folded to
+// LF), so a CRLF file comes back with LF endings, as it would from Format.
+func RewriteManagedEndpoints(src []byte, updated *Config) ([]byte, error) {
+	if updated == nil {
+		return nil, ErrRewriteUnsupported
+	}
+
+	norm := normalizeInput(src)
+	original, err := Parse(norm)
+	if err != nil {
+		return nil, err
+	}
+	if len(original.Routes) != len(updated.Routes) {
+		return nil, ErrRewriteUnsupported
+	}
+
+	spans, err := scanRouteSpans(string(norm))
+	if err != nil {
+		return nil, err
+	}
+	if len(spans) != len(original.Routes) {
+		return nil, ErrRewriteUnsupported
+	}
+
+	var edits []sourceEdit
+	for i := range original.Routes {
+		before, after := original.Routes[i], updated.Routes[i]
+		if before.Path != after.Path || spans[i].path != before.Path {
+			return nil, ErrRewriteUnsupported
+		}
+		routeEdits, err := managedEndpointEdits(string(norm), spans[i], before, after)
+		if err != nil {
+			return nil, err
+		}
+		edits = append(edits, routeEdits...)
+	}
+
+	out, err := applyEdits(norm, edits)
+	if err != nil {
+		return nil, err
+	}
+
+	// Self-check: the spliced file must mean exactly what updated means.
+	// Comparing canonical forms rather than the ASTs keeps this honest without
+	// depending on struct equality across every block type.
+	want, err := Format(updated)
+	if err != nil {
+		return nil, err
+	}
+	reparsed, err := Parse(out)
+	if err != nil {
+		return nil, ErrRewriteUnsupported
+	}
+	got, err := Format(reparsed)
+	if err != nil {
+		return nil, ErrRewriteUnsupported
+	}
+	if !bytes.Equal(got, want) {
+		return nil, ErrRewriteUnsupported
+	}
+	return out, nil
+}
+
+// HasInBodyComments reports whether src carries comments that Format would
+// drop, i.e. comments that are not part of the leading preamble.
+func HasInBodyComments(src []byte) bool {
+	lex := newLexer(string(normalizeInput(src)))
+	sawStmt := false
+	for {
+		tok, err := lex.nextToken()
+		if err != nil || tok.kind == tokEOF {
+			return false
+		}
+		if tok.kind == tokComment {
+			if sawStmt {
+				return true
+			}
+			continue
+		}
+		sawStmt = true
+	}
+}
+
+// routeSpan locates one route block and its managed-endpoint directives in the
+// source, as byte offsets.
+type routeSpan struct {
+	path string
+
+	headStart int // first byte of the route path token
+	bodyStart int // first byte after the opening '{'
+	bodyEnd   int // offset of the closing '}'
+
+	application  *stmtSpan
+	endpointName *stmtSpan
+}
+
+// stmtSpan covers a directive from its name to the end of its value.
+type stmtSpan struct {
+	start int
+	end   int
+}
+
+type sourceEdit struct {
+	start int
+	end   int
+	text  string
+}
+
+// scanRouteSpans walks the token stream and records, for each top-level route
+// block, where it starts and where its managed-endpoint directives sit.
+func scanRouteSpans(src string) ([]routeSpan, error) {
+	lex := newLexer(src)
+
+	var (
+		spans   []routeSpan
+		depth   int
+		prev    token
+		hasPrev bool
+		inRoute bool
+	)
+
+	for {
+		tok, err := lex.nextToken()
+		if err != nil {
+			return nil, err
+		}
+		if tok.kind == tokEOF {
+			break
+		}
+		if tok.kind == tokComment {
+			continue
+		}
+
+		switch tok.kind {
+		case tokLBrace:
+			depth++
+			if depth == 1 && hasPrev && strings.HasPrefix(prev.text, "/") {
+				spans = append(spans, routeSpan{
+					path:      prev.text,
+					headStart: prev.off,
+					bodyStart: tok.end,
+				})
+				inRoute = true
+			}
+		case tokRBrace:
+			depth--
+			if depth < 0 {
+				return nil, ErrRewriteUnsupported
+			}
+			if depth == 0 && inRoute {
+				spans[len(spans)-1].bodyEnd = tok.off
+				inRoute = false
+			}
+		case tokIdent:
+			// Only directives at the route body's own level are managed
+			// endpoints; anything deeper belongs to a nested block.
+			if !inRoute || depth != 1 {
+				break
+			}
+			if tok.text != "application" && tok.text != "endpoint_name" {
+				break
+			}
+			val, err := lex.nextToken()
+			if err != nil {
+				return nil, err
+			}
+			if val.kind != tokIdent && val.kind != tokString {
+				return nil, ErrRewriteUnsupported
+			}
+			stmt := &stmtSpan{start: tok.off, end: val.end}
+			cur := &spans[len(spans)-1]
+			if tok.text == "application" {
+				if cur.application != nil {
+					return nil, ErrRewriteUnsupported
+				}
+				cur.application = stmt
+			} else {
+				if cur.endpointName != nil {
+					return nil, ErrRewriteUnsupported
+				}
+				cur.endpointName = stmt
+			}
+			prev = val
+			hasPrev = true
+			continue
+		}
+
+		prev = tok
+		hasPrev = true
+	}
+
+	if depth != 0 || inRoute {
+		return nil, ErrRewriteUnsupported
+	}
+	return spans, nil
+}
+
+// managedEndpointEdits produces the splices that turn before's managed-endpoint
+// directives into after's.
+func managedEndpointEdits(src string, span routeSpan, before, after Route) ([]sourceEdit, error) {
+	var edits []sourceEdit
+
+	type directive struct {
+		name   string
+		span   *stmtSpan
+		set    bool
+		value  string
+		quoted bool
+		change bool
+	}
+	directives := []directive{
+		{
+			name:   "application",
+			span:   span.application,
+			set:    after.ApplicationSet,
+			value:  after.Application,
+			quoted: after.ApplicationQuoted,
+			change: before.ApplicationSet != after.ApplicationSet || before.Application != after.Application || before.ApplicationQuoted != after.ApplicationQuoted,
+		},
+		{
+			name:   "endpoint_name",
+			span:   span.endpointName,
+			set:    after.EndpointNameSet,
+			value:  after.EndpointName,
+			quoted: after.EndpointNameQuoted,
+			change: before.EndpointNameSet != after.EndpointNameSet || before.EndpointName != after.EndpointName || before.EndpointNameQuoted != after.EndpointNameQuoted,
+		},
+	}
+
+	// Insertions all land at the top of the block body, so they are emitted in
+	// declaration order to keep application above endpoint_name.
+	indent := bodyIndent(src, span)
+	insertAt := span.bodyStart
+	var inserted []string
+
+	for _, d := range directives {
+		if !d.change {
+			continue
+		}
+		switch {
+		case d.set && d.span != nil:
+			edits = append(edits, sourceEdit{
+				start: d.span.start,
+				end:   d.span.end,
+				text:  d.name + " " + formatValue(d.value, d.quoted),
+			})
+		case d.set:
+			if !insertableBody(src, span) {
+				return nil, ErrRewriteUnsupported
+			}
+			inserted = append(inserted, "\n"+indent+d.name+" "+formatValue(d.value, d.quoted))
+		case d.span != nil:
+			edits = append(edits, removeStatement(src, *d.span))
+		}
+	}
+
+	if len(inserted) > 0 {
+		edits = append(edits, sourceEdit{start: insertAt, end: insertAt, text: strings.Join(inserted, "")})
+	}
+	return edits, nil
+}
+
+// insertableBody reports whether the block body starts on its own line, which
+// is what makes inserting a directive line after the opening brace safe. A
+// single-line block (`/hooks { publish }`) falls back to the canonical rewrite
+// rather than producing a mangled line.
+func insertableBody(src string, span routeSpan) bool {
+	for i := span.bodyStart; i < span.bodyEnd && i < len(src); i++ {
+		switch src[i] {
+		case ' ', '\t':
+		case '\n':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// bodyIndent returns the indentation the block's existing directives use, or
+// the route's own indentation plus one level when the body has none.
+func bodyIndent(src string, span routeSpan) string {
+	body := src[span.bodyStart:min(span.bodyEnd, len(src))]
+	for _, line := range strings.Split(body, "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		return line[:len(line)-len(strings.TrimLeft(line, " \t"))]
+	}
+	return lineIndent(src, span.headStart) + "  "
+}
+
+// lineIndent returns the leading whitespace of the line that off sits on.
+func lineIndent(src string, off int) string {
+	start := strings.LastIndexByte(src[:off], '\n') + 1
+	prefix := src[start:off]
+	return prefix[:len(prefix)-len(strings.TrimLeft(prefix, " \t"))]
+}
+
+// removeStatement deletes a directive, taking its whole line with it when the
+// line holds nothing else. A trailing comment on the same line is kept.
+func removeStatement(src string, stmt stmtSpan) sourceEdit {
+	start, end := stmt.start, stmt.end
+
+	lineStart := strings.LastIndexByte(src[:start], '\n') + 1
+	if strings.TrimLeft(src[lineStart:start], " \t") != "" {
+		return sourceEdit{start: start, end: end}
+	}
+
+	rest := src[end:]
+	nl := strings.IndexByte(rest, '\n')
+	tail := rest
+	if nl >= 0 {
+		tail = rest[:nl]
+	}
+	if strings.TrimSpace(tail) != "" {
+		// Something else follows on the line (typically a comment). Drop only
+		// the directive itself so the comment survives.
+		return sourceEdit{start: start, end: end}
+	}
+	if nl < 0 {
+		return sourceEdit{start: lineStart, end: len(src)}
+	}
+	return sourceEdit{start: lineStart, end: end + nl + 1}
+}
+
+func applyEdits(src []byte, edits []sourceEdit) ([]byte, error) {
+	if len(edits) == 0 {
+		return append([]byte(nil), src...), nil
+	}
+	// Stable, so two edits at the same offset (the paired insertions) keep the
+	// order they were produced in.
+	sorted := slices.Clone(edits)
+	slices.SortStableFunc(sorted, func(a, b sourceEdit) int { return a.start - b.start })
+
+	var out bytes.Buffer
+	prev := 0
+	for _, e := range sorted {
+		if e.start < prev || e.end < e.start || e.end > len(src) {
+			return nil, ErrRewriteUnsupported
+		}
+		out.Write(src[prev:e.start])
+		out.WriteString(e.text)
+		prev = e.end
+	}
+	out.Write(src[prev:])
+	return out.Bytes(), nil
+}

--- a/internal/config/edit_test.go
+++ b/internal/config/edit_test.go
@@ -1,0 +1,255 @@
+package config
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const managedEndpointSource = `# Hookaidofile for the billing DMZ.
+pull_api { auth token "raw:t" }
+
+# Invoice sink. Do not repoint without telling the billing team.
+"/a" {
+  # mapped by the Admin API
+  application "billing"
+  endpoint_name "invoice.created"
+  pull { path "/e1" }
+}
+
+# Spare route, kept for the cutover.
+"/b" {
+  pull { path "/e2" }
+}
+`
+
+func parseForEdit(t *testing.T, src string) *Config {
+	t.Helper()
+	cfg, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return cfg
+}
+
+func setManaged(r *Route, application, endpointName string) {
+	r.Application = application
+	r.ApplicationQuoted = true
+	r.ApplicationSet = true
+	r.EndpointName = endpointName
+	r.EndpointNameQuoted = true
+	r.EndpointNameSet = true
+}
+
+func clearManaged(r *Route) {
+	r.Application = ""
+	r.ApplicationQuoted = false
+	r.ApplicationSet = false
+	r.EndpointName = ""
+	r.EndpointNameQuoted = false
+	r.EndpointNameSet = false
+}
+
+// TestRewriteManagedEndpoints_MoveKeepsComments is the regression test for the
+// Admin API deleting every in-body comment: a managed endpoint moved from one
+// route to another must leave the rest of the file byte-identical.
+func TestRewriteManagedEndpoints_MoveKeepsComments(t *testing.T) {
+	cfg := parseForEdit(t, managedEndpointSource)
+	clearManaged(&cfg.Routes[0])
+	setManaged(&cfg.Routes[1], "billing", "invoice.created")
+
+	out, err := RewriteManagedEndpoints([]byte(managedEndpointSource), cfg)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got := string(out)
+
+	for _, comment := range []string{
+		"# Hookaidofile for the billing DMZ.",
+		"# Invoice sink. Do not repoint without telling the billing team.",
+		"# mapped by the Admin API",
+		"# Spare route, kept for the cutover.",
+	} {
+		if !strings.Contains(got, comment) {
+			t.Fatalf("comment %q was dropped:\n%s", comment, got)
+		}
+	}
+
+	reparsed := parseForEdit(t, got)
+	if reparsed.Routes[0].ApplicationSet || reparsed.Routes[0].EndpointNameSet {
+		t.Fatalf("route /a still carries a managed endpoint:\n%s", got)
+	}
+	if reparsed.Routes[1].Application != "billing" || reparsed.Routes[1].EndpointName != "invoice.created" {
+		t.Fatalf("route /b did not receive the managed endpoint:\n%s", got)
+	}
+
+	// Everything that is not a managed-endpoint directive must be untouched,
+	// down to blank lines and indentation.
+	if before, after := withoutManagedLines(managedEndpointSource), withoutManagedLines(got); before != after {
+		t.Fatalf("rewrite touched more than the managed-endpoint lines:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
+func TestRewriteManagedEndpoints_UpdateInPlace(t *testing.T) {
+	cfg := parseForEdit(t, managedEndpointSource)
+	setManaged(&cfg.Routes[0], "billing", "invoice.paid")
+
+	out, err := RewriteManagedEndpoints([]byte(managedEndpointSource), cfg)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `  endpoint_name "invoice.paid"`) {
+		t.Fatalf("value was not replaced in place:\n%s", got)
+	}
+	if before, after := withoutManagedLines(managedEndpointSource), withoutManagedLines(got); before != after {
+		t.Fatalf("rewrite touched more than the managed-endpoint line:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+	if strings.Contains(got, "invoice.created") {
+		t.Fatalf("old value survived:\n%s", got)
+	}
+}
+
+func TestRewriteManagedEndpoints_ClearKeepsTrailingComment(t *testing.T) {
+	src := `pull_api { auth token "raw:t" }
+"/a" {
+  application "billing" # owned by billing
+  endpoint_name "invoice.created"
+  pull { path "/e1" }
+}
+`
+	cfg := parseForEdit(t, src)
+	clearManaged(&cfg.Routes[0])
+
+	out, err := RewriteManagedEndpoints([]byte(src), cfg)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "# owned by billing") {
+		t.Fatalf("trailing comment was dropped:\n%s", got)
+	}
+	if strings.Contains(got, "application ") || strings.Contains(got, "endpoint_name ") {
+		t.Fatalf("directives were not removed:\n%s", got)
+	}
+}
+
+func TestRewriteManagedEndpoints_InsertUsesBodyIndent(t *testing.T) {
+	src := `pull_api { auth token "raw:t" }
+"/a" {
+    pull { path "/e1" }
+}
+`
+	cfg := parseForEdit(t, src)
+	setManaged(&cfg.Routes[0], "billing", "invoice.created")
+
+	out, err := RewriteManagedEndpoints([]byte(src), cfg)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, "\n    application \"billing\"\n    endpoint_name \"invoice.created\"\n") {
+		t.Fatalf("inserted directives do not follow the body indentation:\n%s", got)
+	}
+}
+
+func TestRewriteManagedEndpoints_CRLFSource(t *testing.T) {
+	src := strings.ReplaceAll(managedEndpointSource, "\n", "\r\n")
+	cfg := parseForEdit(t, src)
+	setManaged(&cfg.Routes[1], "billing", "invoice.created")
+	clearManaged(&cfg.Routes[0])
+
+	out, err := RewriteManagedEndpoints([]byte(src), cfg)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	got := string(out)
+	if strings.Contains(got, "\r") {
+		t.Fatalf("output kept carriage returns, Parse would normalize them away:\n%q", got)
+	}
+	if !strings.Contains(got, "# mapped by the Admin API") {
+		t.Fatalf("comment was dropped from CRLF source:\n%s", got)
+	}
+}
+
+// A body that holds everything on one line is not spliced: inserting a
+// directive line there would produce a mangled block, so the caller falls back
+// to the canonical rewrite.
+func TestRewriteManagedEndpoints_SingleLineBodyUnsupported(t *testing.T) {
+	src := `pull_api { auth token "raw:t" }
+"/a" { pull { path "/e1" } }
+`
+	cfg := parseForEdit(t, src)
+	setManaged(&cfg.Routes[0], "billing", "invoice.created")
+
+	if _, err := RewriteManagedEndpoints([]byte(src), cfg); !errors.Is(err, ErrRewriteUnsupported) {
+		t.Fatalf("expected ErrRewriteUnsupported, got %v", err)
+	}
+}
+
+// The self-check is what keeps the splice honest: any change the rewrite does
+// not model must be reported rather than silently written to disk.
+func TestRewriteManagedEndpoints_UnmodelledChangeUnsupported(t *testing.T) {
+	cfg := parseForEdit(t, managedEndpointSource)
+	setManaged(&cfg.Routes[1], "billing", "invoice.created")
+	cfg.Routes[1].Pull.Path = "/moved"
+
+	if _, err := RewriteManagedEndpoints([]byte(managedEndpointSource), cfg); !errors.Is(err, ErrRewriteUnsupported) {
+		t.Fatalf("expected ErrRewriteUnsupported for an unmodelled change, got %v", err)
+	}
+}
+
+func TestRewriteManagedEndpoints_RouteCountMismatch(t *testing.T) {
+	cfg := parseForEdit(t, managedEndpointSource)
+	cfg.Routes = cfg.Routes[:1]
+
+	if _, err := RewriteManagedEndpoints([]byte(managedEndpointSource), cfg); !errors.Is(err, ErrRewriteUnsupported) {
+		t.Fatalf("expected ErrRewriteUnsupported, got %v", err)
+	}
+}
+
+func TestRewriteManagedEndpoints_NoChangeIsByteIdentical(t *testing.T) {
+	cfg := parseForEdit(t, managedEndpointSource)
+
+	out, err := RewriteManagedEndpoints([]byte(managedEndpointSource), cfg)
+	if err != nil {
+		t.Fatalf("rewrite: %v", err)
+	}
+	if string(out) != managedEndpointSource {
+		t.Fatalf("no-op rewrite changed the file:\n%s", out)
+	}
+}
+
+func TestHasInBodyComments(t *testing.T) {
+	tests := []struct {
+		name string
+		src  string
+		want bool
+	}{
+		{name: "preamble only", src: "# header\npull_api { auth token \"raw:t\" }\n", want: false},
+		{name: "in body", src: "pull_api { auth token \"raw:t\" }\n# note\n\"/a\" { pull { path \"/e1\" } }\n", want: true},
+		{name: "inside block", src: "pull_api {\n  # note\n  auth token \"raw:t\"\n}\n", want: true},
+		{name: "none", src: "pull_api { auth token \"raw:t\" }\n", want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := HasInBodyComments([]byte(tc.src)); got != tc.want {
+				t.Fatalf("HasInBodyComments = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// withoutManagedLines drops the managed-endpoint directive lines so a test can
+// assert that a rewrite left every other byte of the file alone.
+func withoutManagedLines(src string) string {
+	var kept []string
+	for _, line := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "application ") || strings.HasPrefix(trimmed, "endpoint_name ") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}

--- a/internal/config/fuzz_test.go
+++ b/internal/config/fuzz_test.go
@@ -35,6 +35,17 @@ secrets {
 }
 `))
 
+	// Backslashes: unknown escapes used to lose theirs, and the formatter has
+	// to re-escape what survives or the second parse sees a different value.
+	f.Add([]byte(`
+"/x" {
+  deliver "https://example.org/x" {
+    header "X-Path" "C:\certs\server.pem"
+    header "X-Regex" "^/hooks/\d+$"
+  }
+}
+`))
+
 	f.Fuzz(func(t *testing.T, input []byte) {
 		cfg, err := Parse(input)
 		if err != nil {
@@ -51,8 +62,17 @@ secrets {
 			t.Fatalf("parse formatted config: %v\nformatted:\n%s", err, string(formatted))
 		}
 
-		if _, err := Format(cfg2); err != nil {
+		again, err := Format(cfg2)
+		if err != nil {
 			t.Fatalf("format re-parsed config: %v", err)
+		}
+
+		// `config fmt` is required to be stable, and the file it writes is the
+		// one the next parse reads: if the second format differs from the
+		// first, formatting a config repeatedly keeps changing the operator's
+		// file, and the value the runtime sees drifts with it.
+		if string(again) != string(formatted) {
+			t.Fatalf("format is not stable:\nfirst:\n%s\nsecond:\n%s", string(formatted), string(again))
 		}
 
 		_ = ValidateWithResult(cfg2)

--- a/internal/config/lexer.go
+++ b/internal/config/lexer.go
@@ -21,6 +21,12 @@ type token struct {
 	kind tokenKind
 	text string
 	pos  position
+
+	// off and end delimit the token in the source, as byte offsets. They let
+	// callers that need to rewrite a file in place (see edit.go) address the
+	// exact bytes of a statement instead of regenerating the file from the AST.
+	off int
+	end int
 }
 
 type position struct {
@@ -51,7 +57,7 @@ func newLexer(src string) *lexer {
 func (l *lexer) nextToken() (token, error) {
 	for {
 		if l.i >= len(l.src) {
-			return token{kind: tokEOF, pos: position{line: l.line, col: l.col}}, nil
+			return token{kind: tokEOF, pos: position{line: l.line, col: l.col}, off: l.i, end: l.i}, nil
 		}
 
 		r, size := utf8.DecodeRuneInString(l.src[l.i:])
@@ -65,15 +71,16 @@ func (l *lexer) nextToken() (token, error) {
 		}
 
 		pos := position{line: l.line, col: l.col}
+		off := l.i
 		switch r {
 		case '{':
 			if text, ok, err := l.readPlaceholder(); err != nil {
 				return token{}, err
 			} else if ok {
-				return token{kind: tokIdent, text: text, pos: pos}, nil
+				return token{kind: tokIdent, text: text, pos: pos, off: off, end: l.i}, nil
 			}
 			l.consumeRune(r, size)
-			return token{kind: tokLBrace, text: "{", pos: pos}, nil
+			return token{kind: tokLBrace, text: "{", pos: pos, off: off, end: l.i}, nil
 		case '#':
 			// Comment until end of line (including the leading '#').
 			start := l.i
@@ -84,19 +91,19 @@ func (l *lexer) nextToken() (token, error) {
 				}
 				l.consumeRune(r2, size2)
 			}
-			return token{kind: tokComment, text: l.src[start:l.i], pos: pos}, nil
+			return token{kind: tokComment, text: l.src[start:l.i], pos: pos, off: off, end: l.i}, nil
 		case '}':
 			l.consumeRune(r, size)
-			return token{kind: tokRBrace, text: "}", pos: pos}, nil
+			return token{kind: tokRBrace, text: "}", pos: pos, off: off, end: l.i}, nil
 		case '"':
 			s, err := l.readString()
 			if err != nil {
 				return token{}, err
 			}
-			return token{kind: tokString, text: s, pos: pos}, nil
+			return token{kind: tokString, text: s, pos: pos, off: off, end: l.i}, nil
 		default:
 			ident := l.readIdent()
-			return token{kind: tokIdent, text: ident, pos: pos}, nil
+			return token{kind: tokIdent, text: ident, pos: pos, off: off, end: l.i}, nil
 		}
 	}
 }
@@ -197,8 +204,14 @@ func (l *lexer) readString() (string, error) {
 			case 'r':
 				out = append(out, '\r')
 			default:
-				// Keep unknown escapes as-is (best-effort).
-				out = append(out, er)
+				// Keep unknown escapes as-is: backslash and the escaped
+				// rune. Dropping the backslash here silently corrupted
+				// every quoted Windows path (`"C:\certs\x.pem"` became
+				// `C:certsx.pem`), and `config fmt`/the Admin API config
+				// rewrite then persisted the corruption. Emitting both
+				// runes stays round-trip safe because quoteString escapes
+				// a literal backslash as `\\`.
+				out = append(out, '\\', er)
 			}
 			continue
 		}

--- a/internal/config/lexer_test.go
+++ b/internal/config/lexer_test.go
@@ -1,0 +1,112 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+// Unknown escapes used to lose their backslash, so a quoted Windows path was
+// silently corrupted (`"C:\certs\server.pem"` parsed as `C:certsserver.pem`)
+// and `config fmt` -- or an Admin API config rewrite -- then persisted the
+// corruption.
+func TestParseQuotedString_UnknownEscapesKeepBackslash(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "windows path", in: `C:\certs\server.pem`, want: `C:\certs\server.pem`},
+		{name: "regex class", in: `^/hooks/\d+$`, want: `^/hooks/\d+$`},
+		{name: "escaped backslash", in: `a\\b`, want: `a\b`},
+		{name: "escaped quote", in: `say \"hi\"`, want: `say "hi"`},
+		{name: "newline", in: `line1\nline2`, want: "line1\nline2"},
+		{name: "tab", in: `a\tb`, want: "a\tb"},
+		{name: "carriage return", in: `a\rb`, want: "a\rb"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			src := "ingress {\n  listen \"" + tc.in + "\"\n}\n"
+			cfg, err := Parse([]byte(src))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := cfg.Ingress.Listen; got != tc.want {
+				t.Fatalf("listen = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The fix is only worth anything if the value also survives the formatter,
+// since `config fmt` and the Admin API config rewrite both write Format's
+// output back to the operator's file.
+func TestFormatRoundTrip_PreservesBackslashes(t *testing.T) {
+	const want = `C:\certs\server.pem`
+	src := "ingress {\n  listen \"" + want + "\"\n}\n"
+
+	cfg, err := Parse([]byte(src))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	formatted, err := Format(cfg)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	if !strings.Contains(string(formatted), `"C:\\certs\\server.pem"`) {
+		t.Fatalf("formatter did not re-escape the backslashes:\n%s", formatted)
+	}
+
+	reparsed, err := Parse(formatted)
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	if got := reparsed.Ingress.Listen; got != want {
+		t.Fatalf("value after round trip = %q, want %q", got, want)
+	}
+
+	again, err := Format(reparsed)
+	if err != nil {
+		t.Fatalf("reformat: %v", err)
+	}
+	if string(again) != string(formatted) {
+		t.Fatalf("format is not stable:\nfirst:\n%s\nsecond:\n%s", formatted, again)
+	}
+}
+
+// parseValue is the one call site that reaches the lexer without peeking
+// first, so it has to propagate the lexer's error instead of reporting
+// "expected value" at the impossible position 0:0.
+func TestParseValue_ReportsLexerError(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantSub string
+	}{
+		{
+			name:    "unterminated string",
+			src:     "ingress {\n  listen \"oops\n}\n",
+			wantSub: "unterminated string at 2:",
+		},
+		{
+			name:    "invalid utf-8",
+			src:     "ingress {\n  listen \"a" + string([]byte{0xff}) + "b\"\n}\n",
+			wantSub: "invalid utf-8 at 2:",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.src))
+			if err == nil {
+				t.Fatal("expected a parse error")
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Fatalf("error %q does not contain %q", err, tc.wantSub)
+			}
+			if strings.Contains(err.Error(), "0:0") {
+				t.Fatalf("error still reports the zero position: %v", err)
+			}
+		})
+	}
+}

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -3673,7 +3673,15 @@ func isDeliverDirective(name string) bool {
 }
 
 func (p *parser) parseValue() (string, bool, error) {
-	tok, _ := p.next()
+	// The lexer error has to be propagated here. Unlike the directive loops,
+	// which peek (and return the error) before consuming, this is the one call
+	// site that reaches the lexer directly, so swallowing the error reported an
+	// unterminated string or invalid UTF-8 as "expected value" at position 0:0
+	// -- a position that cannot exist, since lines are 1-based.
+	tok, err := p.next()
+	if err != nil {
+		return "", false, err
+	}
 	switch tok.kind {
 	case tokString, tokIdent:
 		return tok.text, tok.kind == tokString, nil


### PR DESCRIPTION
## Summary

The three config lexer/parser/format defects from #250.

### Unknown escapes dropped their backslash, and the corruption was persisted

`readString` handled `\\`, `\"`, `\n`, `\t`, `\r` and fell through to a `default` arm that appended only the escaped rune — under a comment claiming it kept unknown escapes as-is. `cert_file "C:\certs\server.pem"` parsed as `C:certsserver.pem`; `"^/hooks/\d+$"` as `^/hooks/d+$`. Nothing warned, and the operator saw only a downstream "file not found" or a matcher that never fired. `config fmt` and the Admin API config rewrite then wrote the mangled value back, making it permanent.

The `default` arm now emits the backslash **and** the rune, which is what the comment always claimed. That is round-trip safe in both directions: `quoteString` escapes a literal backslash as `\\`, so the value survives format → parse → format unchanged (a new test asserts the second format is byte-identical to the first).

I chose preserving over rejecting — the other option the issue offers — because rejection breaks configs that are currently *correct*: `"^/hooks/\d+$"` is a regex an operator wrote deliberately, and a parse error would take the process down on reload rather than fix anything. Preserving also matches every other Caddy-style DSL.

What preserving does **not** fix, and cannot: `"C:\new\tools"` still contains a newline and a tab, because `\n` and `\t` are real escapes. That is inherent to having an escape syntax at all, so it is now documented (`docs/configuration.md`, new "Values, Quoting and Comments" section) with the two ways out — double the backslash, or use forward slashes, which Windows accepts.

### Admin API managed-endpoint mutations deleted every in-body comment

`mutateManagedEndpointConfig` wrote `Format(cfg)` on every applied upsert or delete. The parser keeps comments only in `Config.Preamble`, and `Format` emits only that, so **one** admin call erased every route annotation, rotation note and TODO below the first statement — in the file `AGENTS.md` calls the source of truth, with no warning and no way to get it back.

The issue offers "preserve comments through the AST, or at minimum warn/refuse". I did neither, because there is a third option that is strictly better than both for this path.

Refusing would leave an operator whose Hookaidofile has comments — i.e. any maintained one — with a permanently broken managed-endpoint API. Warning does not stop the loss. And attaching comments to the AST is a rewrite of a 3,700-line parser and a 1,100-line formatter that would put the "`config fmt` is stable" guardrail at risk, to serve a path that changes exactly two directives.

So the mutation path no longer regenerates the file at all. `config.RewriteManagedEndpoints` (new, `internal/config/edit.go`) splices `application`/`endpoint_name` into the existing source and leaves every other byte alone. Everything else in the file — comments, blank lines, the operator's indentation, one-line blocks — is untouched, so the resulting `git diff` is the two lines that actually changed instead of a whole-file rewrite.

It is deliberately narrow and self-verifying:

- The lexer now records byte offsets per token (`off`/`end`), and a scanner locates each top-level route block and the two directives inside it. Nested blocks are skipped by depth, so a `deliver` block's directives can never be mistaken for a route's.
- Existing directive → value replaced in place. Missing → inserted after the opening brace at the body's own indentation. Removed → the whole line goes, unless something else shares it (a trailing comment survives, on its own line).
- **The result is checked before it is returned**: the spliced source is reparsed and its canonical form compared byte-for-byte against `Format(updated)`. Any mismatch — an edit the splicer does not model, an unexpected source shape, a single-line block body it declines to touch — returns `ErrRewriteUnsupported`.

`run.go` falls back to `Format(cfg)` on that error, so the worst case is exactly today's behaviour, and it logs `config_rewrite_dropped_comments` when the file being rewritten actually has in-body comments. The loss is never silent again.

`config fmt` still regenerates the file and still keeps only the preamble. The issue calls that acceptable for an explicit command, and I agree — but it is now documented rather than discovered.

### `parseValue` swallowed the lexer error

`tok, _ := p.next()` reported an unterminated string or invalid UTF-8 in a value position as `config parse error at 0:0: expected value` — and `0:0` is a position that cannot exist, since lines are 1-based, so the operator had nowhere to look.

`parseValue` is the one call site that reaches the lexer without peeking first (the 35 other `p.next()` sites all follow a `peek` that has already returned the error, which is why they can ignore it). It now propagates, like `expect` next to it does.

## Related Issues

Closes #250

## Scope

- [x] DSL / config behavior
- [x] Runtime behavior
- [x] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [x] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

Also run: `go vet ./...`, and a 60s `FuzzParseFormatRoundTrip` run (4.5M execs, no failures) after strengthening that target.

New tests, all three of which were verified to **fail** against the previous implementation by reverting the fix and re-running — they are regression tests, not assertions that happened to hold:

- `internal/config/lexer_test.go` — seven escape cases (Windows path, regex class, and the five real escapes), the format→parse→format round trip including format stability, and the two lexer-error positions.
- `internal/config/edit_test.go` — nine cases for the splice: a move keeps all four comments and touches nothing but the two directive lines; in-place value update; clear keeps a trailing comment; insertion follows the body's indentation; CRLF input; and the four ways it declines (single-line body, unmodelled change, route-count mismatch, no-op is byte-identical).
- `internal/app/run_test.go` — the end-to-end one: an Admin API upsert that moves a managed endpoint between routes leaves the Hookaidofile's comments intact.

`FuzzParseFormatRoundTrip` also gained a backslash-carrying seed and an assertion that the second `Format` equals the first — the "`config fmt` is stable" guardrail was in the target's name but not in its assertions.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

Two behavioural notes for operators:

- **A config that relied on the old escape handling changes meaning.** If someone worked around the corruption by writing `cert_file "C:certsserver.pem"` — the mangled value — that still parses as itself and is unaffected. But a value that *was* being silently mangled now resolves to what the file says, which is the fix: the path that failed to open now opens. Anyone who had adapted a downstream system to the corrupted value should check it. `\\`, `\"`, `\n`, `\t`, `\r` are unchanged.
- **Admin API mutations now produce a minimal diff instead of a reformatted file.** If any tooling diffs the Hookaidofile after an admin call and expected canonical formatting, it will now see the file's original layout. Running `config fmt` explicitly still normalizes it.

## Notes for Reviewers

- The self-check in `RewriteManagedEndpoints` is the load-bearing part. It means the splicer cannot write a file that disagrees with the config the mutation intended, whatever the source looks like — the failure mode is "falls back to the old behaviour", not "writes something wrong". Worth reading first: `internal/config/edit.go:75-93`.
- `token.off`/`token.end` are the only lexer surface added. They are set at every return site; `parse()` ignores them entirely.
- CRLF files come back as LF, because the splice runs on `normalizeInput`'s output — the same normalization `Parse` applies, and the same conversion `Format` would have done. `.gitattributes` normalizes on commit anyway.
- The escape decision is the one place I deviated from a literal reading of the issue (preserve rather than reject). Reasoning is under the first heading above; if you would rather reject, it is a two-line change to that `default` arm plus a docs paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
