### PR TITLE
fix(pullapi): scope lease operations to their route, honour the caller's context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **A cancelled dequeue no longer parks a goroutine or leases into a dead connection.** `queue.Store.Dequeue` takes no context, so a gRPC worker whose own deadline fired left the handler blocked inside the store for the rest of `max_wait` — and any item that arrived meanwhile was leased into a stream gRPC had already discarded, invisible for the full lease TTL (30s by default) until the expiry sweep reclaimed it. Every client timeout thus became a lease-TTL delivery delay. All three backends now implement a context-aware dequeue, and the pull API passes the request context through from HTTP, SSE and gRPC: the long poll ends with its caller, and a caller that is already gone is never handed a lease.
+
+### Security
+
+- **Per-route pull tokens are now enforced on lease operations.** `ack`, `nack`, `dead` and `extend` passed only the lease ID to the store; the route resolved from the request path was used for metrics and nothing else. A client authorized for one endpoint could therefore settle another route's in-flight message if it learned that lease ID — from a shared dashboard, a log line, a support ticket. Exploiting it requires the random `lease_…` value, so severity is low, but the route-scoped credential model the config offers was not enforced where it mattered. A lease belonging to another route is now rejected with the same `409` as an unknown lease, so the response cannot be used to probe for lease IDs either. The check runs only when the config actually uses per-route pull tokens: with a single global token every client is authorized for every route anyway, and the ack path keeps its current cost.
+
 ### Added
 
 - **`attempts_retention { max_age, max_rows }`** bounds delivery-attempt history, which was append-only in every backend — nothing anywhere deleted or capped it. A push deployment doing 10 attempts/s added ~860k records a day forever: the SQLite file and its indexes grew until the disk filled and enqueue started failing, and the memory backend grew until the process was OOM-killed, invisible to the memory-pressure guard because that counts only queued payloads. Defaults are deliberately finite (`max_age 7d`, `max_rows 200000`); set both `off` to restore the previous unbounded behaviour. Pruning uses the existing `queue_retention.prune_interval` cadence, and the memory backend enforces `max_rows` as it writes.

--- a/docs/pull-api.md
+++ b/docs/pull-api.md
@@ -63,6 +63,13 @@ pull_api {
 
 Per-route tokens replace (not extend) the global allowlist for that route.
 
+When any route defines its own token, lease operations are scoped to their route
+as well: `ack`, `nack`, `dead` and `extend` reject a lease that belongs to a
+different route with the same `409` conflict as an unknown lease, so a token for
+one endpoint cannot settle another endpoint's in-flight message. With a single
+global token the check is skipped — every client is authorized for every route
+anyway — so it costs nothing in that setup.
+
 ## Endpoints
 
 ### `POST {endpoint}/dequeue`

--- a/docs/worker-api.md
+++ b/docs/worker-api.md
@@ -44,6 +44,8 @@ Behavior parity includes:
   - global allowlist from `pull_api { auth token ... }`
   - per-route override from `pull { auth token ... }` (replaces global list for that route)
 - `endpoint` in gRPC requests uses the configured pull endpoint path (same path workers use for HTTP Pull routes).
+- Lease operations are scoped to their route whenever per-route tokens are in use, exactly as for HTTP Pull.
+- A `Dequeue` whose RPC is cancelled — the client's own deadline, a dropped connection — ends the long poll instead of running it out, and no message is leased to a caller that is already gone.
 
 ## Listener Guardrails
 

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -885,6 +885,16 @@ func (s *runtimeState) resolvePull(endpoint string) (string, bool) {
 	return route, ok
 }
 
+// hasRouteScopedPullAuth reports whether any route carries its own pull
+// credentials. Lease operations are checked against their route only then: with
+// a single global token every client is authorized for every route, so there is
+// nothing to enforce and no reason to pay for the lookup.
+func (s *runtimeState) hasRouteScopedPullAuth() bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.pullByRoute) > 0
+}
+
 func (s *runtimeState) authorizePull(r *http.Request) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -2438,6 +2448,9 @@ func startServers(
 	pullHandler := pullapi.NewServer(store)
 	pullHandler.ResolveRoute = state.resolvePull
 	pullHandler.Authorize = state.authorizePull
+	// Read through the runtime state rather than captured once: a reload can
+	// add or remove per-route pull tokens.
+	pullHandler.LeaseRouteScoped = state.hasRouteScopedPullAuth
 	if compiled.PullAPI.MaxBatch > 0 {
 		pullHandler.MaxBatch = compiled.PullAPI.MaxBatch
 	}

--- a/internal/pullapi/http.go
+++ b/internal/pullapi/http.go
@@ -49,6 +49,12 @@ type Server struct {
 	ObserveSSEConnect    func(route string)
 	ObserveSSEDisconnect func(route string, statusCode int, messagesSent int, duration time.Duration)
 
+	// LeaseRouteScoped reports whether the running config uses per-route pull
+	// credentials. When it does, lease operations are checked against the route
+	// they were issued for; when it does not, every client is authorized for
+	// every route anyway and the check is skipped. See lease_scope.go.
+	LeaseRouteScoped func() bool
+
 	RecentLeaseOpTTL time.Duration
 	RecentLeaseOpCap int
 
@@ -192,7 +198,7 @@ func (s *Server) handleDequeue(w http.ResponseWriter, r *http.Request, route str
 		leaseTTL = d
 	}
 
-	outcome, opErr := s.Dequeue(route, DequeueParams{
+	outcome, opErr := s.Dequeue(r.Context(), route, DequeueParams{
 		Batch:       req.Batch,
 		MaxWait:     maxWait,
 		HasMaxWait:  req.MaxWait != "",

--- a/internal/pullapi/lease_scope.go
+++ b/internal/pullapi/lease_scope.go
@@ -1,0 +1,97 @@
+package pullapi
+
+import "github.com/nuetzliches/hookaido/v2/internal/queue"
+
+// Lease operations take only a lease ID. The route resolved from the request
+// path was used for metrics and nothing else, so a client authorized for one
+// endpoint could ack, nack, dead-letter or extend another route's in-flight
+// message if it learned that lease ID -- from a shared dashboard, a log line, a
+// support ticket. Exploiting it needs the random `lease_…` value, so the
+// severity is low, but the route-scoped credential model the config offers was
+// not enforced where it matters.
+//
+// The check costs one lookup per lease operation, so it runs only when the
+// deployment actually uses route-scoped pull credentials: with a single global
+// token every client is authorized for every route anyway, and there is nothing
+// to enforce.
+
+// leaseScopeEnforced reports whether lease operations must be checked against
+// the route they were issued for.
+func (s *Server) leaseScopeEnforced(route string) bool {
+	if route == "" || s.LeaseRouteScoped == nil || !s.LeaseRouteScoped() {
+		return false
+	}
+	_, ok := s.Store.(queue.LeaseRouteResolver)
+	return ok
+}
+
+// leasesInRoute splits leaseIDs into those that belong to route and those that
+// do not. Unknown leases count as in-route: they are the store's to reject, and
+// reporting them here would tell a caller which lease IDs exist elsewhere.
+//
+// The error return is deliberate: a resolver failure denies the operation
+// rather than waving it through, so a transient store problem cannot turn into
+// an authorization bypass.
+func (s *Server) leasesInRoute(route string, leaseIDs []string) (inRoute []string, outOfRoute []string, err error) {
+	if !s.leaseScopeEnforced(route) || len(leaseIDs) == 0 {
+		return leaseIDs, nil, nil
+	}
+
+	resolver, ok := s.Store.(queue.LeaseRouteResolver)
+	if !ok {
+		return leaseIDs, nil, nil
+	}
+	routes, err := resolver.LeaseRoutes(leaseIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	inRoute = make([]string, 0, len(leaseIDs))
+	for _, leaseID := range leaseIDs {
+		if owner, known := routes[leaseID]; known && owner != route {
+			outOfRoute = append(outOfRoute, leaseID)
+			continue
+		}
+		inRoute = append(inRoute, leaseID)
+	}
+	return inRoute, outOfRoute, nil
+}
+
+// leaseInRoute is leasesInRoute for a single lease.
+func (s *Server) leaseInRoute(route string, leaseID string) (bool, error) {
+	_, outOfRoute, err := s.leasesInRoute(route, []string{leaseID})
+	if err != nil {
+		return false, err
+	}
+	return len(outOfRoute) == 0, nil
+}
+
+// leaseScopeConflict is the response for a lease that belongs to another route.
+// It is deliberately identical to the unknown-lease response, so the caller
+// cannot use it to probe for lease IDs.
+func leaseScopeConflict() *OpError {
+	return &OpError{
+		StatusCode: 409,
+		Code:       pullErrLeaseConflict,
+		Detail:     "lease is invalid or expired",
+	}
+}
+
+func leaseScopeUnavailable(detail string) *OpError {
+	return &OpError{
+		StatusCode: 500,
+		Code:       pullErrInternal,
+		Detail:     detail,
+	}
+}
+
+// observeForeignLeases records the metrics for leases rejected by the scope
+// check and returns them as batch conflicts.
+func (s *Server) observeForeignLeases(route string, leaseIDs []string, observe func(route string, statusCode int, leaseID string, leaseExpired bool)) []queue.LeaseBatchConflict {
+	conflicts := make([]queue.LeaseBatchConflict, 0, len(leaseIDs))
+	for _, leaseID := range leaseIDs {
+		observe(route, 409, leaseID, false)
+		conflicts = append(conflicts, queue.LeaseBatchConflict{LeaseID: leaseID})
+	}
+	return conflicts
+}

--- a/internal/pullapi/lease_scope_test.go
+++ b/internal/pullapi/lease_scope_test.go
@@ -1,0 +1,247 @@
+package pullapi
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/v2/internal/queue"
+)
+
+// scopeTestServer wires a server for two routes backed by one store, with
+// route-scoped pull credentials in use.
+func scopeTestServer(t *testing.T, store queue.Store) *Server {
+	t.Helper()
+	srv := NewServer(store)
+	srv.Target = "pull"
+	srv.LeaseRouteScoped = func() bool { return true }
+	srv.ResolveRoute = func(endpoint string) (string, bool) {
+		switch endpoint {
+		case "/pull/a":
+			return "/a", true
+		case "/pull/b":
+			return "/b", true
+		}
+		return "", false
+	}
+	return srv
+}
+
+func leaseFor(t *testing.T, store queue.Store, route string) queue.Envelope {
+	t.Helper()
+	if err := store.Enqueue(queue.Envelope{Route: route, Target: "pull", Payload: []byte("{}")}); err != nil {
+		t.Fatalf("enqueue %s: %v", route, err)
+	}
+	resp, err := store.Dequeue(queue.DequeueRequest{Route: route, Target: "pull", Batch: 1, LeaseTTL: time.Minute})
+	if err != nil {
+		t.Fatalf("dequeue %s: %v", route, err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("dequeue %s items=%d, want 1", route, len(resp.Items))
+	}
+	return resp.Items[0]
+}
+
+// A client authorized only for route /a must not be able to settle route /b's
+// in-flight message by presenting its lease ID. The handlers passed only the
+// lease ID to the store; the resolved route was used for metrics and nothing
+// else, so per-route pull tokens bought nothing at the operation layer.
+func TestLeaseScope_ForeignLeaseRejected(t *testing.T) {
+	ops := []struct {
+		name string
+		run  func(srv *Server, route string, lease queue.Envelope) *OpError
+	}{
+		{
+			name: "ack",
+			run: func(srv *Server, route string, lease queue.Envelope) *OpError {
+				return srv.AckSingle(route, lease.LeaseID)
+			},
+		},
+		{
+			name: "nack",
+			run: func(srv *Server, route string, lease queue.Envelope) *OpError {
+				return srv.NackSingle(route, lease.LeaseID, false, "", 0)
+			},
+		},
+		{
+			name: "mark_dead",
+			run: func(srv *Server, route string, lease queue.Envelope) *OpError {
+				return srv.NackSingle(route, lease.LeaseID, true, "manual", 0)
+			},
+		},
+		{
+			name: "extend",
+			run: func(srv *Server, route string, lease queue.Envelope) *OpError {
+				return srv.Extend(route, lease.LeaseID, time.Minute)
+			},
+		},
+	}
+
+	for _, op := range ops {
+		t.Run(op.name, func(t *testing.T) {
+			store := queue.NewMemoryStore()
+			srv := scopeTestServer(t, store)
+			lease := leaseFor(t, store, "/b")
+
+			// The attacker calls route /a's endpoint with route /b's lease.
+			opErr := op.run(srv, "/a", lease)
+			if opErr == nil {
+				t.Fatalf("%s on a foreign lease was accepted", op.name)
+			}
+			if opErr.StatusCode != 409 || opErr.Code != pullErrLeaseConflict {
+				t.Fatalf("status=%d code=%q, want 409/%s", opErr.StatusCode, opErr.Code, pullErrLeaseConflict)
+			}
+
+			// The message is untouched: still leased to its own route.
+			stats, err := store.Stats()
+			if err != nil {
+				t.Fatalf("stats: %v", err)
+			}
+			if stats.ByState[queue.StateLeased] != 1 {
+				t.Fatalf("message state changed: %v", stats.ByState)
+			}
+
+			// And the legitimate owner can still settle it.
+			if opErr := op.run(srv, "/b", lease); opErr != nil {
+				t.Fatalf("%s by the owning route failed: %v", op.name, opErr)
+			}
+		})
+	}
+}
+
+func TestLeaseScope_BatchSplitsForeignLeases(t *testing.T) {
+	store := queue.NewMemoryStore()
+	srv := scopeTestServer(t, store)
+
+	mine := leaseFor(t, store, "/a")
+	theirs := leaseFor(t, store, "/b")
+
+	res, opErr := srv.AckBatch("/a", []string{mine.LeaseID, theirs.LeaseID})
+	if opErr != nil {
+		t.Fatalf("ack batch: %v", opErr)
+	}
+	if res.Succeeded != 1 {
+		t.Fatalf("succeeded=%d, want 1 (only the in-route lease)", res.Succeeded)
+	}
+	if len(res.Conflicts) != 1 || res.Conflicts[0].LeaseID != theirs.LeaseID {
+		t.Fatalf("conflicts=%+v, want the foreign lease", res.Conflicts)
+	}
+
+	stats, err := store.Stats()
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.ByState[queue.StateLeased] != 1 {
+		t.Fatalf("the foreign lease was settled: %v", stats.ByState)
+	}
+}
+
+// Without route-scoped credentials every client is authorized for every route,
+// so the lookup is skipped entirely -- including its cost on the ack hot path.
+func TestLeaseScope_SkippedWithoutRouteScopedCredentials(t *testing.T) {
+	store := &countingLeaseRouteStore{MemoryStore: queue.NewMemoryStore()}
+	srv := scopeTestServer(t, store)
+	srv.LeaseRouteScoped = func() bool { return false }
+
+	lease := leaseFor(t, store, "/b")
+	if opErr := srv.AckSingle("/a", lease.LeaseID); opErr != nil {
+		t.Fatalf("ack across routes without scoped credentials: %v", opErr)
+	}
+	if store.calls != 0 {
+		t.Fatalf("LeaseRoutes was called %d times, want 0", store.calls)
+	}
+}
+
+// A resolver failure must deny rather than wave the operation through.
+func TestLeaseScope_ResolverFailureDenies(t *testing.T) {
+	store := &failingLeaseRouteStore{MemoryStore: queue.NewMemoryStore()}
+	srv := scopeTestServer(t, store)
+	lease := leaseFor(t, store, "/a")
+
+	opErr := srv.AckSingle("/a", lease.LeaseID)
+	if opErr == nil {
+		t.Fatal("expected the ack to fail when the scope check cannot run")
+	}
+	if opErr.StatusCode != 500 {
+		t.Fatalf("status=%d, want 500", opErr.StatusCode)
+	}
+}
+
+// A gRPC worker that gives up must not have items leased to it afterwards: they
+// would be invisible for the whole lease TTL before the expiry sweep.
+func TestDequeue_CancelledContextDoesNotLease(t *testing.T) {
+	store := queue.NewMemoryStore()
+	srv := NewServer(store)
+	srv.Target = "pull"
+
+	if err := store.Enqueue(queue.Envelope{ID: "evt_1", Route: "/a", Target: "pull", Payload: []byte("{}")}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	outcome, opErr := srv.Dequeue(ctx, "/a", DequeueParams{Batch: 1, MaxWait: time.Second, HasMaxWait: true})
+	if opErr != nil {
+		t.Fatalf("a cancelled dequeue must not be reported as a store failure: %v", opErr)
+	}
+	if len(outcome.Items) != 0 {
+		t.Fatalf("items=%d, want 0: the caller is gone", len(outcome.Items))
+	}
+
+	stats, err := store.Stats()
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.ByState[queue.StateLeased] != 0 {
+		t.Fatalf("the message was leased to a cancelled caller: %v", stats.ByState)
+	}
+	if stats.ByState[queue.StateQueued] != 1 {
+		t.Fatalf("the message should still be queued: %v", stats.ByState)
+	}
+}
+
+// The long poll must end when the caller does, rather than parking a goroutine
+// for the rest of max_wait.
+func TestDequeue_ContextCancelledMidWaitReturns(t *testing.T) {
+	store := queue.NewMemoryStore()
+	srv := NewServer(store)
+	srv.Target = "pull"
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if _, opErr := srv.Dequeue(ctx, "/a", DequeueParams{Batch: 1, MaxWait: 30 * time.Second, HasMaxWait: true}); opErr != nil {
+			t.Errorf("dequeue: %v", opErr)
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the long poll outlived its caller")
+	}
+}
+
+type countingLeaseRouteStore struct {
+	*queue.MemoryStore
+	calls int
+}
+
+func (s *countingLeaseRouteStore) LeaseRoutes(leaseIDs []string) (map[string]string, error) {
+	s.calls++
+	return s.MemoryStore.LeaseRoutes(leaseIDs)
+}
+
+type failingLeaseRouteStore struct {
+	*queue.MemoryStore
+}
+
+func (s *failingLeaseRouteStore) LeaseRoutes([]string) (map[string]string, error) {
+	return nil, errors.New("synthetic resolver failure")
+}

--- a/internal/pullapi/ops.go
+++ b/internal/pullapi/ops.go
@@ -1,6 +1,7 @@
 package pullapi
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"time"
@@ -42,7 +43,12 @@ type LeaseBatchResult struct {
 	Conflicts []queue.LeaseBatchConflict
 }
 
-func (s *Server) Dequeue(route string, params DequeueParams) (DequeueResult, *OpError) {
+// Dequeue takes ctx so a long poll ends when the caller does. Without it a
+// worker that timed out left the handler blocked inside the store for the rest
+// of max_wait, and items arriving meanwhile were leased into a connection that
+// no longer existed -- invisible for the whole lease TTL, until the expiry
+// sweep reclaimed them.
+func (s *Server) Dequeue(ctx context.Context, route string, params DequeueParams) (DequeueResult, *OpError) {
 	batch := params.Batch
 	if batch <= 0 {
 		batch = 1
@@ -69,14 +75,30 @@ func (s *Server) Dequeue(route string, params DequeueParams) (DequeueResult, *Op
 		leaseTTL = s.MaxLeaseTTL
 	}
 
-	resp, err := s.Store.Dequeue(queue.DequeueRequest{
+	req := queue.DequeueRequest{
 		Route:    route,
 		Target:   s.Target,
 		Batch:    batch,
 		MaxWait:  maxWait,
 		LeaseTTL: leaseTTL,
-	})
+	}
+
+	var (
+		resp queue.DequeueResponse
+		err  error
+	)
+	if ctxStore, ok := s.Store.(queue.ContextDequeuer); ok {
+		resp, err = ctxStore.DequeueContext(ctx, req)
+	} else {
+		resp, err = s.Store.Dequeue(req)
+	}
 	if err != nil {
+		// The caller is gone by definition on this path, so there is nothing
+		// to report to and nothing to count: treating a client disconnect as a
+		// store outage would page someone for a worker's own timeout.
+		if ctx.Err() != nil {
+			return DequeueResult{}, nil
+		}
 		s.observeDequeue(route, 503, nil)
 		return DequeueResult{}, &OpError{
 			StatusCode: 503,
@@ -103,6 +125,14 @@ func (s *Server) AckSingle(route string, leaseID string) *OpError {
 	if s.isRecentlyCompletedLease(leaseID, recentLeaseOpAck) {
 		s.observeAck(route, 204, leaseID, false)
 		return nil
+	}
+
+	if ok, err := s.leaseInRoute(route, leaseID); err != nil {
+		s.observeAck(route, 500, leaseID, false)
+		return leaseScopeUnavailable("ack failed")
+	} else if !ok {
+		s.observeAck(route, 409, leaseID, false)
+		return leaseScopeConflict()
 	}
 
 	if err := s.Store.Ack(leaseID); err != nil {
@@ -138,6 +168,16 @@ func (s *Server) AckBatch(route string, leaseIDs []string) (LeaseBatchResult, *O
 		return LeaseBatchResult{Succeeded: ackedFromCompleted}, nil
 	}
 
+	pendingLeaseIDs, foreignLeaseIDs, err := s.leasesInRoute(route, pendingLeaseIDs)
+	if err != nil {
+		s.observeAck(route, 500, "", false)
+		return LeaseBatchResult{}, leaseScopeUnavailable("ack failed")
+	}
+	scopeConflicts := s.observeForeignLeases(route, foreignLeaseIDs, s.observeAck)
+	if len(pendingLeaseIDs) == 0 {
+		return LeaseBatchResult{Succeeded: ackedFromCompleted, Conflicts: scopeConflicts}, nil
+	}
+
 	if batchStore, ok := s.Store.(queue.LeaseBatchStore); ok {
 		res, err := batchStore.AckBatch(pendingLeaseIDs)
 		if err != nil {
@@ -155,12 +195,12 @@ func (s *Server) AckBatch(route string, leaseIDs []string) (LeaseBatchResult, *O
 		}
 		return LeaseBatchResult{
 			Succeeded: ackedFromCompleted + res.Succeeded,
-			Conflicts: append([]queue.LeaseBatchConflict(nil), res.Conflicts...),
+			Conflicts: append(scopeConflicts, res.Conflicts...),
 		}, nil
 	}
 
 	acked := 0
-	conflicts := make([]queue.LeaseBatchConflict, 0)
+	conflicts := scopeConflicts
 
 	for _, leaseID := range pendingLeaseIDs {
 		err := s.Store.Ack(leaseID)
@@ -215,6 +255,18 @@ func (s *Server) NackSingle(route string, leaseID string, dead bool, reason stri
 	if s.isRecentlyCompletedLease(leaseID, recentLeaseOpNack) {
 		s.observeNack(route, 204, leaseID, false)
 		return nil
+	}
+
+	if ok, err := s.leaseInRoute(route, leaseID); err != nil {
+		s.observeNack(route, 500, leaseID, false)
+		detail := "nack failed"
+		if dead {
+			detail = "mark dead failed"
+		}
+		return leaseScopeUnavailable(detail)
+	} else if !ok {
+		s.observeNack(route, 409, leaseID, false)
+		return leaseScopeConflict()
 	}
 
 	if dead {
@@ -272,6 +324,20 @@ func (s *Server) NackBatch(route string, leaseIDs []string, dead bool, reason st
 		return LeaseBatchResult{Succeeded: succeededFromCompleted}, nil
 	}
 
+	pendingLeaseIDs, foreignLeaseIDs, scopeErr := s.leasesInRoute(route, pendingLeaseIDs)
+	if scopeErr != nil {
+		s.observeNack(route, 500, "", false)
+		detail := "nack failed"
+		if dead {
+			detail = "mark dead failed"
+		}
+		return LeaseBatchResult{}, leaseScopeUnavailable(detail)
+	}
+	scopeConflicts := s.observeForeignLeases(route, foreignLeaseIDs, s.observeNack)
+	if len(pendingLeaseIDs) == 0 {
+		return LeaseBatchResult{Succeeded: succeededFromCompleted, Conflicts: scopeConflicts}, nil
+	}
+
 	if batchStore, ok := s.Store.(queue.LeaseBatchStore); ok {
 		var (
 			res queue.LeaseBatchResult
@@ -301,12 +367,12 @@ func (s *Server) NackBatch(route string, leaseIDs []string, dead bool, reason st
 		}
 		return LeaseBatchResult{
 			Succeeded: succeededFromCompleted + res.Succeeded,
-			Conflicts: append([]queue.LeaseBatchConflict(nil), res.Conflicts...),
+			Conflicts: append(scopeConflicts, res.Conflicts...),
 		}, nil
 	}
 
 	succeeded := 0
-	conflicts := make([]queue.LeaseBatchConflict, 0)
+	conflicts := scopeConflicts
 
 	for _, leaseID := range pendingLeaseIDs {
 		var err error
@@ -366,6 +432,14 @@ func (s *Server) Extend(route string, leaseID string, extendBy time.Duration) *O
 			Detail:     "lease_id is required",
 		}
 	}
+	if ok, err := s.leaseInRoute(route, leaseID); err != nil {
+		s.observeExtend(route, 500, leaseID, extendBy, false)
+		return leaseScopeUnavailable("extend failed")
+	} else if !ok {
+		s.observeExtend(route, 409, leaseID, extendBy, false)
+		return leaseScopeConflict()
+	}
+
 	if err := s.Store.Extend(leaseID, extendBy); err != nil {
 		if errors.Is(err, queue.ErrLeaseNotFound) || errors.Is(err, queue.ErrLeaseExpired) {
 			s.observeExtend(route, 409, leaseID, extendBy, errors.Is(err, queue.ErrLeaseExpired))

--- a/internal/pullapi/ops_test.go
+++ b/internal/pullapi/ops_test.go
@@ -1,6 +1,7 @@
 package pullapi
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -17,7 +18,7 @@ func TestPullOpsDequeueClampsAndDefaults(t *testing.T) {
 	srv.DefaultLeaseTTL = 30 * time.Second
 	srv.MaxLeaseTTL = 20 * time.Second
 
-	_, opErr := srv.Dequeue("/hooks/github", DequeueParams{
+	_, opErr := srv.Dequeue(context.Background(), "/hooks/github", DequeueParams{
 		Batch:       99,
 		HasMaxWait:  false,
 		HasLeaseTTL: false,

--- a/internal/pullapi/sse.go
+++ b/internal/pullapi/sse.go
@@ -118,7 +118,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 		}
 
 		// Non-blocking dequeue.
-		outcome, opErr := s.Dequeue(route, DequeueParams{
+		outcome, opErr := s.Dequeue(ctx, route, DequeueParams{
 			Batch:       batch,
 			MaxWait:     0,
 			HasMaxWait:  true,

--- a/internal/pullapi/sse_test.go
+++ b/internal/pullapi/sse_test.go
@@ -545,7 +545,14 @@ type lateEnqueueStore struct {
 }
 
 func (s *lateEnqueueStore) Dequeue(req queue.DequeueRequest) (queue.DequeueResponse, error) {
-	resp, err := s.MemoryStore.Dequeue(req)
+	return s.DequeueContext(context.Background(), req)
+}
+
+// DequeueContext has to be overridden too: pullapi prefers it when the store
+// implements queue.ContextDequeuer, and the embedded MemoryStore provides it,
+// so without this the wrapper would be bypassed entirely.
+func (s *lateEnqueueStore) DequeueContext(ctx context.Context, req queue.DequeueRequest) (queue.DequeueResponse, error) {
+	resp, err := s.MemoryStore.DequeueContext(ctx, req)
 	if err != nil || len(resp.Items) > 0 {
 		return resp, err
 	}

--- a/internal/queue/memory.go
+++ b/internal/queue/memory.go
@@ -1,6 +1,7 @@
 package queue
 
 import (
+	"context"
 	"errors"
 	"sort"
 	"strings"
@@ -745,6 +746,13 @@ func (s *MemoryStore) maybePruneLocked(now time.Time) {
 }
 
 func (s *MemoryStore) Dequeue(req DequeueRequest) (DequeueResponse, error) {
+	return s.DequeueContext(context.Background(), req)
+}
+
+// DequeueContext is Dequeue with the caller's context honoured: a consumer that
+// has gone away neither keeps a goroutine parked for the rest of max_wait nor
+// receives a lease it can never settle.
+func (s *MemoryStore) DequeueContext(ctx context.Context, req DequeueRequest) (DequeueResponse, error) {
 	batch := req.Batch
 	if batch <= 0 {
 		batch = 1
@@ -766,6 +774,12 @@ func (s *MemoryStore) Dequeue(req DequeueRequest) (DequeueResponse, error) {
 	deadline := time.Now().Add(maxWait)
 
 	for {
+		// Checked before the scan, so a cancelled caller never has items
+		// leased to it.
+		if err := ctx.Err(); err != nil {
+			return DequeueResponse{}, err
+		}
+
 		s.mu.Lock()
 		now := req.Now
 		if now.IsZero() {
@@ -839,8 +853,33 @@ func (s *MemoryStore) Dequeue(req DequeueRequest) (DequeueResponse, error) {
 			continue
 		case <-timer.C:
 			return DequeueResponse{}, nil
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return DequeueResponse{}, ctx.Err()
 		}
 	}
+}
+
+// LeaseRoutes reports the route each known lease belongs to.
+func (s *MemoryStore) LeaseRoutes(leaseIDs []string) (map[string]string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	out := make(map[string]string, len(leaseIDs))
+	for _, leaseID := range leaseIDs {
+		itemID, ok := s.leases[leaseID]
+		if !ok {
+			continue
+		}
+		env := s.items[itemID]
+		if env == nil {
+			continue
+		}
+		out[leaseID] = env.Route
+	}
+	return out, nil
 }
 
 func (s *MemoryStore) Ack(leaseID string) error {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -1,6 +1,9 @@
 package queue
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 type State string
 
@@ -233,6 +236,32 @@ type BatchEnqueuer interface {
 // after which a fresh channel must be obtained by calling NotifyCh again.
 type StoreNotifier interface {
 	NotifyCh() <-chan struct{}
+}
+
+// ContextDequeuer is an optional extension for stores whose long-poll Dequeue
+// can be abandoned when the caller's context is done.
+//
+// Store.Dequeue takes no context, so a worker that gave up -- a gRPC client
+// whose own deadline fired, an HTTP consumer that disconnected -- left the
+// handler blocked inside the store for the rest of max_wait. Any items that
+// arrived meanwhile were leased into a dead connection and stayed invisible for
+// the whole lease TTL before the expiry sweep reclaimed them, turning each
+// client timeout into a lease-TTL delivery delay.
+type ContextDequeuer interface {
+	DequeueContext(ctx context.Context, req DequeueRequest) (DequeueResponse, error)
+}
+
+// LeaseRouteResolver is an optional extension for stores that can report which
+// route a lease belongs to.
+//
+// It exists so route-scoped credentials can be enforced where the lease
+// operations happen: Ack, Nack, MarkDead and Extend take only a lease ID, so a
+// client authorized for one endpoint could settle another route's in-flight
+// message if it learned that lease ID.
+type LeaseRouteResolver interface {
+	// LeaseRoutes maps each known lease ID to the route of the item it holds.
+	// Unknown leases are absent from the result rather than an error.
+	LeaseRoutes(leaseIDs []string) (map[string]string, error)
 }
 
 const statsTopBacklogLimit = 10

--- a/modules/grpcworker/server.go
+++ b/modules/grpcworker/server.go
@@ -59,7 +59,7 @@ func (s *Server) Dequeue(ctx context.Context, req *workerapipb.DequeueRequest) (
 		return nil, status.Error(codes.Internal, "pull server is not configured")
 	}
 
-	outcome, opErr := s.Pull.Dequeue(route, pullapi.DequeueParams{
+	outcome, opErr := s.Pull.Dequeue(ctx, route, pullapi.DequeueParams{
 		Batch:       int(req.GetBatch()),
 		MaxWait:     maxWait,
 		HasMaxWait:  hasMaxWait,

--- a/modules/postgres/postgres.go
+++ b/modules/postgres/postgres.go
@@ -609,6 +609,13 @@ func (s *Store) EnqueueBatch(items []queue.Envelope) (int, error) {
 }
 
 func (s *Store) Dequeue(req queue.DequeueRequest) (queue.DequeueResponse, error) {
+	return s.DequeueContext(context.Background(), req)
+}
+
+// DequeueContext is Dequeue with the caller's context honoured: a consumer that
+// has gone away neither keeps a goroutine parked for the rest of max_wait nor
+// receives a lease it can never settle.
+func (s *Store) DequeueContext(dequeueCtx context.Context, req queue.DequeueRequest) (queue.DequeueResponse, error) {
 	return runPostgresStoreOperationResult(s, "dequeue", func() (queue.DequeueResponse, error) {
 		if s == nil || s.db == nil {
 			return queue.DequeueResponse{}, errors.New("postgres store is closed")
@@ -642,6 +649,12 @@ func (s *Store) Dequeue(req queue.DequeueRequest) (queue.DequeueResponse, error)
 
 		deadline := time.Now().Add(maxWait)
 		for {
+			// Checked before the scan, so a cancelled caller never has items
+			// leased to it.
+			if err := dequeueCtx.Err(); err != nil {
+				return queue.DequeueResponse{}, err
+			}
+
 			resp, err := s.dequeueOnce(req, batch, leaseTTL)
 			if err != nil {
 				return queue.DequeueResponse{}, err
@@ -669,6 +682,11 @@ func (s *Store) Dequeue(req queue.DequeueRequest) (queue.DequeueResponse, error)
 				continue
 			case <-timer.C:
 				continue
+			case <-dequeueCtx.Done():
+				if !timer.Stop() {
+					<-timer.C
+				}
+				return queue.DequeueResponse{}, dequeueCtx.Err()
 			}
 		}
 	})
@@ -825,6 +843,42 @@ WHERE id = $4
 		s.signal()
 	}
 	return queue.DequeueResponse{Items: items}, nil
+}
+
+// LeaseRoutes reports the route each known lease belongs to.
+func (s *Store) LeaseRoutes(leaseIDs []string) (map[string]string, error) {
+	return runPostgresStoreOperationResult(s, "lease_routes", func() (map[string]string, error) {
+		ids := normalizeUniqueIDs(leaseIDs)
+		if len(ids) == 0 {
+			return map[string]string{}, nil
+		}
+
+		rows, err := s.db.QueryContext(context.Background(), `
+SELECT lease_id, route
+FROM queue_items
+WHERE lease_id = ANY($1)
+`, ids)
+		if err != nil {
+			return nil, err
+		}
+		defer rows.Close()
+
+		out := make(map[string]string, len(ids))
+		for rows.Next() {
+			var leaseID sql.NullString
+			var route string
+			if err := rows.Scan(&leaseID, &route); err != nil {
+				return nil, err
+			}
+			if leaseID.Valid {
+				out[leaseID.String] = route
+			}
+		}
+		if err := rows.Err(); err != nil {
+			return nil, err
+		}
+		return out, nil
+	})
 }
 
 func (s *Store) Ack(leaseID string) error {

--- a/modules/sqlite/sqlite.go
+++ b/modules/sqlite/sqlite.go
@@ -1023,6 +1023,13 @@ WHERE id IN (
 }
 
 func (s *Store) Dequeue(req queue.DequeueRequest) (queue.DequeueResponse, error) {
+	return s.DequeueContext(context.Background(), req)
+}
+
+// DequeueContext is Dequeue with the caller's context honoured: a consumer that
+// has gone away neither keeps a goroutine parked for the rest of max_wait nor
+// receives a lease it can never settle.
+func (s *Store) DequeueContext(ctx context.Context, req queue.DequeueRequest) (queue.DequeueResponse, error) {
 	pruneNow := req.Now
 	if pruneNow.IsZero() {
 		pruneNow = s.now()
@@ -1052,6 +1059,12 @@ func (s *Store) Dequeue(req queue.DequeueRequest) (queue.DequeueResponse, error)
 	deadline := time.Now().Add(maxWait)
 
 	for {
+		// Checked before the scan, so a cancelled caller never has items
+		// leased to it.
+		if err := ctx.Err(); err != nil {
+			return queue.DequeueResponse{}, err
+		}
+
 		resp, err := s.dequeueOnce(req, batch, leaseTTL)
 		if err != nil {
 			return queue.DequeueResponse{}, err
@@ -1079,6 +1092,11 @@ func (s *Store) Dequeue(req queue.DequeueRequest) (queue.DequeueResponse, error)
 			continue
 		case <-timer.C:
 			continue
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			return queue.DequeueResponse{}, ctx.Err()
 		}
 	}
 }
@@ -1453,6 +1471,46 @@ LIMIT ?;
 		return nil, err
 	}
 	return ids, nil
+}
+
+// LeaseRoutes reports the route each known lease belongs to.
+func (s *Store) LeaseRoutes(leaseIDs []string) (map[string]string, error) {
+	ids := normalizeUniqueIDs(leaseIDs)
+	if len(ids) == 0 {
+		return map[string]string{}, nil
+	}
+
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, 0, len(ids))
+	for _, id := range ids {
+		args = append(args, id)
+	}
+
+	rows, err := s.db.QueryContext(context.Background(), `
+SELECT lease_id, route
+FROM queue_items
+WHERE lease_id IN (`+placeholders+`);
+`, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	out := make(map[string]string, len(ids))
+	for rows.Next() {
+		var leaseID sql.NullString
+		var route string
+		if err := rows.Scan(&leaseID, &route); err != nil {
+			return nil, err
+		}
+		if leaseID.Valid {
+			out[leaseID.String] = route
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (s *Store) Ack(leaseID string) error {


### PR DESCRIPTION
## Summary

Both pull/worker transport findings from #258.

### Lease operations were not bound to the route's token scope

The config supports per-route pull tokens, and `authorizePull` picks the authorizer from the request's endpoint — but `ack`, `nack`, `dead` and `extend` passed only the lease ID to the store. The resolved route was used for metrics and nothing else. A client authorized only for endpoint A could therefore `POST /a/ack` with a route-B lease ID and settle, dead-letter or extend B's in-flight message; the metrics attributed it to A as well.

Enforcement now lives where the operation happens:

- `queue.LeaseRouteResolver` (new optional store extension, implemented by all three backends) maps lease IDs to the route of the item they hold. One lookup covers a whole batch.
- A lease belonging to another route is rejected with **the same 409 as an unknown lease**, deliberately: a distinct response would let a caller probe which lease IDs exist elsewhere. Unknown leases are left for the store to reject, for the same reason.
- Batch operations split the request rather than failing it: in-route leases are settled, foreign ones come back as conflicts, exactly as an expired lease does.
- A resolver error **denies** the operation with a 500. A transient store problem must not turn into an authorization bypass.

The check costs one lookup per lease operation, and ack is the pull hot path, so it runs only when the deployment actually uses per-route pull credentials (`Server.LeaseRouteScoped`, wired to the runtime state so a reload that adds or removes route tokens is picked up). With a single global token every client is authorized for every route anyway — there is nothing to enforce and nothing to pay for.

### gRPC `Dequeue` ignored the RPC context

A worker calling `Dequeue` with `max_wait=30s` whose own deadline fires at 5s cancels the RPC, but the handler stayed blocked inside `Pull.Dequeue`, which never saw a context — `queue.Store.Dequeue` does not take one. Items arriving at t=10s were leased and returned into a stream gRPC had already discarded, then sat invisible for the full lease TTL (30s by default) until the expiry sweep reclaimed them. At-least-once holds, but each client timeout became a lease-TTL delivery delay plus a goroutine parked for the remaining `max_wait`.

`queue.ContextDequeuer` (new optional extension) adds `DequeueContext`, implemented by all three backends: the context is checked before each scan — so a cancelled caller is never handed a lease — and is part of the wait select, so the long poll ends with its caller. `pullapi.Dequeue` takes a `context.Context` and prefers the context-aware path when the store offers it; HTTP passes `r.Context()`, SSE passes its stream context (which already carries `sse_max_connection`), and gRPC passes the RPC context.

One deliberate detail: when the dequeue returns a context error, the pull API returns an empty result rather than a 503. The caller is gone by definition on that path, so counting it as a store outage would page someone for a worker's own timeout.

## Related Issues

Closes #258

## Scope

- [ ] DSL / config behavior
- [x] Runtime behavior
- [x] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [x] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

Also run: `go vet ./...` and the Postgres-backed packages against a local `docker-compose.test.yml` instance.

New tests (`internal/pullapi/lease_scope_test.go`):

- The attack, for all four operations (ack, nack, mark-dead, extend): a call on route A's endpoint carrying route B's lease is rejected 409, B's message is verified untouched, and B's own client can still settle it.
- Batch: a mixed request settles the in-route lease and reports the foreign one as a conflict, leaving it leased.
- The lookup is skipped entirely without route-scoped credentials (asserted by counting resolver calls).
- A resolver failure denies with 500.
- A dequeue with an already-cancelled context leases nothing and is not reported as a store failure.
- A long poll cancelled mid-wait returns instead of running out its 30s.

Verified to fail against the previous behaviour: disabling the scope check makes the foreign-lease and batch tests report the operation as accepted, and removing the context-aware path makes the cancelled-dequeue test lease the message and the mid-wait test time out at 5s with "the long poll outlived its caller".

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

- **A deployment with per-route pull tokens gains one store lookup per lease operation.** For memory it is a map lookup; for SQLite and Postgres a single indexed `SELECT` covering the whole batch. Deployments with only a global token are unaffected — the check does not run.
- **A client that was relying on cross-route lease settlement will start getting 409s.** That is the fix, and no documented workflow does this: the pull API resolves the route from the endpoint the worker is already using.
- No config surface change. `pullapi.Server.Dequeue` gained a leading `context.Context` parameter (internal package).

## Notes for Reviewers

- `internal/pullapi/lease_scope.go` holds the whole enforcement, including why the rejection is indistinguishable from an unknown lease and why the check is conditional.
- Both store extensions are optional interfaces, following `StoreNotifier` / `LeaseBatchStore`. A store that implements neither keeps the old behaviour, which is what keeps this from being a breaking change for out-of-tree backends.
- Worth knowing for future decorators: a wrapper that overrides `Dequeue` but embeds a store implementing `DequeueContext` is now bypassed, because the pull API prefers the context-aware method. The SSE test wrapper hit exactly this and now overrides both; the comment there says why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
