### PR TITLE
fix(mcp): verify reloads, publish atomically, stop honestly, open read-only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /healthz?details=true` reports the running config's identity** under `diagnostics.config`: `fingerprint` (SHA-256 of the config file bytes as loaded), `generation` and `loaded_at`. Liveness alone cannot tell you which config a process is running, so this is what lets a deployment pipeline — or the MCP tools below — confirm that a config it wrote was actually adopted.
+
 ### Fixed
+
+- **MCP `config_apply` no longer reports a reload that did not happen.** The "reload health check" polled `GET /healthz` for a 200 — the liveness endpoint a running instance answers regardless of which config it runs. With `hookaido run` started without `--watch` (the default) the file write triggered nothing at all, and the tool still returned `ok/applied/reloaded`: a token revoked through `config_apply` was reported applied while the old token kept authenticating. A reload that failed at apply time looked identical. Because the check could not fail for those reasons, the rollback path was effectively dead code. `config_apply` now signals the instance when a pid file is configured, then waits for it to report the fingerprint of the bytes just written, and rolls the file back when it does not. `instance_reload` verifies the same way. An instance too old to report its config identity yields `applied: true, reloaded: false` plus a `reload_verification` note rather than a false success.
+
+- **MCP `messages_publish` is atomic on the direct SQLite path.** A batch was enqueued item by item, so a mid-batch `ErrQueueFull` left items `[0,k)` queued while the tool returned only an error — and retrying the same batch then failed at item 0 with "already exists", leaving the operation permanently half-applied and un-retryable without manual cleanup. It now uses the backend's transactional batch enqueue, matching the contract the admin-proxy path already kept.
+
+- **MCP `instance_stop` on Windows no longer hard-kills while reporting a graceful stop.** Windows maps every signal to `TerminateProcess`, so the SIGTERM phase terminated the queue server with no drain and no shutdown hooks, and both the tool output (`forced: false`) and the audit event recorded it as graceful. An un-forced stop is now refused there with an explanation; `force` terminates and is reported as `forced: true`.
+
+- **MCP read-only tool sets open the database read-only.** Without `--enable-mutations`, `mcp serve --db` still called the full store constructor on every tool request: `BEGIN IMMEDIATE` migration transactions and `PRAGMA journal_mode=WAL` against the running server's database, plus a checkpoint loop. Pointing a newer binary's MCP server at an older still-running server migrated its schema forward, and the older server then failed its downgrade guard at the next restart; every call also contended for the write lock with the live server.
 
 - **A cancelled dequeue no longer parks a goroutine or leases into a dead connection.** `queue.Store.Dequeue` takes no context, so a gRPC worker whose own deadline fired left the handler blocked inside the store for the rest of `max_wait` — and any item that arrived meanwhile was leased into a stream gRPC had already discarded, invisible for the full lease TTL (30s by default) until the expiry sweep reclaimed it. Every client timeout thus became a lease-TTL delivery delay. All three backends now implement a context-aware dequeue, and the pull API passes the request context through from HTTP, SSE and gRPC: the long poll ends with its caller, and a caller that is already gone is never handed a lease.
 

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -31,11 +31,25 @@ Returns `200` when the instance is healthy.
 
 Returns detailed JSON diagnostics (follows `admin_api.auth` — requires bearer token when configured):
 
+`diagnostics.config` identifies the config the process is actually running:
+`fingerprint` is the SHA-256 of the config file's bytes as loaded, `generation`
+counts successful loads (starting at 1 for startup), and `loaded_at` is when the
+current one took effect. Liveness alone cannot answer that question — `/healthz`
+returns 200 whichever config is in force — so this is what lets a deployment
+pipeline confirm that a config it wrote was adopted rather than silently
+ignored, which is exactly what the MCP `config_apply` and `instance_reload`
+tools do with it.
+
 ```json
 {
   "ok": true,
   "time": "2026-02-12T20:15:00Z",
   "diagnostics": {
+    "config": {
+      "fingerprint": "9f2c…",
+      "generation": 3,
+      "loaded_at": "2026-02-12T20:10:00Z"
+    },
     "queue": {
       "total": 1523,
       "by_state": { "queued": 1200, "leased": 300, "dead": 23 },

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -2,8 +2,10 @@ package app
 
 import (
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -212,6 +214,7 @@ func run() int {
 	defer stop()
 
 	state := newRuntimeState(compiled)
+	state.setConfigFingerprint(data)
 	if err := state.loadAuth(compiled); err != nil {
 		runtimeLogger.Error("load_auth_failed", slog.Any("err", err))
 		return 1
@@ -426,6 +429,9 @@ type runtimeState struct {
 	pullAuthorize        pullapi.Authorizer
 	workerAuthorize      workerapi.Authorizer
 	adminAuthorize       admin.Authorizer
+	configFingerprint    string
+	configGeneration     int
+	configLoadedAt       time.Time
 	pullByRoute          map[string]pullapi.Authorizer
 	workerByRoute        map[string]workerapi.Authorizer
 	basicByRoute         map[string]*ingress.BasicAuth
@@ -461,6 +467,36 @@ func newRuntimeState(compiled config.Compiled) *runtimeState {
 	s.adaptiveController = newAdaptiveAdmissionController(compiled.Defaults.AdaptiveBackpressure, compiled.Defaults.TrendSignals)
 	s.configureIngressRateLimits(compiled)
 	return s
+}
+
+// setConfigFingerprint records which config bytes the process is running.
+//
+// It is what lets a caller verify that a config it wrote was actually adopted.
+// Liveness alone cannot: /healthz answers 200 whichever config is in force, so
+// a write that no reload picked up -- the instance runs without --watch, or the
+// reload failed at apply time and kept the old config -- was indistinguishable
+// from a successful apply.
+func (s *runtimeState) setConfigFingerprint(raw []byte) {
+	sum := sha256.Sum256(raw)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.configFingerprint = hex.EncodeToString(sum[:])
+	s.configGeneration++
+	s.configLoadedAt = time.Now().UTC()
+}
+
+// configDiagnostics reports the running config identity for /healthz?details=true.
+func (s *runtimeState) configDiagnostics() map[string]any {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := map[string]any{
+		"fingerprint": s.configFingerprint,
+		"generation":  s.configGeneration,
+	}
+	if !s.configLoadedAt.IsZero() {
+		out["loaded_at"] = s.configLoadedAt.Format(time.RFC3339Nano)
+	}
+	return out
 }
 
 func (s *runtimeState) updateAll(compiled config.Compiled) {
@@ -1728,6 +1764,7 @@ func reloadConfig(path string, running config.Compiled, state *runtimeState, log
 		return running, false
 	}
 	state.updateAll(compiled)
+	state.setConfigFingerprint(data)
 
 	logger.Info("config_reloaded_ok", slog.String("trigger", trigger))
 	return compiled, true
@@ -2576,7 +2613,17 @@ func startServers(
 		appMetrics.observePublishResult(event.Accepted, event.Rejected, event.Code, event.Scoped)
 	}
 	if appMetrics != nil {
-		adminH.HealthDiagnostics = appMetrics.healthDiagnostics
+		// The config identity rides along with the health diagnostics so a
+		// caller that applied a config can verify the running process adopted
+		// it, rather than inferring success from liveness.
+		adminH.HealthDiagnostics = func() map[string]any {
+			out := appMetrics.healthDiagnostics()
+			if out == nil {
+				out = map[string]any{}
+			}
+			out["config"] = state.configDiagnostics()
+			return out
+		}
 	}
 
 	// Build the HTTP components. Ingress serves its bare route paths; the API

--- a/internal/hookaido/module.go
+++ b/internal/hookaido/module.go
@@ -60,6 +60,11 @@ type QueueBackendConfig struct {
 	// Delivery-attempt history retention.
 	AttemptsRetentionMaxAge  time.Duration
 	AttemptsRetentionMaxRows int
+
+	// ReadOnly asks the backend to open the store without writing to it --
+	// no schema migrations, no background maintenance. Backends that cannot
+	// honour it may ignore it; callers that depend on it must not mutate.
+	ReadOnly bool
 }
 
 // TracingProvider sets up distributed tracing and provides HTTP instrumentation.

--- a/internal/mcp/config_fingerprint.go
+++ b/internal/mcp/config_fingerprint.go
@@ -1,0 +1,187 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/nuetzliches/hookaido/v2/internal/config"
+)
+
+// A reload used to be confirmed with waitForAdminHealth, which polls
+// GET /healthz for a 200 -- the unauthenticated liveness endpoint a running
+// instance answers regardless of which config it is running. Two paths reported
+// success while the process still served the old config:
+//
+//   - `hookaido run` without --watch (the default): writing the file triggers
+//     nothing, healthz answers 200 on the first poll, and config_apply returned
+//     ok/applied/reloaded -- so a token revoked through config_apply was
+//     reported applied while the old token kept authenticating.
+//   - With --watch, a reload that fails at apply time logs config_reload_failed
+//     and keeps the old config, while healthz stays 200.
+//
+// Because the check could not fail for those reasons, rollbackConfigFile was
+// effectively dead code.
+//
+// The instance now reports the fingerprint of the config bytes it is running
+// under /healthz?details=true, so the tools can wait for the config they wrote
+// to actually be in force, and roll back when it is not.
+
+// configFingerprint is the fingerprint the running instance reports for a given
+// config file content.
+func configFingerprint(content []byte) string {
+	sum := sha256.Sum256(content)
+	return hex.EncodeToString(sum[:])
+}
+
+type runningConfigIdentity struct {
+	Fingerprint string
+	Generation  int
+}
+
+// errConfigDiagnosticsUnavailable reports that the instance answered health
+// checks but did not report a config fingerprint -- an older instance, or one
+// whose admin API predates this field.
+var errConfigDiagnosticsUnavailable = errors.New("running instance does not report a config fingerprint")
+
+// fetchRunningConfigIdentity reads the config identity from the admin API's
+// detailed health endpoint.
+func fetchRunningConfigIdentity(compiled config.Compiled, timeout time.Duration) (runningConfigIdentity, error) {
+	url, err := adminHealthURL(compiled.AdminAPI)
+	if err != nil {
+		return runningConfigIdentity{}, err
+	}
+	token, err := loadAdminHealthToken(compiled.AdminAPI.AuthTokens)
+	if err != nil {
+		return runningConfigIdentity{}, err
+	}
+
+	if strings.Contains(url, "?") {
+		url += "&details=true"
+	} else {
+		url += "?details=true"
+	}
+
+	// No Proxy, for the same reason as waitForAdminHealth: this is the
+	// operator's own admin endpoint and the request carries the admin token.
+	client := &http.Client{
+		Transport: &http.Transport{TLSClientConfig: adminProxyTLSConfig(compiled.AdminAPI)},
+		Timeout:   minDuration(timeout, 5*time.Second),
+	}
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return runningConfigIdentity{}, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return runningConfigIdentity{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return runningConfigIdentity{}, fmt.Errorf("health check returned status %d", resp.StatusCode)
+	}
+
+	var payload struct {
+		Diagnostics struct {
+			Config struct {
+				Fingerprint string `json:"fingerprint"`
+				Generation  int    `json:"generation"`
+			} `json:"config"`
+		} `json:"diagnostics"`
+	}
+	// A body that is not the expected JSON, or that carries no fingerprint,
+	// both mean the same thing to the caller: this instance cannot say which
+	// config it is running. Reporting them alike keeps an older instance from
+	// looking like a failure while still refusing to claim a verified reload.
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&payload); err != nil {
+		return runningConfigIdentity{}, fmt.Errorf("%w: %v", errConfigDiagnosticsUnavailable, err)
+	}
+	if strings.TrimSpace(payload.Diagnostics.Config.Fingerprint) == "" {
+		return runningConfigIdentity{}, errConfigDiagnosticsUnavailable
+	}
+	return runningConfigIdentity{
+		Fingerprint: payload.Diagnostics.Config.Fingerprint,
+		Generation:  payload.Diagnostics.Config.Generation,
+	}, nil
+}
+
+// waitForRunningConfig polls until the instance reports it is running the given
+// fingerprint, and returns an error when it does not within the timeout.
+func waitForRunningConfig(compiled config.Compiled, want string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		identity, err := fetchRunningConfigIdentity(compiled, timeout)
+		switch {
+		case err == nil && identity.Fingerprint == want:
+			return nil
+		case err == nil:
+			lastErr = fmt.Errorf("running config fingerprint is %s, want %s", shortFingerprint(identity.Fingerprint), shortFingerprint(want))
+		case errors.Is(err, errConfigDiagnosticsUnavailable):
+			// Nothing to wait for: this instance cannot report what it runs.
+			return err
+		default:
+			lastErr = err
+		}
+
+		if !time.Now().Before(deadline) {
+			break
+		}
+		sleep := minDuration(200*time.Millisecond, time.Until(deadline))
+		if sleep <= 0 {
+			break
+		}
+		time.Sleep(sleep)
+	}
+	if lastErr == nil {
+		lastErr = errors.New("timed out")
+	}
+	return fmt.Errorf("the running instance did not adopt the written config (%w); it may be running without --watch, or the reload may have failed -- check the instance log for config_reload_failed", lastErr)
+}
+
+func shortFingerprint(fp string) string {
+	if len(fp) <= 12 {
+		return fp
+	}
+	return fp[:12]
+}
+
+// signalReloadBestEffort sends SIGHUP to the configured instance when it can,
+// so config_apply does not depend on the operator having started the process
+// with --watch (which defaults to false). It reports whether the signal was
+// sent and, when it was not, why -- never an error: the config is verified by
+// its fingerprint afterwards either way, and an instance running with --watch
+// needs no signal at all.
+func (s *Server) signalReloadBestEffort(args map[string]any) (bool, string) {
+	if strings.TrimSpace(s.PIDFilePath) == "" {
+		return false, "pid file path is not configured"
+	}
+	pidFile, err := s.resolvePIDFilePath(args)
+	if err != nil {
+		return false, err.Error()
+	}
+	pid, err := readPIDFileValue(pidFile)
+	if err != nil {
+		return false, err.Error()
+	}
+	if !isPIDRunning(pid) {
+		return false, fmt.Sprintf("process %d is not running", pid)
+	}
+	if err := signalPID(pid, syscall.SIGHUP); err != nil {
+		return false, err.Error()
+	}
+	return true, ""
+}

--- a/internal/mcp/config_fingerprint_test.go
+++ b/internal/mcp/config_fingerprint_test.go
@@ -1,0 +1,211 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// writeStubHealthz answers like a running instance: a plain 200 for the
+// liveness probe, and detailed diagnostics carrying the fingerprint of the
+// config the instance is running. Pass an empty configPath to model an instance
+// that reports no config identity at all.
+func writeStubHealthz(t *testing.T, w http.ResponseWriter, r *http.Request, configPath string) {
+	t.Helper()
+	if r.URL.Query().Get("details") != "true" {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok\n"))
+		return
+	}
+
+	diagnostics := map[string]any{}
+	if strings.TrimSpace(configPath) != "" {
+		content, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Errorf("stub healthz: read config: %v", err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		diagnostics["config"] = map[string]any{
+			"fingerprint": configFingerprint(content),
+			"generation":  1,
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"ok":          true,
+		"diagnostics": diagnostics,
+	})
+}
+
+// startStubAdmin runs a stub admin API whose healthz reports the fingerprint of
+// runningPath, and returns its address. runningPath is what the *instance* is
+// running, which is not necessarily what was just written to disk.
+func startStubAdmin(t *testing.T, token string, runningPath func() string) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet || r.URL.Path != "/admin/healthz" {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			if r.Header.Get("Authorization") != "Bearer "+token {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			writeStubHealthz(t, w, r, runningPath())
+		}),
+	}
+	done := make(chan struct{})
+	go func() {
+		_ = srv.Serve(ln)
+		close(done)
+	}()
+	t.Cleanup(func() {
+		_ = srv.Close()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Fatal("timed out waiting for the stub admin server to stop")
+		}
+	})
+	return ln.Addr().String()
+}
+
+// The reload check used to be a liveness probe: /healthz answers 200 whichever
+// config is in force, so config_apply reported ok/applied/reloaded while the
+// instance still served the old config -- and rollbackConfigFile could never
+// run. This models exactly that: the instance keeps running the old file.
+func TestToolConfigApply_ReloadNotAdoptedRollsBack(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "Hookaidofile")
+	runningPath := filepath.Join(dir, "running-config")
+
+	const token = "admintoken"
+	addr := startStubAdmin(t, token, func() string { return runningPath })
+
+	original := fmt.Sprintf(`admin_api {
+  listen %q
+  prefix "/admin"
+  auth token "raw:%s"
+}
+"/r" {
+  deliver "https://example.com" {}
+}
+`, addr, token)
+	if err := os.WriteFile(cfgPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+	// The instance is running the original and never picks the new one up.
+	if err := os.WriteFile(runningPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write running config: %v", err)
+	}
+
+	candidate := strings.Replace(original, "https://example.com", "https://example.org", 1)
+
+	s := NewServer(nil, nil, cfgPath, "", WithMutationsEnabled(true), WithRole(RoleAdmin), WithPrincipal("test-admin"))
+	resp := callTool(t, s, "config_apply", map[string]any{
+		"path":           cfgPath,
+		"content":        candidate,
+		"mode":           "write_and_reload",
+		"reload_timeout": "1s",
+		"reason":         "apply test",
+	})
+	if resp.IsError {
+		t.Fatalf("unexpected config_apply error: %s", resp.Content[0].Text)
+	}
+
+	out, ok := resp.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structured content type: %T", resp.StructuredContent)
+	}
+	if okVal, _ := out["ok"].(bool); okVal {
+		t.Fatal("config_apply reported success while the instance kept the old config")
+	}
+	if reloaded, _ := out["reloaded"].(bool); reloaded {
+		t.Fatal("reloaded=true without the instance adopting the config")
+	}
+	if rolledBack, _ := out["rolled_back"].(bool); !rolledBack {
+		t.Fatal("expected the file to be rolled back")
+	}
+
+	got, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != original {
+		t.Fatalf("config was not restored:\n%s", got)
+	}
+}
+
+// An instance that cannot report its config identity must not be claimed as a
+// verified reload -- but must not be treated as a failure either, since the
+// file was written and the old liveness check is all that is available.
+func TestToolConfigApply_UnverifiableInstanceReportsHonestly(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "Hookaidofile")
+
+	const token = "admintoken"
+	addr := startStubAdmin(t, token, func() string { return "" })
+
+	original := fmt.Sprintf(`admin_api {
+  listen %q
+  prefix "/admin"
+  auth token "raw:%s"
+}
+"/r" {
+  deliver "https://example.com" {}
+}
+`, addr, token)
+	if err := os.WriteFile(cfgPath, []byte(original), 0o600); err != nil {
+		t.Fatalf("write original: %v", err)
+	}
+	candidate := strings.Replace(original, "https://example.com", "https://example.org", 1)
+
+	s := NewServer(nil, nil, cfgPath, "", WithMutationsEnabled(true), WithRole(RoleAdmin), WithPrincipal("test-admin"))
+	resp := callTool(t, s, "config_apply", map[string]any{
+		"path":           cfgPath,
+		"content":        candidate,
+		"mode":           "write_and_reload",
+		"reload_timeout": "1s",
+		"reason":         "apply test",
+	})
+	if resp.IsError {
+		t.Fatalf("unexpected config_apply error: %s", resp.Content[0].Text)
+	}
+	out, ok := resp.StructuredContent.(map[string]any)
+	if !ok {
+		t.Fatalf("structured content type: %T", resp.StructuredContent)
+	}
+	if applied, _ := out["applied"].(bool); !applied {
+		t.Fatal("expected applied=true: the file was written")
+	}
+	if reloaded, _ := out["reloaded"].(bool); reloaded {
+		t.Fatal("expected reloaded=false: nothing confirmed the instance adopted it")
+	}
+	if rolledBack, _ := out["rolled_back"].(bool); rolledBack {
+		t.Fatal("expected no rollback")
+	}
+	if note, _ := out["reload_verification"].(string); note == "" {
+		t.Fatal("expected reload_verification to explain why the reload is unverified")
+	}
+
+	got, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if string(got) != candidate {
+		t.Fatal("the written config should stay in place")
+	}
+}

--- a/internal/mcp/process_signal.go
+++ b/internal/mcp/process_signal.go
@@ -1,0 +1,11 @@
+package mcp
+
+import "errors"
+
+// errGracefulStopUnsupported reports that the platform has no way to ask a
+// process to shut down cleanly, so the only stop available is a hard kill.
+//
+// Windows is the case that matters: os.Process.Signal maps every signal to
+// TerminateProcess, so sending "SIGTERM" there is a kill with no drain and no
+// shutdown hooks. Callers must not present that as a graceful stop.
+var errGracefulStopUnsupported = errors.New("graceful stop is not supported on this platform; pass force to terminate the process")

--- a/internal/mcp/process_signal_windows.go
+++ b/internal/mcp/process_signal_windows.go
@@ -43,6 +43,14 @@ func sendSignal(pid int, sig syscall.Signal) error {
 	if sig == syscall.SIGHUP {
 		return fmt.Errorf("signal %s is not supported on Windows", sig)
 	}
+	// SIGTERM has no Windows equivalent: p.Signal maps it to TerminateProcess,
+	// which is a hard kill. Refusing it here is what keeps a stop that skipped
+	// the drain from being reported as graceful; stopPID escalates to
+	// SIGKILL -- the same TerminateProcess -- only when force is set, and then
+	// reports forced: true.
+	if sig == syscall.SIGTERM {
+		return fmt.Errorf("%w (signal %s)", errGracefulStopUnsupported, sig)
+	}
 
 	p, err := os.FindProcess(pid)
 	if err != nil {

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -1954,7 +1954,13 @@ func (s *Server) openQueueStore() (closableStore, error) {
 	if !ok {
 		return nil, errors.New("sqlite queue backend is not available (not compiled in)")
 	}
-	raw, _, err := b.OpenStore(hookaido.QueueBackendConfig{DSN: p})
+	// A read-only tool set must not write to the database it inspects. Opening
+	// read-write ran migrations against the running server's database on every
+	// tool request -- so a newer binary's `mcp serve --db` migrated an older
+	// server's schema forward under it, and the older server then refused to
+	// start at its next restart -- and it contended for the single write lock
+	// with the live server each time.
+	raw, _, err := b.OpenStore(hookaido.QueueBackendConfig{DSN: p, ReadOnly: !s.MutationsEnabled})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mcp/publish_atomic_test.go
+++ b/internal/mcp/publish_atomic_test.go
@@ -1,0 +1,91 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/nuetzliches/hookaido/v2/internal/queue"
+)
+
+// closableMemoryStore adapts the memory store to the closableStore the tools
+// use. The memory backend enqueues a batch all-or-nothing, exactly as the
+// sqlite backend does in a transaction.
+type closableMemoryStore struct {
+	*queue.MemoryStore
+}
+
+func (closableMemoryStore) Close() error { return nil }
+
+func preparedItems(ids ...string) []queue.Envelope {
+	out := make([]queue.Envelope, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, queue.Envelope{ID: id, Route: "/r", Target: "pull", Payload: []byte("{}")})
+	}
+	return out
+}
+
+func queuedCount(t *testing.T, store queue.Store) int {
+	t.Helper()
+	stats, err := store.Stats()
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	return stats.ByState[queue.StateQueued]
+}
+
+// The direct-sqlite publish path enqueued item by item, so a batch that hit
+// ErrQueueFull halfway left items [0,k) queued while the tool returned only an
+// error -- and retrying the same batch then failed at item 0 with "already
+// exists", leaving the operation permanently half-applied. The admin-proxy
+// variant of the same tool treats atomicity as the contract.
+func TestPublishAllOrNothing_MidBatchFailureCommitsNothing(t *testing.T) {
+	memory := queue.NewMemoryStore(queue.WithQueueLimits(2, "reject"))
+	store := closableMemoryStore{MemoryStore: memory}
+
+	if _, err := publishAllOrNothing(store, preparedItems("a", "b", "c")); err == nil {
+		t.Fatal("expected the over-capacity batch to fail")
+	}
+	if got := queuedCount(t, memory); got != 0 {
+		t.Fatalf("queued=%d, want 0: the failed batch left messages behind", got)
+	}
+
+	// The same batch is retryable, which the half-applied version was not.
+	if _, err := publishAllOrNothing(store, preparedItems("a", "b")); err != nil {
+		t.Fatalf("retry of a smaller batch: %v", err)
+	}
+	if got := queuedCount(t, memory); got != 2 {
+		t.Fatalf("queued=%d, want 2", got)
+	}
+}
+
+func TestPublishAllOrNothing_Success(t *testing.T) {
+	memory := queue.NewMemoryStore()
+	store := closableMemoryStore{MemoryStore: memory}
+
+	n, err := publishAllOrNothing(store, preparedItems("a", "b", "c"))
+	if err != nil {
+		t.Fatalf("publish: %v", err)
+	}
+	if n != 3 {
+		t.Fatalf("published=%d, want 3", n)
+	}
+	if got := queuedCount(t, memory); got != 3 {
+		t.Fatalf("queued=%d, want 3", got)
+	}
+}
+
+// A backend without atomic batch enqueue cannot be made atomic here, so the
+// error has to say how far it got rather than pretend nothing happened.
+func TestPublishAllOrNothing_NonBatchBackendReportsPartialState(t *testing.T) {
+	memory := queue.NewMemoryStore(queue.WithQueueLimits(2, "reject"))
+	store := closableMemoryStore{MemoryStore: memory}
+
+	// publishSequentially is what a backend without BatchEnqueuer would take.
+	_, err := publishSequentially(store, preparedItems("a", "b", "c"))
+	if err == nil {
+		t.Fatal("expected the over-capacity batch to fail")
+	}
+	if got := err.Error(); !strings.Contains(got, "already published") {
+		t.Fatalf("error %q does not report the partial state", got)
+	}
+}

--- a/internal/mcp/runtime_control.go
+++ b/internal/mcp/runtime_control.go
@@ -503,9 +503,29 @@ func (s *Server) toolInstanceReload(args map[string]any) (any, error) {
 	}
 
 	healthURL, healthErr := waitForAdminHealth(compiled, timeout)
+	verificationNote := ""
+	if healthErr == nil {
+		// Liveness says the process answers, not which config it answers with:
+		// a reload that fails at apply time keeps the old config and healthz
+		// stays 200. Wait for the instance to report the fingerprint of the
+		// file on disk instead.
+		content, readErr := os.ReadFile(s.ConfigPath)
+		switch {
+		case readErr != nil:
+			verificationNote = readErr.Error()
+		default:
+			verifyErr := waitForRunningConfig(compiled, configFingerprint(content), timeout)
+			if errors.Is(verifyErr, errConfigDiagnosticsUnavailable) {
+				verificationNote = verifyErr.Error()
+			} else if verifyErr != nil {
+				healthErr = verifyErr
+			}
+		}
+	}
+
 	out := map[string]any{
 		"ok":         healthErr == nil,
-		"reloaded":   healthErr == nil,
+		"reloaded":   healthErr == nil && verificationNote == "",
 		"signaled":   true,
 		"pid":        pid,
 		"pid_file":   pidFile,
@@ -516,6 +536,9 @@ func (s *Server) toolInstanceReload(args map[string]any) (any, error) {
 	}
 	if healthErr != nil {
 		out["errors"] = []string{healthErr.Error()}
+	}
+	if verificationNote != "" {
+		out["reload_verification"] = verificationNote
 	}
 	return out, nil
 }
@@ -614,19 +637,40 @@ func signalPID(pid int, sig syscall.Signal) error {
 	return nil
 }
 
+// stopPID asks the process to stop, escalating to a hard kill only when force
+// is set -- and it reports which of the two actually happened.
+//
+// On Windows there is no graceful signal to send: os.Process.Signal maps
+// everything to TerminateProcess. The platform layer therefore refuses SIGTERM
+// there rather than silently performing a hard kill, which used to be reported
+// as `forced: false` in both the tool output and the audit event -- an
+// operator calling instance_stop without force killed the queue server outright
+// with no drain and no shutdown hooks, and the record said it had stopped
+// gracefully.
 func stopPID(pid int, timeout time.Duration, force bool) (stopped bool, forced bool, err error) {
 	if !isPIDRunning(pid) {
 		return true, false, nil
 	}
-	if err := signalPID(pid, syscall.SIGTERM); err != nil {
-		return false, false, err
+
+	termErr := signalPID(pid, syscall.SIGTERM)
+	switch {
+	case termErr == nil:
+		if waitForPIDExit(pid, timeout) {
+			return true, false, nil
+		}
+		if !force {
+			return false, false, nil
+		}
+	case errors.Is(termErr, errGracefulStopUnsupported):
+		// Without force there is nothing honest left to do: say so instead of
+		// terminating and calling it graceful.
+		if !force {
+			return false, false, termErr
+		}
+	default:
+		return false, false, termErr
 	}
-	if waitForPIDExit(pid, timeout) {
-		return true, false, nil
-	}
-	if !force {
-		return false, false, nil
-	}
+
 	if err := signalPID(pid, syscall.SIGKILL); err != nil {
 		return false, false, err
 	}

--- a/internal/mcp/runtime_control_test.go
+++ b/internal/mcp/runtime_control_test.go
@@ -220,9 +220,22 @@ admin_api { listen %q }
 		}
 	}
 
-	stopResp := callTool(t, s, "instance_stop", map[string]any{
-		"timeout": "8s",
-	})
+	stopArgs := map[string]any{"timeout": "8s"}
+	if runtime.GOOS == "windows" {
+		// Windows has no graceful stop: os.Process.Signal maps everything to
+		// TerminateProcess. An un-forced stop therefore reports that rather
+		// than hard-killing the queue server and calling it graceful.
+		gracefulResp := callTool(t, s, "instance_stop", stopArgs)
+		if !gracefulResp.IsError {
+			t.Fatal("expected instance_stop without force to be refused on windows")
+		}
+		if len(gracefulResp.Content) == 0 || !strings.Contains(gracefulResp.Content[0].Text, "graceful stop is not supported") {
+			t.Fatalf("expected the graceful-stop refusal, got %#v", gracefulResp.Content)
+		}
+		stopArgs["force"] = true
+	}
+
+	stopResp := callTool(t, s, "instance_stop", stopArgs)
 	if stopResp.IsError {
 		t.Fatalf("unexpected instance_stop error: %s", stopResp.Content[0].Text)
 	}
@@ -235,6 +248,14 @@ admin_api { listen %q }
 	}
 	if stopped, _ := stopOut["stopped"].(bool); !stopped {
 		t.Fatalf("expected stopped=true")
+	}
+	// forced must describe what actually happened.
+	forced, _ := stopOut["forced"].(bool)
+	if runtime.GOOS == "windows" && !forced {
+		t.Fatal("a Windows stop is always a hard kill and must be reported as forced")
+	}
+	if runtime.GOOS != "windows" && forced {
+		t.Fatal("a process that exited on SIGTERM must not be reported as forced")
 	}
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2013,7 +2013,11 @@ func TestToolConfigApplyWriteAndReloadSuccess(t *testing.T) {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
-			w.WriteHeader(http.StatusOK)
+			// Reports the fingerprint of whatever the file currently holds,
+			// which is what a running instance with --watch does: config_apply
+			// may only claim a reload once the instance says it runs those
+			// bytes.
+			writeStubHealthz(t, w, r, cfgPath)
 		}),
 	}
 	done := make(chan struct{})

--- a/internal/mcp/spec.md
+++ b/internal/mcp/spec.md
@@ -118,7 +118,7 @@ Arguments:
 Mode enum:
 - `preview_only` (default): validate/compile only; no write
 - `write_only`: atomic write to configured path after successful validate/compile
-- `write_and_reload`: atomic write + bounded admin health check (`GET {admin_prefix}/healthz`), rollback to previous file on failed health check
+- `write_and_reload`: atomic write + verification that the running instance adopted the written config, rollback to the previous file when it did not
 
 Notes:
 - `reason` is **required**, `actor` and `request_id` are optional — the same audit triple every other mutating tool takes. They are echoed on the response under `audit` and recorded in `metadata.config_mutation`.
@@ -126,7 +126,9 @@ Notes:
 - `reload_timeout` is optional and only used by `write_and_reload` (default `5s`).
 - Admin auth tokens are loaded for the health check; unresolved token refs fail `write_and_reload`.
 - Token refs used by MCP health/reload flows support `env:`, `file:`, `vault:`, and `raw:` schemes via the shared secrets resolver.
-- `write_and_reload` does not signal a running `hookaido run` process; runtime reload is handled by config file watch (`--watch`) or explicit `instance_reload`.
+- `write_and_reload` verifies the reload rather than inferring it from liveness. It sends `SIGHUP` when a pid file is configured (so it does not depend on `--watch`, which defaults to off), then polls `GET {admin_prefix}/healthz?details=true` until `diagnostics.config.fingerprint` equals the SHA-256 of the bytes it wrote. If that does not happen within `reload_timeout` the previous file is restored and the tool reports `ok: false`, `rolled_back: true`.
+- Response fields: `reload_signaled` reports whether a `SIGHUP` was sent; `reload_verification` is present only when the instance could not report its config identity (an older build), in which case `applied` is `true` and `reloaded` is `false` — the write happened, the adoption is unverified.
+- `instance_reload` verifies the same way after signalling.
 
 ### `admin_health`
 Return local read-only snapshot (`config_readable`, `db_exists`, `db_readable`).
@@ -793,6 +795,8 @@ Notes:
   - `timestamp`, `principal`, `role`, `tool`, `input_hash`, `result`, `duration_ms` (and `error` when applicable)
   - Config-lifecycle mutation tools (`config_apply`, `management_endpoint_upsert`, `management_endpoint_delete`) include `metadata.config_mutation` (`operation`, `mode`, path/selector fields, the audit triple `reason`/`actor`/`request_id`, and apply outcome flags such as `ok`, `applied`, `reloaded`, `rolled_back` when available). `config_apply` additionally records `content_sha256` and `content_bytes`, so a reviewer can identify the config text that was applied — `input_hash` covers the whole argument object and changes with the reason or mode too.
   - Runtime process-control tools (`instance_start`, `instance_stop`, `instance_reload`) include `metadata.runtime_control` (`operation`, pid/timeout context, and outcome flags such as `started|stopped|reloaded`, `already_running|already_stopped`, `signaled` when available).
+- `instance_stop` without `force` is refused on Windows: the platform has no graceful stop (every signal maps to `TerminateProcess`), so a stop there is always a hard kill and is reported as `forced: true`. Pass `force` to terminate deliberately.
+- A read-only tool set (no `--enable-mutations`) opens the SQLite database read-only: no schema migrations, no WAL/journal pragmas, no checkpoint loop. Pointing a newer binary's `mcp serve --db` at a running older server no longer migrates its schema forward.
   - ID-based queue mutation tools (`dlq_requeue`, `dlq_delete`, `messages_cancel`, `messages_requeue`, `messages_resume`) include `metadata.id_mutation` (`operation`, `changed_field`, `ids_requested`, `ids_unique`, `changed` when available).
   - `messages_publish` also includes `metadata.admin_proxy_publish` rollback counters (`rollback_attempts`, `rollback_succeeded`, `rollback_failed`, `rollback_ids`) plus running totals (`*_total`) for Admin-proxy publish rollback observability.
   - `messages_*_by_filter` also include `metadata.filter_mutation` (`operation`, `changed_field`, `matched`, `changed`, `preview_only`) for mutation-result observability.

--- a/internal/mcp/tools_config.go
+++ b/internal/mcp/tools_config.go
@@ -371,8 +371,10 @@ func (s *Server) toolConfigApply(args map[string]any) (any, error) {
 	applied := false
 	reloaded := false
 	rolledBack := false
+	reloadSignaled := false
 	healthURL := ""
 	reloadErr := ""
+	verificationNote := ""
 
 	if mode == "write_only" {
 		if err := writeFileAtomic(p, []byte(content)); err != nil {
@@ -391,17 +393,44 @@ func (s *Server) toolConfigApply(args map[string]any) (any, error) {
 			return nil, err
 		}
 
+		// The instance is signalled where possible instead of hoping --watch is
+		// on: `hookaido run` defaults to --watch=false, so writing the file
+		// triggered nothing at all in the default setup.
+		signaled, signalErr := s.signalReloadBestEffort(args)
+
 		healthURL, err = waitForAdminHealth(compiled, reloadTimeout)
-		if err != nil {
+		if err == nil {
+			// Liveness only says the process answers. Wait for it to report the
+			// fingerprint of the bytes just written -- that is the difference
+			// between "the instance is up" and "the instance is running this
+			// config".
+			err = waitForRunningConfig(compiled, configFingerprint([]byte(content)), reloadTimeout)
+			if errors.Is(err, errConfigDiagnosticsUnavailable) {
+				// An instance too old to report its config identity: fall back
+				// to the liveness check it was verified with before, and say so
+				// rather than claiming a verified reload.
+				verificationNote = err.Error()
+				err = nil
+				reloaded = false
+				applied = true
+			}
+		}
+
+		switch {
+		case err != nil:
 			reloadErr = err.Error()
+			if signalErr != "" {
+				reloadErr = fmt.Sprintf("%s (reload signal: %s)", reloadErr, signalErr)
+			}
 			if rbErr := rollbackConfigFile(p, existed, previous); rbErr != nil {
 				return nil, fmt.Errorf("reload verification failed (%v), rollback failed: %w", err, rbErr)
 			}
 			rolledBack = true
-		} else {
+		case verificationNote == "":
 			applied = true
 			reloaded = true
 		}
+		reloadSignaled = signaled
 	}
 
 	out := map[string]any{
@@ -422,7 +451,11 @@ func (s *Server) toolConfigApply(args map[string]any) (any, error) {
 		out["reload_timeout"] = reloadTimeout.String()
 		out["health_url"] = healthURL
 		out["reloaded"] = reloaded
+		out["reload_signaled"] = reloadSignaled
 		out["rolled_back"] = rolledBack
+		if verificationNote != "" {
+			out["reload_verification"] = verificationNote
+		}
 		out["reload_error"] = reloadErr
 		if reloadErr != "" {
 			out["errors"] = []string{reloadErr}

--- a/internal/mcp/tools_messages.go
+++ b/internal/mcp/tools_messages.go
@@ -379,24 +379,66 @@ func (s *Server) toolMessagesPublish(args map[string]any) (any, error) {
 		return nil, fmt.Errorf("items[%d].id %q already exists", dupIdx, dupID)
 	}
 
-	published := 0
-	for i, env := range prepared {
-		if err := store.Enqueue(env); err != nil {
-			switch {
-			case errors.Is(err, queue.ErrEnvelopeExists):
-				return nil, fmt.Errorf("items[%d].id %q already exists", i, env.ID)
-			case errors.Is(err, queue.ErrQueueFull):
-				return nil, fmt.Errorf("items[%d]: queue full", i)
-			default:
-				return nil, fmt.Errorf("items[%d]: %w", i, err)
-			}
-		}
-		published++
+	// Atomicity is the contract this tool's admin-proxy variant already keeps
+	// (it rolls back committed IDs on failure). The direct path enqueued item
+	// by item, so a mid-batch ErrQueueFull left items [0,k) queued while the
+	// tool reported only an error -- and retrying the same batch then failed at
+	// item 0 with "already exists", leaving the operation permanently
+	// half-applied and un-retryable without manual cleanup.
+	published, err := publishAllOrNothing(store, prepared)
+	if err != nil {
+		return nil, err
 	}
 	return map[string]any{
 		"published": published,
 		"audit":     mutationAuditMap(audit, s.auditPrincipal()),
 	}, nil
+}
+
+// publishAllOrNothing enqueues every item or none. It uses the store's batch
+// enqueue when the backend offers one (sqlite does, transactionally); without
+// it there is nothing to roll back to, so the loop is the honest fallback and
+// its partial state is reported in the error.
+func publishAllOrNothing(store closableStore, prepared []queue.Envelope) (int, error) {
+	if batcher, ok := any(store).(queue.BatchEnqueuer); ok {
+		n, err := batcher.EnqueueBatch(prepared)
+		if err != nil {
+			return 0, publishEnqueueError(err, prepared, n)
+		}
+		return n, nil
+	}
+
+	return publishSequentially(store, prepared)
+}
+
+// publishSequentially is the fallback for a backend without atomic batch
+// enqueue. There is nothing to roll back to there, so the partial state goes
+// into the error rather than being hidden.
+func publishSequentially(store closableStore, prepared []queue.Envelope) (int, error) {
+	published := 0
+	for i, env := range prepared {
+		if err := store.Enqueue(env); err != nil {
+			return published, fmt.Errorf("items[%d] (%d of %d already published, batch enqueue unsupported by this backend): %w",
+				i, published, len(prepared), publishEnqueueError(err, prepared, i))
+		}
+		published++
+	}
+	return published, nil
+}
+
+func publishEnqueueError(err error, prepared []queue.Envelope, idx int) error {
+	id := ""
+	if idx >= 0 && idx < len(prepared) {
+		id = prepared[idx].ID
+	}
+	switch {
+	case errors.Is(err, queue.ErrEnvelopeExists):
+		return fmt.Errorf("id %q already exists", id)
+	case errors.Is(err, queue.ErrQueueFull):
+		return errors.New("queue full")
+	default:
+		return err
+	}
 }
 
 type adminPublishBatch struct {

--- a/modules/sqlite/readonly_test.go
+++ b/modules/sqlite/readonly_test.go
@@ -1,0 +1,106 @@
+package sqlite
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/v2/internal/queue"
+)
+
+// A read-only tool set must not write to the database it inspects. Opening
+// read-write ran BEGIN IMMEDIATE migration transactions against the running
+// server's database on every request, so a newer binary's `mcp serve --db`
+// migrated an older server's schema forward under it -- and the older server
+// then failed its downgrade guard at the next restart.
+func TestReadOnlyStore_ReadsButNeverWrites(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "hookaido.db")
+
+	owner, err := NewStore(dbPath, WithCheckpointInterval(0))
+	if err != nil {
+		t.Fatalf("open owner store: %v", err)
+	}
+	if err := owner.Enqueue(queue.Envelope{ID: "evt_1", Route: "/r", Target: "pull", Payload: []byte("{}")}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if err := owner.Close(); err != nil {
+		t.Fatalf("close owner store: %v", err)
+	}
+
+	before, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	ro, err := NewStore(dbPath, WithReadOnly(true))
+	if err != nil {
+		t.Fatalf("open read-only store: %v", err)
+	}
+	t.Cleanup(func() { _ = ro.Close() })
+
+	// Reads still work: this is what the read-only tool set needs.
+	stats, err := ro.Stats()
+	if err != nil {
+		t.Fatalf("stats: %v", err)
+	}
+	if stats.ByState[queue.StateQueued] != 1 {
+		t.Fatalf("queued=%d, want 1", stats.ByState[queue.StateQueued])
+	}
+	if _, err := ro.ListMessages(queue.MessageListRequest{Route: "/r", Limit: 10}); err != nil {
+		t.Fatalf("list messages: %v", err)
+	}
+
+	// Writes do not.
+	err = ro.Enqueue(queue.Envelope{ID: "evt_2", Route: "/r", Target: "pull", Payload: []byte("{}")})
+	if err == nil {
+		t.Fatal("a read-only store must not accept an enqueue")
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "read") {
+		t.Logf("enqueue rejected with: %v", err)
+	}
+
+	after, err := os.Stat(dbPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) || after.Size() != before.Size() {
+		t.Fatalf("the database file changed: size %d->%d, mtime %v->%v",
+			before.Size(), after.Size(), before.ModTime(), after.ModTime())
+	}
+}
+
+// A read-only store cannot create the database it is pointed at: that would
+// mean writing, and an empty file would then look like a valid but empty queue.
+func TestReadOnlyStore_MissingFileFails(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.db")
+	if _, err := NewStore(missing, WithReadOnly(true)); err == nil {
+		t.Fatal("expected opening a missing database read-only to fail")
+	}
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatal("a read-only open must not create the database file")
+	}
+}
+
+// The checkpoint loop is a background writer, so it must not run either.
+func TestReadOnlyStore_NoCheckpointLoop(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "hookaido.db")
+	owner, err := NewStore(dbPath, WithCheckpointInterval(0))
+	if err != nil {
+		t.Fatalf("open owner store: %v", err)
+	}
+	if err := owner.Close(); err != nil {
+		t.Fatalf("close owner store: %v", err)
+	}
+
+	ro, err := NewStore(dbPath, WithReadOnly(true), WithCheckpointInterval(time.Millisecond))
+	if err != nil {
+		t.Fatalf("open read-only store: %v", err)
+	}
+	defer func() { _ = ro.Close() }()
+
+	if ro.checkpointStop != nil {
+		t.Fatal("the checkpoint loop must not start on a read-only store")
+	}
+}

--- a/modules/sqlite/sqlite.go
+++ b/modules/sqlite/sqlite.go
@@ -270,6 +270,7 @@ type Store struct {
 	dlqMaxDepth              int
 	attemptsRetentionMaxAge  time.Duration
 	attemptsMaxRows          int
+	readOnly                 bool
 	checkpointInterval       time.Duration
 	checkpointStop           chan struct{}
 	checkpointDone           chan struct{}
@@ -371,14 +372,9 @@ func NewStore(dbPath string, opts ...Option) (*Store, error) {
 		}
 	}
 
-	db, err := sql.Open("sqlite", dbPath)
-	if err != nil {
-		return nil, err
-	}
-	db.SetMaxOpenConns(1)
-
+	// Options are applied before the database is opened, because read-only mode
+	// changes the DSN itself.
 	s := &Store{
-		db:                 db,
 		nowFn:              time.Now,
 		notify:             make(chan struct{}),
 		pollInterval:       1 * time.Second,
@@ -390,13 +386,57 @@ func NewStore(dbPath string, opts ...Option) (*Store, error) {
 		opt(s)
 	}
 
+	dsn := dbPath
+	if s.readOnly {
+		if _, err := os.Stat(dbPath); err != nil {
+			return nil, err
+		}
+		dsn = readOnlyDSN(dbPath)
+	} else if dir := filepath.Dir(dbPath); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return nil, err
+		}
+	}
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		return nil, err
+	}
+	db.SetMaxOpenConns(1)
+	s.db = db
+
 	if err := s.init(); err != nil {
 		_ = db.Close()
 		return nil, err
 	}
-	s.startCheckpointLoop()
+	if !s.readOnly {
+		s.startCheckpointLoop()
+	}
 
 	return s, nil
+}
+
+// WithReadOnly opens the database read-only: no migrations, no journal or
+// synchronous pragmas, no checkpoint loop.
+//
+// It exists for processes that inspect another instance's database, such as
+// `hookaido mcp serve --db` with a read-only tool set. Opening read-write there
+// ran `BEGIN IMMEDIATE` migration transactions against the running server's
+// database on every tool request -- so pointing a newer binary's MCP server at
+// an older server's database migrated the schema forward under it, and the
+// older server then failed its downgrade guard at the next restart. Every call
+// also briefly contended for the single write lock with the live server.
+func WithReadOnly(readOnly bool) Option {
+	return func(s *Store) {
+		s.readOnly = readOnly
+	}
+}
+
+// readOnlyDSN turns a plain file path into a modernc sqlite DSN that opens the
+// database read-only. The immutable flag is deliberately not set: the file is
+// being written by another process.
+func readOnlyDSN(dbPath string) string {
+	return "file:" + filepath.ToSlash(dbPath) + "?mode=ro"
 }
 
 func WithQueueLimits(maxDepth int, dropPolicy string) Option {
@@ -417,6 +457,15 @@ func (s *Store) Close() error {
 
 func (s *Store) init() error {
 	ctx := context.Background()
+
+	if s.readOnly {
+		// A read-only connection cannot set these pragmas or run migrations,
+		// and must not: the schema belongs to whichever process owns the file.
+		if _, err := s.db.ExecContext(ctx, "PRAGMA busy_timeout=5000;"); err != nil {
+			return fmt.Errorf("sqlite: set busy_timeout: %w", err)
+		}
+		return nil
+	}
 
 	var journalMode string
 	if err := s.db.QueryRowContext(ctx, "PRAGMA journal_mode=WAL;").Scan(&journalMode); err != nil {
@@ -3440,6 +3489,7 @@ func (backend) OpenStore(cfg hookaido.QueueBackendConfig) (any, func() error, er
 		WithDeliveredRetention(cfg.DeliveredRetentionMaxAge),
 		WithDLQRetention(cfg.DLQRetentionMaxAge, cfg.DLQRetentionMaxDepth),
 		WithAttemptsRetention(cfg.AttemptsRetentionMaxAge, cfg.AttemptsRetentionMaxRows),
+		WithReadOnly(cfg.ReadOnly),
 	)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

All four MCP correctness findings from #256.

### `config_apply` reported reloads it had no evidence for

The "reload health check" was `waitForAdminHealth`, which polls `GET /healthz` for a 200 — the liveness endpoint a running instance answers regardless of which config it runs. Both false-success paths in the issue are real, and the second one is the reason the rollback existed at all:

- `hookaido run` defaults to `--watch=false`, so the file write triggered **nothing**. healthz answered 200 on the first poll and the tool returned `ok/applied/reloaded` while the process served the old config — a token revoked through `config_apply` was reported applied while the old token kept authenticating.
- With `--watch`, a reload that fails at apply time logs `config_reload_failed`, keeps the old config, and healthz stays 200.

Since the check could not fail for either reason, `rollbackConfigFile` was effectively unreachable.

Fixing this needs evidence the tool can check, so the instance now publishes it: `GET /healthz?details=true` reports `diagnostics.config` with the `fingerprint` (SHA-256 of the config file bytes as loaded), a `generation` counter and `loaded_at`. That is a small, generally useful Admin API addition — a deployment pipeline can ask the same question — and it is documented in `docs/admin-api.md`.

`config_apply` then does what the issue asks:

1. writes the file,
2. **signals** the instance (`SIGHUP`) when a pid file is configured, instead of hoping `--watch` is on,
3. waits for the reported fingerprint to equal the SHA-256 of the bytes it wrote,
4. rolls the file back and returns `ok: false, rolled_back: true` when it does not — the rollback path is now live and tested.

`instance_reload` verifies the same way after signalling.

One compatibility case: an instance too old to report a config identity yields `applied: true, reloaded: false` and a `reload_verification` note explaining why the adoption is unverified. Reporting that as a failure would break upgrades in the wrong direction; reporting it as success is what this PR is fixing.

### Direct-SQLite `messages_publish` was not atomic

The direct path enqueued item by item, so an `ErrQueueFull` at item k left items `[0,k)` queued while the tool returned only an error. Retrying the same batch then failed at item 0 with "already exists": permanently half-applied and un-retryable without manual cleanup. The admin-proxy variant of the same tool treats atomicity as the contract, rolling back committed IDs on failure.

It now uses the store's `BatchEnqueuer`, which sqlite implements in one transaction. The sequential loop survives only as the fallback for a backend without it, where there is nothing to roll back to — and there it reports how far it got in the error rather than hiding the partial state.

### Windows `instance_stop` hard-killed while reporting a graceful stop

`stopPID` sends SIGTERM for the graceful phase, and on Windows `sendSignal` translated any non-zero, non-SIGHUP signal to `TerminateProcess`. So a Windows operator calling `instance_stop` without `force` killed the queue server outright — no drain, no shutdown hooks — while the tool output (`forced: false`) and the audit event both recorded a graceful stop.

The platform layer now refuses SIGTERM on Windows, as it already refuses SIGHUP, and `stopPID` distinguishes "the platform has no graceful stop" from a real signal error: without `force` it says so; with `force` it terminates and reports `forced: true`. The existing lifecycle test now asserts the platform difference and, on both platforms, that `forced` describes what actually happened.

### Read-only tool sets opened the live database read-write

`mcp serve --db` advertises read-only tools, but `openQueueStore` called the full `sqlite.NewStore` — `BEGIN IMMEDIATE` migration transactions and `PRAGMA journal_mode=WAL` against the running server's database, on every tool request, plus a checkpoint loop. Running a *newer* binary's `mcp serve` against an older still-running server's database migrated its schema forward, and the older server then failed its downgrade guard at the next restart.

`sqlite.WithReadOnly` opens with `mode=ro`, skips migrations and the journal/synchronous pragmas, and does not start the checkpoint loop. It reaches the MCP server through a new `ReadOnly` field on `hookaido.QueueBackendConfig`, set when mutations are not enabled — so an `--enable-mutations` server, whose tools legitimately write, is unaffected.

## Related Issues

Closes #256

## Scope

- [ ] DSL / config behavior
- [x] Runtime behavior
- [x] Admin or Pull API behavior
- [x] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Validation

- [x] `go test ./...` passed locally
- [x] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

Also run: `go vet ./...`, the Postgres-backed packages against a local instance, and `GOOS=windows`/`GOOS=darwin` builds for the signal change.

New tests:

- `internal/mcp/config_fingerprint_test.go` — a stub admin API that reports the fingerprint of whatever config the *instance* is running (not what was written). One test models the instance keeping the old config: `ok: false`, `reloaded: false`, `rolled_back: true`, and the file restored byte-for-byte. Another models an instance that reports no config identity: written, not claimed as reloaded, not rolled back, with the note set. The first fails against the previous behaviour, reporting success while the instance kept the old config.
- `internal/mcp/publish_atomic_test.go` — an over-capacity batch leaves nothing queued and the batch stays retryable; the success path; and the non-atomic fallback's error naming how far it got.
- `modules/sqlite/readonly_test.go` — a read-only store reads, refuses to write, leaves the file's size and mtime untouched, refuses to create a missing database, and starts no checkpoint loop.
- `internal/mcp/runtime_control_test.go` — the lifecycle test now asserts the Windows refusal and that `forced` matches reality on both platforms.

The existing `TestToolConfigApplyWriteAndReloadSuccess` stub was updated to serve the fingerprint, so the success path exercises the real verification rather than the liveness probe.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable)
- [x] Backward compatibility considered

- **`config_apply` will now fail where it used to "succeed".** An operator running without `--watch` and without a configured pid file gets a rollback and `ok: false` instead of a false success. That is the fix, but it turns a silent no-op into a visible failure, and the error says what to do (enable `--watch`, or configure the pid file so the tool can signal).
- **`instance_stop` without `force` now errors on Windows.** Scripts relying on it must pass `force`, which is what was happening anyway — just now it is recorded truthfully.
- **`/healthz?details=true` gained a `config` object.** It is behind the same auth as the rest of the detailed payload; the fingerprint is a hash, not config content.
- The MCP read-only store change means a read-only server can no longer create a missing database file. Pointing `--db` at a path that does not exist now fails instead of silently creating an empty queue.

## Notes for Reviewers

- `internal/mcp/config_fingerprint.go` carries the reasoning for the whole first item, including why an undecodable or fingerprint-less health payload is treated as "cannot verify" rather than as a failure.
- The fingerprint is over the raw file bytes rather than the compiled config, so the MCP side can compute the expected value from exactly what it wrote, with no normalization to agree on.
- `signalReloadBestEffort` never fails the operation: an instance running with `--watch` needs no signal, and the fingerprint check is the real gate either way. Its outcome is reported as `reload_signaled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
