### PR TITLE
feat(config): add attempts_retention, prune delivery-attempt history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **`attempts_retention { max_age, max_rows }`** bounds delivery-attempt history, which was append-only in every backend — nothing anywhere deleted or capped it. A push deployment doing 10 attempts/s added ~860k records a day forever: the SQLite file and its indexes grew until the disk filled and enqueue started failing, and the memory backend grew until the process was OOM-killed, invisible to the memory-pressure guard because that counts only queued payloads. Defaults are deliberately finite (`max_age 7d`, `max_rows 200000`); set both `off` to restore the previous unbounded behaviour. Pruning uses the existing `queue_retention.prune_interval` cadence, and the memory backend enforces `max_rows` as it writes.
+
 ### Fixed
 
 - **Postgres: routine retention no longer stalls ingest.** `maybePrune` held the store mutex — which also guards `now()`, the notify channel and every store operation's first step — across up to four unbounded `DELETE` statements. A retention pass with millions of eligible rows blocked all enqueues, dequeues, SSE notify registrations and long-poll wakeups for the duration of the delete. Pruning now runs under its own mutex, as it does on SQLite, and deletes in bounded chunks. On both backends a store operation that arrives while a prune is running now proceeds instead of queueing behind it.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -60,6 +60,7 @@ Global:
 - `queue_retention { max_age, prune_interval }`
 - `delivered_retention { max_age }`
 - `dlq_retention { max_age, max_depth }`
+- `attempts_retention { max_age, max_rows }`
 - `secrets { secret "ID" { value, valid_from, valid_until? } }`
 - `defaults { max_body, max_headers, egress?, publish_policy?, deliver?, trend_signals?, adaptive_backpressure? }`
 - `observability { access_log, runtime_log?, metrics?, tracing? }`:
@@ -190,6 +191,12 @@ Persisted, replayable envelope:
 - For `queue { backend memory }`, when delivered retention is enabled, `queue_limits.max_depth`
   also guards `queued + leased + delivered` items to bound in-memory retention growth.
 - Set `max_age off` (or `0`) to disable delivered retention.
+
+### Delivery-Attempt Retention & Pruning
+- Controlled by `attempts_retention { max_age, max_rows }`.
+- Pruning removes attempt records older than `max_age` and caps the history at `max_rows` (oldest first).
+- Pruning cadence uses `queue_retention.prune_interval`; the memory backend also enforces `max_rows` on write.
+- Set `max_age off` and `max_rows off` to disable attempt retention. Attempt history is otherwise append-only, so the defaults are finite by design.
 
 ### DLQ Retention & Pruning
 - Controlled by `dlq_retention { max_age, max_depth }`.
@@ -351,6 +358,7 @@ Endpoints:
 - memory-backend pressure guard (runtime): retained non-active item limit `max(max_depth, 1000)` and retained non-active byte limit `256MiB` (whichever triggers first emits `ErrMemoryPressure` / ingress `503`)
 - `queue_retention`: `max_age "7d"`, `prune_interval "5m"`
 - `dlq_retention`: `max_age "30d"`, `max_depth 10000`
+- `attempts_retention`: `max_age "7d"`, `max_rows 200000`
 - `deliver`: retry exponential (`max 8`, `base 2s`, `cap 2m`, `jitter 0.2`), `timeout 10s`, `concurrency 20`
 - deliver signing headers (when `sign hmac` is set): `signature_header "X-Hookaido-Signature"`, `timestamp_header "X-Hookaido-Timestamp"`
 - deliver signing secret selection (when multiple `sign hmac secret_ref` are set): `secret_selection "newest_valid"`

--- a/Hookaidofile
+++ b/Hookaidofile
@@ -5,7 +5,7 @@
 # Supported top-level blocks:
 #   ingress, pull_api, admin_api, vars, secrets, defaults,
 #   observability, queue_limits, queue_retention, delivered_retention,
-#   dlq_retention, named matchers (@name { ... })
+#   dlq_retention, attempts_retention, named matchers (@name { ... })
 #
 # Route directives:
 #   match, rate_limit, auth (basic | hmac | forward), queue,
@@ -77,6 +77,12 @@ pull_api {
 # dlq_retention {
 #   max_age 30d
 #   max_depth 10000
+# }
+
+# Delivery-attempt history retention (optional; defaults shown)
+# attempts_retention {
+#   max_age 7d
+#   max_rows 200000
 # }
 
 # Queue limits (optional; defaults shown)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -291,6 +291,26 @@ dlq_retention {
 }
 ```
 
+### `attempts_retention`
+
+```hcl
+attempts_retention {
+  max_age 7d        # prune delivery attempts older than this
+  max_rows 200000   # cap the attempt history
+}
+```
+
+Every delivery attempt is recorded (see [Delivery → Delivery Attempts](delivery.md#delivery-attempts)).
+That history is append-only, so both limits default to finite values rather than
+unbounded growth: without them a push deployment doing 10 attempts/s adds ~860k
+records a day forever — the SQLite file grows until the disk fills, and the
+memory backend grows until the process is killed, invisible to the
+memory-pressure guard, which counts only queued payloads.
+
+Pruning uses the same `queue_retention.prune_interval` cadence; the memory
+backend additionally enforces `max_rows` as it writes. Set `max_age off` and
+`max_rows off` to keep attempts forever, which is what earlier versions did.
+
 ### `secrets`
 
 Define named secrets with validity windows for key rotation:
@@ -687,6 +707,8 @@ Placeholders resolve within a single value (no cross-token expansion).
 | `queue_retention.prune_interval` | `5m`                                          |
 | `dlq_retention.max_age`          | `30d`                                         |
 | `dlq_retention.max_depth`        | `10000`                                       |
+| `attempts_retention.max_age`     | `7d`                                          |
+| `attempts_retention.max_rows`    | `200000`                                      |
 | `deliver.retry`                  | `exponential max 8 base 2s cap 2m jitter 0.2` |
 | `deliver.timeout`                | `10s`                                         |
 | `deliver.concurrency`            | `20`                                          |

--- a/docs/delivery.md
+++ b/docs/delivery.md
@@ -231,6 +231,10 @@ A requeued message starts its retry budget over: it is delivered as if newly enq
 
 ## Delivery Attempts
 
+Attempt history is bounded by [`attempts_retention`](configuration.md#attempts_retention)
+(`max_age 7d`, `max_rows 200000` by default). Earlier versions kept every attempt
+forever on every backend.
+
 Each delivery attempt is recorded with:
 
 - `event_id` — source message ID

--- a/docs/deployment-modes.md
+++ b/docs/deployment-modes.md
@@ -192,7 +192,7 @@ Filesystem snapshots (LVM, ZFS, EBS) also work — SQLite WAL is crash-safe.
 - [ ] Enable TLS on Pull API and Admin API
 - [ ] Use a durable backend: `sqlite` with persistent `--db`, or `postgres` with `--postgres-dsn`/`HOOKAIDO_POSTGRES_DSN`
 - [ ] Admin API defaults to localhost — expose only over a secure channel if needed
-- [ ] Configure `queue_limits`, `queue_retention`, and `dlq_retention` for your throughput
+- [ ] Configure `queue_limits`, `queue_retention`, `dlq_retention`, and `attempts_retention` for your throughput
 - [ ] Enable [observability](observability.md) (metrics + access logs at minimum)
 
 ---

--- a/editors/vscode/syntaxes/hookaidofile.tmLanguage.json
+++ b/editors/vscode/syntaxes/hookaidofile.tmLanguage.json
@@ -66,7 +66,7 @@
       "name": "keyword.control.channel.hookaidofile"
     },
     "top-level-block": {
-      "match": "\\b(ingress|defaults|vars|secrets|pull_api|admin_api|observability|queue_retention|delivered_retention|dlq_retention|queue_limits)\\b",
+      "match": "\\b(ingress|defaults|vars|secrets|pull_api|admin_api|observability|queue_retention|delivered_retention|dlq_retention|attempts_retention|queue_limits)\\b",
       "name": "keyword.other.block.hookaidofile"
     },
     "auth-keyword": {

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -2903,6 +2903,8 @@ func newQueueStore(compiled config.Compiled, dbPath, postgresDSN string) (queue.
 		DeliveredRetentionMaxAge: compiled.DeliveredRetention.MaxAge,
 		DLQRetentionMaxAge:       compiled.DLQRetention.MaxAge,
 		DLQRetentionMaxDepth:     compiled.DLQRetention.MaxDepth,
+		AttemptsRetentionMaxAge:  compiled.AttemptsRetention.MaxAge,
+		AttemptsRetentionMaxRows: compiled.AttemptsRetention.MaxRows,
 	}
 
 	store, closer, err := b.OpenStore(cfg)
@@ -3251,6 +3253,13 @@ func dlqRetentionEqual(a, b config.DLQRetentionConfig) bool {
 	return a.MaxAge == b.MaxAge && a.MaxDepth == b.MaxDepth
 }
 
+func attemptsRetentionEqual(a, b config.AttemptsRetentionConfig) bool {
+	if a.Enabled != b.Enabled {
+		return false
+	}
+	return a.MaxAge == b.MaxAge && a.MaxRows == b.MaxRows
+}
+
 func requiresRestartForReload(compiled, running config.Compiled) bool {
 	if compiled.SharedListener != running.SharedListener ||
 		compiled.IngressShared != running.IngressShared ||
@@ -3279,7 +3288,8 @@ func requiresRestartForReload(compiled, running config.Compiled) bool {
 		!queueLimitsEqual(compiled.QueueLimits, running.QueueLimits) ||
 		!queueRetentionEqual(compiled.QueueRetention, running.QueueRetention) ||
 		!deliveredRetentionEqual(compiled.DeliveredRetention, running.DeliveredRetention) ||
-		!dlqRetentionEqual(compiled.DLQRetention, running.DLQRetention) {
+		!dlqRetentionEqual(compiled.DLQRetention, running.DLQRetention) ||
+		!attemptsRetentionEqual(compiled.AttemptsRetention, running.AttemptsRetention) {
 		return true
 	}
 

--- a/internal/config/attempts_retention_test.go
+++ b/internal/config/attempts_retention_test.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseFormat_AttemptsRetentionBlock(t *testing.T) {
+	in := []byte(`
+attempts_retention {
+  max_age "3d"
+  max_rows 50000
+}
+
+pull_api { auth token "raw:t" }
+
+"/x" { pull { path "/e" } }
+`)
+
+	cfg, err := Parse(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if cfg.AttemptsRetention == nil {
+		t.Fatal("expected an attempts_retention block")
+	}
+
+	out, err := Format(cfg)
+	if err != nil {
+		t.Fatalf("format: %v", err)
+	}
+	got := string(out)
+	if !strings.Contains(got, `max_age "3d"`) {
+		t.Fatalf("expected quoted max_age, got:\n%s", got)
+	}
+	if !strings.Contains(got, "max_rows 50000") {
+		t.Fatalf("expected max_rows 50000, got:\n%s", got)
+	}
+
+	again, err := Parse(out)
+	if err != nil {
+		t.Fatalf("reparse: %v", err)
+	}
+	second, err := Format(again)
+	if err != nil {
+		t.Fatalf("reformat: %v", err)
+	}
+	if string(second) != got {
+		t.Fatalf("format is not stable:\n%s\n---\n%s", got, second)
+	}
+}
+
+func TestCompile_AttemptsRetention(t *testing.T) {
+	const preamble = `
+pull_api { auth token "raw:t" }
+"/x" { pull { path "/e" } }
+`
+
+	tests := []struct {
+		name      string
+		block     string
+		wantAge   time.Duration
+		wantRows  int
+		wantOn    bool
+		wantError string
+	}{
+		{
+			name:     "defaults are finite",
+			block:    "",
+			wantAge:  7 * 24 * time.Hour,
+			wantRows: 200000,
+			wantOn:   true,
+		},
+		{
+			name:     "explicit values",
+			block:    "attempts_retention {\n  max_age \"12h\"\n  max_rows 1000\n}\n",
+			wantAge:  12 * time.Hour,
+			wantRows: 1000,
+			wantOn:   true,
+		},
+		{
+			name:     "age off keeps the row cap",
+			block:    "attempts_retention {\n  max_age off\n}\n",
+			wantAge:  0,
+			wantRows: 200000,
+			wantOn:   true,
+		},
+		{
+			name:     "both off disables retention",
+			block:    "attempts_retention {\n  max_age off\n  max_rows off\n}\n",
+			wantAge:  0,
+			wantRows: 0,
+			wantOn:   false,
+		},
+		{
+			name:      "negative rows rejected",
+			block:     "attempts_retention {\n  max_rows -1\n}\n",
+			wantError: "attempts_retention.max_rows must be a non-negative integer",
+		},
+		{
+			name:      "invalid age rejected",
+			block:     "attempts_retention {\n  max_age \"soon\"\n}\n",
+			wantError: "attempts_retention.max_age",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := Parse([]byte(tc.block + preamble))
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			compiled, res := Compile(cfg)
+
+			if tc.wantError != "" {
+				if res.OK {
+					t.Fatalf("expected a validation error containing %q", tc.wantError)
+				}
+				joined := strings.Join(res.Errors, "; ")
+				if !strings.Contains(joined, tc.wantError) {
+					t.Fatalf("errors %q do not contain %q", joined, tc.wantError)
+				}
+				return
+			}
+
+			if !res.OK {
+				t.Fatalf("compile: %v", res.Errors)
+			}
+			got := compiled.AttemptsRetention
+			if got.MaxAge != tc.wantAge {
+				t.Fatalf("MaxAge = %v, want %v", got.MaxAge, tc.wantAge)
+			}
+			if got.MaxRows != tc.wantRows {
+				t.Fatalf("MaxRows = %d, want %d", got.MaxRows, tc.wantRows)
+			}
+			if got.Enabled != tc.wantOn {
+				t.Fatalf("Enabled = %v, want %v", got.Enabled, tc.wantOn)
+			}
+		})
+	}
+}
+
+func TestCompile_AttemptsRetentionRequiresPruneInterval(t *testing.T) {
+	in := []byte(`
+queue_retention {
+  max_age off
+  prune_interval off
+}
+attempts_retention {
+  max_age "12h"
+}
+pull_api { auth token "raw:t" }
+"/x" { pull { path "/e" } }
+`)
+
+	cfg, err := Parse(in)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	_, res := Compile(cfg)
+	if res.OK {
+		t.Fatal("expected retention without a prune interval to be rejected")
+	}
+	if !strings.Contains(strings.Join(res.Errors, "; "), "queue_retention.prune_interval") {
+		t.Fatalf("unexpected errors: %v", res.Errors)
+	}
+}
+
+func TestParse_AttemptsRetentionRejectsDuplicatesAndUnknownDirectives(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "duplicate block",
+			in:   "attempts_retention { max_age \"1h\" }\nattempts_retention { max_age \"2h\" }\n",
+			want: "duplicate attempts_retention block",
+		},
+		{
+			name: "duplicate max_age",
+			in:   "attempts_retention {\n  max_age \"1h\"\n  max_age \"2h\"\n}\n",
+			want: "duplicate attempts_retention max_age",
+		},
+		{
+			name: "duplicate max_rows",
+			in:   "attempts_retention {\n  max_rows 1\n  max_rows 2\n}\n",
+			want: "duplicate attempts_retention max_rows",
+		},
+		{
+			name: "unknown directive",
+			in:   "attempts_retention {\n  max_depth 5\n}\n",
+			want: `unknown attempts_retention directive "max_depth"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := Parse([]byte(tc.in))
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error %q does not contain %q", err, tc.want)
+			}
+		})
+	}
+}

--- a/internal/config/compile.go
+++ b/internal/config/compile.go
@@ -71,6 +71,8 @@ const (
 	defaultDeliveredRetentionMaxAge       = 0
 	defaultDLQRetentionMaxAge             = 30 * 24 * time.Hour
 	defaultDLQRetentionMaxDepth           = 10000
+	defaultAttemptsRetentionMaxAge        = 7 * 24 * time.Hour
+	defaultAttemptsRetentionMaxRows       = 200000
 	defaultEgressHTTPSOnly                = true
 	defaultEgressRedirects                = false
 	defaultEgressDNSRebindProtection      = true
@@ -112,6 +114,7 @@ type Compiled struct {
 	QueueRetention     QueueRetentionConfig
 	DeliveredRetention DeliveredRetentionConfig
 	DLQRetention       DLQRetentionConfig
+	AttemptsRetention  AttemptsRetentionConfig
 	QueueLimits        QueueLimitsConfig
 	// SharedListener is set when pull_api and admin_api co-listen on the same
 	// address (prefix-muxed). Kept for backward-compatible semantics.
@@ -462,6 +465,15 @@ type DLQRetentionConfig struct {
 	Enabled  bool
 }
 
+// AttemptsRetentionConfig bounds delivery-attempt history. Attempts are written
+// once per delivery attempt and were previously never removed by any backend,
+// so the defaults are deliberately finite.
+type AttemptsRetentionConfig struct {
+	MaxAge  time.Duration
+	MaxRows int
+	Enabled bool
+}
+
 // Compile validates the config and returns a runtime-ready, normalized version
 // with defaults applied.
 func Compile(cfg *Config) (Compiled, ValidationResult) {
@@ -516,6 +528,7 @@ func compileConfig(cfg *Config, untrusted bool) (Compiled, ValidationResult) {
 	qr, qrRes := compileQueueRetention(cfg.QueueRetention)
 	dr, drRes := compileDeliveredRetention(cfg.DeliveredRetention)
 	dlq, dlqRes := compileDLQRetention(cfg.DLQRetention)
+	attempts, attemptsRes := compileAttemptsRetention(cfg.AttemptsRetention)
 	ql, qlRes := compileQueueLimits(cfg.QueueLimits)
 	res.Errors = append(res.Errors, ingRes.Errors...)
 	res.Errors = append(res.Errors, defsRes.Errors...)
@@ -526,6 +539,7 @@ func compileConfig(cfg *Config, untrusted bool) (Compiled, ValidationResult) {
 	res.Errors = append(res.Errors, qrRes.Errors...)
 	res.Errors = append(res.Errors, drRes.Errors...)
 	res.Errors = append(res.Errors, dlqRes.Errors...)
+	res.Errors = append(res.Errors, attemptsRes.Errors...)
 	res.Errors = append(res.Errors, qlRes.Errors...)
 	res.Warnings = append(res.Warnings, ingRes.Warnings...)
 	res.Warnings = append(res.Warnings, defsRes.Warnings...)
@@ -536,6 +550,7 @@ func compileConfig(cfg *Config, untrusted bool) (Compiled, ValidationResult) {
 	res.Warnings = append(res.Warnings, qrRes.Warnings...)
 	res.Warnings = append(res.Warnings, drRes.Warnings...)
 	res.Warnings = append(res.Warnings, dlqRes.Warnings...)
+	res.Warnings = append(res.Warnings, attemptsRes.Warnings...)
 	res.Warnings = append(res.Warnings, qlRes.Warnings...)
 
 	compiled := Compiled{
@@ -549,6 +564,7 @@ func compileConfig(cfg *Config, untrusted bool) (Compiled, ValidationResult) {
 		QueueRetention:     qr,
 		DeliveredRetention: dr,
 		DLQRetention:       dlq,
+		AttemptsRetention:  attempts,
 		QueueLimits:        ql,
 	}
 
@@ -1404,7 +1420,7 @@ func compileConfig(cfg *Config, untrusted bool) (Compiled, ValidationResult) {
 		}
 	}
 
-	if compiled.QueueRetention.PruneInterval <= 0 && (compiled.QueueRetention.Enabled || compiled.DeliveredRetention.Enabled || compiled.DLQRetention.Enabled) {
+	if compiled.QueueRetention.PruneInterval <= 0 && (compiled.QueueRetention.Enabled || compiled.DeliveredRetention.Enabled || compiled.DLQRetention.Enabled || compiled.AttemptsRetention.Enabled) {
 		res.Errors = append(res.Errors, "queue_retention.prune_interval must be a positive duration when retention is enabled")
 	}
 
@@ -2569,6 +2585,52 @@ func compileDLQRetention(in *DLQRetentionBlock) (DLQRetentionConfig, ValidationR
 	}
 
 	out.Enabled = out.MaxAge > 0 || out.MaxDepth > 0
+	return out, res
+}
+
+// compileAttemptsRetention mirrors compileDLQRetention: `off` (or 0) disables a
+// dimension, and the block as a whole is disabled only when both are off.
+func compileAttemptsRetention(in *AttemptsRetentionBlock) (AttemptsRetentionConfig, ValidationResult) {
+	var res ValidationResult
+	out := AttemptsRetentionConfig{
+		MaxAge:  defaultAttemptsRetentionMaxAge,
+		MaxRows: defaultAttemptsRetentionMaxRows,
+		Enabled: true,
+	}
+
+	if in == nil {
+		return out, res
+	}
+
+	if in.MaxAgeSet {
+		raw := strings.TrimSpace(resolveValue(in.MaxAge, "attempts_retention.max_age", &res))
+		d, off, err := parseDurationValue(raw)
+		if err != nil {
+			res.Errors = append(res.Errors, fmt.Sprintf("attempts_retention.max_age %s", err.Error()))
+		} else if off || d == 0 {
+			out.MaxAge = 0
+		} else {
+			out.MaxAge = d
+		}
+	}
+
+	if in.MaxRowsSet {
+		raw := strings.TrimSpace(resolveValue(in.MaxRows, "attempts_retention.max_rows", &res))
+		if raw == "" {
+			res.Errors = append(res.Errors, "attempts_retention.max_rows must not be empty")
+		} else if strings.EqualFold(raw, "off") {
+			out.MaxRows = 0
+		} else {
+			v, err := strconv.Atoi(raw)
+			if err != nil || v < 0 {
+				res.Errors = append(res.Errors, "attempts_retention.max_rows must be a non-negative integer")
+			} else {
+				out.MaxRows = v
+			}
+		}
+	}
+
+	out.Enabled = out.MaxAge > 0 || out.MaxRows > 0
 	return out, res
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 	QueueRetention     *QueueRetentionBlock
 	DeliveredRetention *DeliveredRetentionBlock
 	DLQRetention       *DLQRetentionBlock
+	AttemptsRetention  *AttemptsRetentionBlock
 	QueueLimits        *QueueLimitsBlock
 
 	NamedMatchers []NamedMatcher
@@ -306,6 +307,16 @@ type DeliveredRetentionBlock struct {
 	MaxAge       string
 	MaxAgeQuoted bool
 	MaxAgeSet    bool
+}
+
+// AttemptsRetentionBlock configures how long delivery-attempt history is kept.
+type AttemptsRetentionBlock struct {
+	MaxAge        string
+	MaxAgeQuoted  bool
+	MaxAgeSet     bool
+	MaxRows       string
+	MaxRowsQuoted bool
+	MaxRowsSet    bool
 }
 
 type DLQRetentionBlock struct {

--- a/internal/config/format.go
+++ b/internal/config/format.go
@@ -18,55 +18,62 @@ func format(cfg *Config) ([]byte, error) {
 		b.WriteByte('\n')
 	}
 
-	hasBody := cfg.Ingress != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || cfg.PullAPI != nil || cfg.AdminAPI != nil || cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.QueueLimits != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0
+	hasBody := cfg.Ingress != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || cfg.PullAPI != nil || cfg.AdminAPI != nil || cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0
 	if len(cfg.Preamble) > 0 && hasBody {
 		b.WriteByte('\n')
 	}
 
 	if cfg.Ingress != nil {
 		writeIngressBlock(&b, cfg.Ingress)
-		if cfg.PullAPI != nil || cfg.AdminAPI != nil || cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
+		if cfg.PullAPI != nil || cfg.AdminAPI != nil || cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
 			b.WriteByte('\n')
 		}
 	}
 
 	if cfg.PullAPI != nil {
 		writeAPIBlock(&b, "pull_api", cfg.PullAPI)
-		if cfg.AdminAPI != nil || cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
+		if cfg.AdminAPI != nil || cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
 			b.WriteByte('\n')
 		}
 	}
 
 	if cfg.AdminAPI != nil {
 		writeAPIBlock(&b, "admin_api", cfg.AdminAPI)
-		if cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
+		if cfg.Observability != nil || cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
 			b.WriteByte('\n')
 		}
 	}
 
 	if cfg.Observability != nil {
 		writeObservabilityBlock(&b, cfg.Observability)
-		if cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
+		if cfg.QueueRetention != nil || cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
 			b.WriteByte('\n')
 		}
 	}
 
 	if cfg.QueueRetention != nil {
 		writeQueueRetentionBlock(&b, cfg.QueueRetention)
-		if cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
+		if cfg.DeliveredRetention != nil || cfg.DLQRetention != nil || cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
 			b.WriteByte('\n')
 		}
 	}
 
 	if cfg.DeliveredRetention != nil {
 		writeDeliveredRetentionBlock(&b, cfg.DeliveredRetention)
-		if cfg.DLQRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
+		if cfg.DLQRetention != nil || cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
 			b.WriteByte('\n')
 		}
 	}
 
 	if cfg.DLQRetention != nil {
 		writeDLQRetentionBlock(&b, cfg.DLQRetention)
+		if cfg.AttemptsRetention != nil || cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
+			b.WriteByte('\n')
+		}
+	}
+
+	if cfg.AttemptsRetention != nil {
+		writeAttemptsRetentionBlock(&b, cfg.AttemptsRetention)
 		if cfg.QueueLimits != nil || cfg.Defaults != nil || cfg.Vars != nil || cfg.Secrets != nil || len(cfg.NamedMatchers) > 0 || len(cfg.Routes) > 0 {
 			b.WriteByte('\n')
 		}
@@ -642,6 +649,17 @@ func writeDLQRetentionBlock(b *bytes.Buffer, q *DLQRetentionBlock) {
 	}
 	if q.MaxDepthSet {
 		fmt.Fprintf(b, "  max_depth %s\n", formatValue(q.MaxDepth, q.MaxDepthQuoted))
+	}
+	b.WriteString("}\n")
+}
+
+func writeAttemptsRetentionBlock(b *bytes.Buffer, a *AttemptsRetentionBlock) {
+	b.WriteString("attempts_retention {\n")
+	if a.MaxAgeSet {
+		fmt.Fprintf(b, "  max_age %s\n", formatValue(a.MaxAge, a.MaxAgeQuoted))
+	}
+	if a.MaxRowsSet {
+		fmt.Fprintf(b, "  max_rows %s\n", formatValue(a.MaxRows, a.MaxRowsQuoted))
 	}
 	b.WriteString("}\n")
 }

--- a/internal/config/parser.go
+++ b/internal/config/parser.go
@@ -187,6 +187,16 @@ func (p *parser) parseTopLevelBlock(cfg *Config) error {
 		}
 		cfg.DLQRetention = b
 		return nil
+	case "attempts_retention":
+		if cfg.AttemptsRetention != nil {
+			return p.errAt(nameTok.pos, "duplicate attempts_retention block")
+		}
+		b, err := p.parseAttemptsRetentionBlock()
+		if err != nil {
+			return err
+		}
+		cfg.AttemptsRetention = b
+		return nil
 	case "queue_limits":
 		if cfg.QueueLimits != nil {
 			return p.errAt(nameTok.pos, "duplicate queue_limits block")
@@ -2352,6 +2362,64 @@ func (p *parser) parseDLQRetentionBlock() (*DLQRetentionBlock, error) {
 			out.MaxDepthSet = true
 		default:
 			return nil, p.errAt(dirTok.pos, "unknown dlq_retention directive %q", dirTok.text)
+		}
+	}
+
+	return out, nil
+}
+
+func (p *parser) parseAttemptsRetentionBlock() (*AttemptsRetentionBlock, error) {
+	if _, err := p.expect(tokLBrace, "expected '{' after attempts_retention"); err != nil {
+		return nil, err
+	}
+	out := &AttemptsRetentionBlock{}
+
+	for {
+		tok, err := p.peek()
+		if err != nil {
+			return nil, err
+		}
+		if tok.kind == tokEOF {
+			return nil, p.errAt(tok.pos, "unexpected EOF (missing '}')")
+		}
+		if tok.kind == tokRBrace {
+			_, _ = p.next()
+			break
+		}
+		if tok.kind == tokComment {
+			_, _ = p.next()
+			continue
+		}
+
+		dirTok, _ := p.next()
+		if dirTok.kind != tokIdent {
+			return nil, p.errAt(dirTok.pos, "expected directive name")
+		}
+		switch dirTok.text {
+		case "max_age":
+			if out.MaxAgeSet {
+				return nil, p.errAt(dirTok.pos, "duplicate attempts_retention max_age")
+			}
+			v, quoted, err := p.parseValue()
+			if err != nil {
+				return nil, err
+			}
+			out.MaxAge = v
+			out.MaxAgeQuoted = quoted
+			out.MaxAgeSet = true
+		case "max_rows":
+			if out.MaxRowsSet {
+				return nil, p.errAt(dirTok.pos, "duplicate attempts_retention max_rows")
+			}
+			v, quoted, err := p.parseValue()
+			if err != nil {
+				return nil, err
+			}
+			out.MaxRows = v
+			out.MaxRowsQuoted = quoted
+			out.MaxRowsSet = true
+		default:
+			return nil, p.errAt(dirTok.pos, "unknown attempts_retention directive %q", dirTok.text)
 		}
 	}
 

--- a/internal/hookaido/module.go
+++ b/internal/hookaido/module.go
@@ -56,6 +56,10 @@ type QueueBackendConfig struct {
 	// DLQ retention.
 	DLQRetentionMaxAge   time.Duration
 	DLQRetentionMaxDepth int
+
+	// Delivery-attempt history retention.
+	AttemptsRetentionMaxAge  time.Duration
+	AttemptsRetentionMaxRows int
 }
 
 // TracingProvider sets up distributed tracing and provides HTTP instrumentation.

--- a/internal/queue/memory.go
+++ b/internal/queue/memory.go
@@ -45,6 +45,8 @@ type MemoryStore struct {
 	deliveredRetentionMaxAge time.Duration
 	dlqRetentionMaxAge       time.Duration
 	dlqMaxDepth              int
+	attemptsRetentionMaxAge  time.Duration
+	attemptsMaxRows          int
 	evictionsTotalByReason   map[string]int64
 	memoryPressureRejects    int64
 	memoryPressureItemLimit  int
@@ -180,6 +182,26 @@ func WithDLQRetention(maxAge time.Duration, maxDepth int) MemoryOption {
 			s.dlqMaxDepth = maxDepth
 		} else {
 			s.dlqMaxDepth = 0
+		}
+	}
+}
+
+// WithAttemptsRetention bounds the delivery-attempt history. Attempts were
+// previously appended forever with no cap and no retention: a long-running
+// instance delivering millions of webhooks accumulated millions of records --
+// hundreds of MB -- and the memory-pressure guard counts only envelope bytes,
+// so the growth was invisible to the very mechanism meant to bound memory.
+func WithAttemptsRetention(maxAge time.Duration, maxRows int) MemoryOption {
+	return func(s *MemoryStore) {
+		if maxAge > 0 {
+			s.attemptsRetentionMaxAge = maxAge
+		} else {
+			s.attemptsRetentionMaxAge = 0
+		}
+		if maxRows > 0 {
+			s.attemptsMaxRows = maxRows
+		} else {
+			s.attemptsMaxRows = 0
 		}
 	}
 }
@@ -625,7 +647,7 @@ func (s *MemoryStore) maybePruneLocked(now time.Time) {
 	if s.pruneInterval <= 0 {
 		return
 	}
-	if s.retentionMaxAge <= 0 && s.deliveredRetentionMaxAge <= 0 && s.dlqRetentionMaxAge <= 0 && s.dlqMaxDepth <= 0 {
+	if s.retentionMaxAge <= 0 && s.deliveredRetentionMaxAge <= 0 && s.dlqRetentionMaxAge <= 0 && s.dlqMaxDepth <= 0 && s.attemptsRetentionMaxAge <= 0 {
 		return
 	}
 	if !s.lastPrune.IsZero() && now.Sub(s.lastPrune) < s.pruneInterval {
@@ -704,6 +726,19 @@ func (s *MemoryStore) maybePruneLocked(now time.Time) {
 			for i := 0; i < excess; i++ {
 				s.evictLocked(items[i].id, memoryEvictionReasonDeadRetentionDepth)
 			}
+		}
+	}
+
+	if s.attemptsRetentionMaxAge > 0 && len(s.attempts) > 0 {
+		cutoff := now.Add(-s.attemptsRetentionMaxAge)
+		// Attempts are appended in time order, so the first one still inside
+		// the window marks the whole surviving tail.
+		keep := 0
+		for keep < len(s.attempts) && !s.attempts[keep].CreatedAt.After(cutoff) {
+			keep++
+		}
+		if keep > 0 {
+			s.attempts = append([]DeliveryAttempt(nil), s.attempts[keep:]...)
 		}
 	}
 	s.lastPrune = now
@@ -1903,7 +1938,19 @@ func (s *MemoryStore) RecordAttempt(attempt DeliveryAttempt) error {
 	}
 
 	s.attempts = append(s.attempts, attempt)
+	s.trimAttemptsLocked()
 	return nil
+}
+
+// trimAttemptsLocked enforces the row cap. It runs on every write, like the
+// backlog-trend cap it mirrors, so the slice can never grow past the bound
+// between prune passes; the age-based half runs with the other retention in
+// maybePruneLocked.
+func (s *MemoryStore) trimAttemptsLocked() {
+	if s.attemptsMaxRows <= 0 || len(s.attempts) <= s.attemptsMaxRows {
+		return
+	}
+	s.attempts = append([]DeliveryAttempt(nil), s.attempts[len(s.attempts)-s.attemptsMaxRows:]...)
 }
 
 func (s *MemoryStore) ListAttempts(req AttemptListRequest) (AttemptListResponse, error) {
@@ -2072,6 +2119,7 @@ func (memoryBackend) OpenStore(cfg hookaido.QueueBackendConfig) (any, func() err
 		WithQueueRetention(cfg.RetentionMaxAge, cfg.RetentionPruneInterval),
 		WithDeliveredRetention(cfg.DeliveredRetentionMaxAge),
 		WithDLQRetention(cfg.DLQRetentionMaxAge, cfg.DLQRetentionMaxDepth),
+		WithAttemptsRetention(cfg.AttemptsRetentionMaxAge, cfg.AttemptsRetentionMaxRows),
 	)
 	return store, func() error { return nil }, nil
 }

--- a/internal/queue/store_contract_test.go
+++ b/internal/queue/store_contract_test.go
@@ -1,6 +1,7 @@
 package queue_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
@@ -863,6 +864,147 @@ func TestStoreContract_ReadinessTransitionsNotifyWaiters(t *testing.T) {
 						t.Fatalf("%s made the message ready without waking waiters", tc.name)
 					}
 				})
+			}
+		})
+	}
+}
+
+// contractAttemptsRetentionFactories configures attempt-history retention on
+// every backend so the shared behaviour can be exercised.
+func contractAttemptsRetentionFactories(maxAge time.Duration, maxRows int) []storeFactory {
+	out := []storeFactory{
+		{
+			name: "memory",
+			new: func(t *testing.T, now *time.Time) queue.Store {
+				t.Helper()
+				return queue.NewMemoryStore(
+					queue.WithNowFunc(func() time.Time { return now.UTC() }),
+					queue.WithQueueRetention(0, time.Nanosecond),
+					queue.WithAttemptsRetention(maxAge, maxRows),
+				)
+			},
+		},
+		{
+			name: "sqlite",
+			new: func(t *testing.T, now *time.Time) queue.Store {
+				t.Helper()
+				dbPath := filepath.Join(t.TempDir(), "hookaido.db")
+				s, err := sqlite.NewStore(
+					dbPath,
+					sqlite.WithNowFunc(func() time.Time { return now.UTC() }),
+					sqlite.WithPollInterval(5*time.Millisecond),
+					sqlite.WithCheckpointInterval(0),
+					sqlite.WithRetention(0, time.Nanosecond),
+					sqlite.WithAttemptsRetention(maxAge, maxRows),
+				)
+				if err != nil {
+					t.Fatalf("new sqlite store: %v", err)
+				}
+				t.Cleanup(func() { _ = s.Close() })
+				return s
+			},
+		},
+	}
+
+	dsn := strings.TrimSpace(os.Getenv("HOOKAIDO_TEST_POSTGRES_DSN"))
+	if dsn != "" {
+		out = append(out, storeFactory{
+			name: "postgres",
+			new: func(t *testing.T, now *time.Time) queue.Store {
+				t.Helper()
+				s, err := postgres.NewStore(
+					dsn,
+					postgres.WithNowFunc(func() time.Time { return now.UTC() }),
+					postgres.WithPollInterval(5*time.Millisecond),
+					postgres.WithRetention(0, time.Nanosecond),
+					postgres.WithAttemptsRetention(maxAge, maxRows),
+				)
+				if err != nil {
+					t.Fatalf("new postgres store: %v", err)
+				}
+				postgres.TruncateForTest(t, s)
+				t.Cleanup(func() { _ = s.Close() })
+				return s
+			},
+		})
+	}
+
+	return out
+}
+
+func recordAttempts(t *testing.T, store queue.Store, n int, at time.Time) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		if err := store.RecordAttempt(queue.DeliveryAttempt{
+			ID:        fmt.Sprintf("att_%d_%d", at.UnixNano(), i),
+			EventID:   fmt.Sprintf("evt_%d", i),
+			Route:     "/r",
+			Target:    "https://example.org/hook",
+			Attempt:   1,
+			Outcome:   queue.AttemptOutcomeAcked,
+			CreatedAt: at,
+		}); err != nil {
+			t.Fatalf("record attempt %d: %v", i, err)
+		}
+	}
+}
+
+func attemptCount(t *testing.T, store queue.Store) int {
+	t.Helper()
+	resp, err := store.ListAttempts(queue.AttemptListRequest{Limit: 1000})
+	if err != nil {
+		t.Fatalf("list attempts: %v", err)
+	}
+	return len(resp.Items)
+}
+
+// Delivery-attempt history was append-only in every backend: nothing anywhere
+// deleted or capped it. The memory store grew until it OOMed the process --
+// invisible to the memory-pressure guard, which counts only envelope bytes --
+// and the SQLite/Postgres tables grew until the disk filled and enqueue started
+// failing.
+func TestStoreContract_AttemptsRetentionPrunesByAge(t *testing.T) {
+	for _, factory := range contractAttemptsRetentionFactories(time.Hour, 0) {
+		t.Run(factory.name, func(t *testing.T) {
+			now := time.Date(2026, 2, 14, 21, 15, 0, 0, time.UTC)
+			store := factory.new(t, &now)
+
+			recordAttempts(t, store, 3, now)
+			if got := attemptCount(t, store); got != 3 {
+				t.Fatalf("attempts before prune = %d, want 3", got)
+			}
+
+			now = now.Add(2 * time.Hour)
+			recordAttempts(t, store, 1, now)
+
+			// Retention runs with the other prunes, on enqueue or dequeue.
+			if _, err := store.Dequeue(queue.DequeueRequest{Route: "/r", Target: "pull", Batch: 1}); err != nil {
+				t.Fatalf("dequeue: %v", err)
+			}
+
+			if got := attemptCount(t, store); got != 1 {
+				t.Fatalf("attempts after prune = %d, want 1 (only the recent one survives)", got)
+			}
+		})
+	}
+}
+
+func TestStoreContract_AttemptsRetentionCapsRowCount(t *testing.T) {
+	for _, factory := range contractAttemptsRetentionFactories(0, 5) {
+		t.Run(factory.name, func(t *testing.T) {
+			now := time.Date(2026, 2, 14, 21, 15, 0, 0, time.UTC)
+			store := factory.new(t, &now)
+
+			for i := 0; i < 12; i++ {
+				now = now.Add(time.Second)
+				recordAttempts(t, store, 1, now)
+			}
+			if _, err := store.Dequeue(queue.DequeueRequest{Route: "/r", Target: "pull", Batch: 1}); err != nil {
+				t.Fatalf("dequeue: %v", err)
+			}
+
+			if got := attemptCount(t, store); got > 5 {
+				t.Fatalf("attempts = %d, want at most the configured 5", got)
 			}
 		})
 	}

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -45,6 +45,8 @@ type Store struct {
 	deliveredRetentionMaxAge time.Duration
 	dlqRetentionMaxAge       time.Duration
 	dlqMaxDepth              int
+	attemptsRetentionMaxAge  time.Duration
+	attemptsMaxRows          int
 
 	metrics *postgresRuntimeMetrics
 }
@@ -202,6 +204,23 @@ func WithDeliveredRetention(maxAge time.Duration) Option {
 			s.deliveredRetentionMaxAge = maxAge
 		} else {
 			s.deliveredRetentionMaxAge = 0
+		}
+	}
+}
+
+// WithAttemptsRetention bounds delivery-attempt history by age and by row
+// count. Both dimensions are optional; zero disables that half.
+func WithAttemptsRetention(maxAge time.Duration, maxRows int) Option {
+	return func(s *Store) {
+		if maxAge > 0 {
+			s.attemptsRetentionMaxAge = maxAge
+		} else {
+			s.attemptsRetentionMaxAge = 0
+		}
+		if maxRows > 0 {
+			s.attemptsMaxRows = maxRows
+		} else {
+			s.attemptsMaxRows = 0
 		}
 	}
 }
@@ -2406,7 +2425,8 @@ WHERE id = $3
 }
 
 func (s *Store) maybePrune(now time.Time) error {
-	if s.retentionMaxAge <= 0 && s.deliveredRetentionMaxAge <= 0 && s.dlqRetentionMaxAge <= 0 && s.dlqMaxDepth <= 0 {
+	if s.retentionMaxAge <= 0 && s.deliveredRetentionMaxAge <= 0 && s.dlqRetentionMaxAge <= 0 && s.dlqMaxDepth <= 0 &&
+		s.attemptsRetentionMaxAge <= 0 && s.attemptsMaxRows <= 0 {
 		return nil
 	}
 	if s.pruneInterval <= 0 {
@@ -2500,6 +2520,41 @@ WHERE id IN (
 			}
 		}
 	}
+	// Delivery-attempt history was append-only: nothing in any backend ever
+	// deleted from delivery_attempts, so a push deployment doing 10 attempts/s
+	// added ~860k rows a day forever.
+	if s.attemptsRetentionMaxAge > 0 {
+		cutoff := now.Add(-s.attemptsRetentionMaxAge).UTC()
+		if err := s.pruneAttemptsBatched(ctx, `created_at <= $1`, cutoff); err != nil {
+			return err
+		}
+	}
+
+	if s.attemptsMaxRows > 0 {
+		for {
+			res, err := s.db.ExecContext(ctx, `
+DELETE FROM delivery_attempts
+WHERE ctid IN (
+  SELECT ctid
+  FROM delivery_attempts
+  ORDER BY created_at DESC, id DESC
+  OFFSET $1
+  LIMIT $2
+)
+`, s.attemptsMaxRows, postgresPruneBatch)
+			if err != nil {
+				return err
+			}
+			n, err := res.RowsAffected()
+			if err != nil {
+				return err
+			}
+			if n < postgresPruneBatch {
+				break
+			}
+		}
+	}
+
 	s.lastPrune = now
 	return nil
 }
@@ -2518,6 +2573,33 @@ DELETE FROM queue_items
 WHERE ctid IN (
   SELECT ctid
   FROM queue_items
+  WHERE %s
+  LIMIT %d
+)
+`, strings.TrimSpace(where), postgresPruneBatch)
+
+	for {
+		res, err := s.db.ExecContext(ctx, query, args...)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n < postgresPruneBatch {
+			return nil
+		}
+	}
+}
+
+// pruneAttemptsBatched is pruneBatched for the delivery_attempts table.
+func (s *Store) pruneAttemptsBatched(ctx context.Context, where string, args ...any) error {
+	query := fmt.Sprintf(`
+DELETE FROM delivery_attempts
+WHERE ctid IN (
+  SELECT ctid
+  FROM delivery_attempts
   WHERE %s
   LIMIT %d
 )
@@ -2751,6 +2833,7 @@ func (backend) OpenStore(cfg hookaido.QueueBackendConfig) (any, func() error, er
 		WithRetention(cfg.RetentionMaxAge, cfg.RetentionPruneInterval),
 		WithDeliveredRetention(cfg.DeliveredRetentionMaxAge),
 		WithDLQRetention(cfg.DLQRetentionMaxAge, cfg.DLQRetentionMaxDepth),
+		WithAttemptsRetention(cfg.AttemptsRetentionMaxAge, cfg.AttemptsRetentionMaxRows),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/modules/sqlite/sqlite.go
+++ b/modules/sqlite/sqlite.go
@@ -235,6 +235,23 @@ func WithDLQRetention(maxAge time.Duration, maxDepth int) Option {
 	}
 }
 
+// WithAttemptsRetention bounds delivery-attempt history by age and by row
+// count. Both dimensions are optional; zero disables that half.
+func WithAttemptsRetention(maxAge time.Duration, maxRows int) Option {
+	return func(s *Store) {
+		if maxAge > 0 {
+			s.attemptsRetentionMaxAge = maxAge
+		} else {
+			s.attemptsRetentionMaxAge = 0
+		}
+		if maxRows > 0 {
+			s.attemptsMaxRows = maxRows
+		} else {
+			s.attemptsMaxRows = 0
+		}
+	}
+}
+
 type Store struct {
 	db *sql.DB
 
@@ -251,6 +268,8 @@ type Store struct {
 	deliveredRetentionMaxAge time.Duration
 	dlqRetentionMaxAge       time.Duration
 	dlqMaxDepth              int
+	attemptsRetentionMaxAge  time.Duration
+	attemptsMaxRows          int
 	checkpointInterval       time.Duration
 	checkpointStop           chan struct{}
 	checkpointDone           chan struct{}
@@ -904,7 +923,8 @@ func (s *Store) maybePrune(now time.Time) error {
 	if s.pruneInterval <= 0 {
 		return nil
 	}
-	if s.retentionMaxAge <= 0 && s.deliveredRetentionMaxAge <= 0 && s.dlqRetentionMaxAge <= 0 && s.dlqMaxDepth <= 0 {
+	if s.retentionMaxAge <= 0 && s.deliveredRetentionMaxAge <= 0 && s.dlqRetentionMaxAge <= 0 && s.dlqMaxDepth <= 0 &&
+		s.attemptsRetentionMaxAge <= 0 && s.attemptsMaxRows <= 0 {
 		return nil
 	}
 
@@ -971,6 +991,33 @@ WHERE id IN (
 			return err
 		}
 	}
+	// Delivery-attempt history was append-only: nothing in any backend ever
+	// deleted from delivery_attempts, so a push deployment doing 10 attempts/s
+	// added ~860k rows a day forever, until the file (and its created_at index)
+	// exhausted the disk and enqueue started failing.
+	if s.attemptsRetentionMaxAge > 0 {
+		cutoff := now.Add(-s.attemptsRetentionMaxAge)
+		if _, err := s.db.ExecContext(context.Background(), `
+DELETE FROM delivery_attempts
+WHERE created_at <= ?;
+`, cutoff.UnixNano()); err != nil {
+			return err
+		}
+	}
+
+	if s.attemptsMaxRows > 0 {
+		if _, err := s.db.ExecContext(context.Background(), `
+DELETE FROM delivery_attempts
+WHERE id IN (
+  SELECT id FROM delivery_attempts
+  ORDER BY created_at DESC, id DESC
+  LIMIT -1 OFFSET ?
+);
+`, s.attemptsMaxRows); err != nil {
+			return err
+		}
+	}
+
 	s.lastPrune = now
 	return nil
 }
@@ -3334,6 +3381,7 @@ func (backend) OpenStore(cfg hookaido.QueueBackendConfig) (any, func() error, er
 		WithRetention(cfg.RetentionMaxAge, cfg.RetentionPruneInterval),
 		WithDeliveredRetention(cfg.DeliveredRetentionMaxAge),
 		WithDLQRetention(cfg.DLQRetentionMaxAge, cfg.DLQRetentionMaxDepth),
+		WithAttemptsRetention(cfg.AttemptsRetentionMaxAge, cfg.AttemptsRetentionMaxRows),
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

#252: delivery-attempt history was append-only in all three backends. `RecordAttempt` is called once per delivery attempt, and nothing anywhere deleted or capped what it wrote — the only `DELETE FROM delivery_attempts` in the repository was in `modules/postgres/testing.go`.

- **SQLite/Postgres**: `maybePrune` covered `queue_items` only, and there was no retention setting for attempts to begin with. A push deployment at 10 attempts/s adds ~860k rows a day, forever; the file and its `created_at DESC` index btrees grow until the disk fills, at which point enqueue and ack start failing and ingest goes down.
- **Memory**: the only mutation of `s.attempts` was the append. No cap, unlike `trendRows` next to it (capped at 200,000). Worse, the memory-pressure guard counts envelope bytes only, so this growth was invisible to the exact mechanism meant to bound memory — the process OOMs and takes the whole in-memory queue with it.

## What this adds

`attempts_retention { max_age, max_rows }`, the DSL shape the issue proposes, following `dlq_retention`'s structure exactly (`off` disables a dimension; the block is disabled only when both are off).

**Defaults are finite: `max_age 7d`, `max_rows 200000`.** The issue asks for "a sane default rather than infinite", and that is the part with a compatibility cost, so it is worth being explicit: an instance that upgrades starts pruning history it previously kept. `max_age off` + `max_rows off` restores the old behaviour. 200,000 is the number the codebase already picked for the comparable in-memory cap on `trendRows`, and at ~200 bytes per record it bounds the memory backend at tens of MB rather than hundreds.

Enforcement per backend:

- **SQLite**: an age DELETE plus a keep-newest-N DELETE in `maybePrune`, on the existing `queue_retention.prune_interval` cadence.
- **Postgres**: the same two, through the batched-delete helper added for #257, so a first prune over a large backlog does not run as one unbounded statement.
- **Memory**: the row cap is enforced on every write (like `trendRows`), so the slice can never exceed the bound *between* prune passes — which matters, because the failure mode here is memory, not disk. The age half runs with the other retention in `maybePruneLocked`, exploiting that attempts are appended in time order, so it is a prefix scan rather than a filter.

Wiring follows the existing retention settings end to end: `QueueBackendConfig` → each backend's `WithAttemptsRetention`, plus `attemptsRetentionEqual` in `requiresRestartForReload` so a change to it is treated like every other retention change on reload.

**MCP coverage** (per `AGENTS.md`): covered, with no schema change needed. `config_validate`, `config_compile`, `config_fmt_preview` and `config_apply` operate on whole config text and route through the same parser and compiler, so the new block works through all of them today. No MCP tool enumerates retention settings — `config_compile`'s summary reports backend and publish-policy fields only — so there is nothing block-specific to add.

## Related Issues

Closes #252

## Scope

- [x] DSL / config behavior
- [x] Runtime behavior
- [ ] Admin or Pull API behavior
- [x] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [x] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

Also run: `go vet ./...`, the Postgres-backed packages against a local `docker-compose.test.yml` instance, and `hookaido config validate` against the repo's own `Hookaidofile`.

New tests:

- `internal/queue/store_contract_test.go` — retention by age and by row count, across **all three backends** (a new factory set mirroring the delivered-retention one).
- `internal/config/attempts_retention_test.go` — parse/format round trip including format stability, a six-case compile table (defaults, explicit values, one dimension off, both off, and the two rejection paths), the `prune_interval` requirement now covering attempts, and four parser rejections (duplicate block, duplicate directive ×2, unknown directive).

Docs updated: `docs/configuration.md` (new section plus the defaults table), `docs/delivery.md` (the Delivery Attempts section now says its history is bounded), `docs/deployment-modes.md` checklist, `DESIGN.md` (DSL surface, a retention section, and the defaults list), the VS Code grammar's top-level block list, and the sample `Hookaidofile`.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

- **This deletes data on upgrade.** An instance carrying more than 7 days or 200,000 delivery attempts will prune the excess at its first prune pass after the upgrade. That is the fix, but it is a one-way operation on history someone may be querying through `ListAttempts` or the Admin API. Operators who want the old behaviour set `attempts_retention { max_age off; max_rows off }`; operators who want a different window set it explicitly. This is the first line of the CHANGELOG entry for that reason.
- **The first prune after upgrading can be large.** On Postgres it is chunked (5,000 rows per statement); on SQLite it is two statements, which on a multi-million-row table will take a moment on the first pass only, under the dedicated prune mutex, so it does not block other operations.
- Reload: a change to `attempts_retention` is treated like the other retention settings, i.e. it requires a restart rather than being silently ignored.

## Notes for Reviewers

- The default values are the judgement call in this PR. They are two named constants in `internal/config/compile.go`, next to the other retention defaults.
- The memory backend enforces the row cap on write and the age bound on prune — deliberately asymmetric, explained in the comment on `trimAttemptsLocked`. If you would rather have both on the prune path, the cap becomes advisory between passes, which is what makes the OOM possible in the first place.
- Postgres gained a second batched-delete helper for the attempts table rather than a table-name parameter on the existing one, to keep the table names out of format strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
