### PR TITLE
chore(release): prepare v2.12.0

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,16 +4,16 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
 
 ## P1 - Medium Priority (awesome-go readiness, target: July 2026)
 
-- [ ] **Test coverage ≥80%** — 76.7% as of v2.11.0, measured with `make cover` (needs `HOOKAIDO_TEST_POSTGRES_DSN`; see `docker-compose.test.yml`). Generated protobuf code is excluded — 292 never-hand-tested statements say nothing about the code we write.
+- [ ] **Test coverage ≥80%** — 77.1% as of v2.12.0, measured with `make cover` (needs `HOOKAIDO_TEST_POSTGRES_DSN`; see `docker-compose.test.yml`). Generated protobuf code is excluded — 292 never-hand-tested statements say nothing about the code we write.
 
-  Flat against v2.10.1's 76.9% despite a large new test surface: the #249–#258 fixes added roughly as many production statements as they added covered ones, so the ratio held while the absolute covered count grew.
+  Up from v2.11.0's 76.7%, reversing that release's slight dip from v2.10.1's 76.9%. The #273–#276 work added more covered statements than production ones: `internal/app` moved 62.5% → 64.5% because `resolveClientIP`, `pollConfig` and the query-auth wiring are all directly testable without a server bring-up, and `internal/ingress` is at 92.5%.
 
-  Ranked by uncovered statements, which is what actually moves the total — a package at 62% with 1,200 uncovered statements matters far more than one at 62% with 40:
+  Ranked by uncovered statements, which is what actually moves the total — a package at 64% with 1,200 uncovered statements matters far more than one at 64% with 40:
 
   | Package | Uncovered | Total | % |
   | --- | ---: | ---: | ---: |
-  | `internal/config` | 1241 | 5720 | 78.3% |
-  | `internal/app` | 1219 | 3255 | 62.5% |
+  | `internal/config` | 1248 | 5841 | 78.6% |
+  | `internal/app` | 1201 | 3383 | 64.5% |
   | `internal/mcp` | 932 | 4134 | 77.5% |
   | `internal/admin` | 543 | 2606 | 79.2% |
   | `modules/sqlite` | 432 | 1693 | 74.5% |
@@ -21,7 +21,7 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
   | `internal/queue` | 213 | 1337 | 84.1% |
   | `internal/pullapi` | 179 | 673 | 73.4% |
 
-  Reaching 80% needs roughly **760 more covered statements**. `internal/config` and `internal/mcp` are the tractable bulk (parser and handler edge cases). `internal/app` is the largest percentage gap but the hardest: its zero-coverage functions are `run.go` startup paths that need a real server bring-up, which is where the last coverage pass deliberately stopped.
+  Reaching 80% needs roughly **690 more covered statements**. `internal/config` and `internal/mcp` are the tractable bulk (parser and handler edge cases). `internal/app` is still the largest percentage gap and still the hardest: what remains uncovered there is concentrated in `run.go` startup paths that need a real server bring-up, which is where every coverage pass so far has deliberately stopped. The v2.12.0 delta is the argument for the approach that works — extract the logic into a function that takes its inputs as arguments, as `resolveClientIP` and `pollConfig` do, rather than trying to test `run()`.
 
 - [ ] **Publish a reachable coverage report** — awesome-go requires a Codecov or Coveralls link that resolves. CI computes a profile and uploads it, but only as a workflow artifact (`ci.yml`, `actions/upload-artifact` name `coverage`): that expires, needs a signed-in session, and is not a report — so there is no durable link to submit. Needs a coverage service wired into CI plus a README badge. Two things to fix while doing it: the `test` job does not set `HOOKAIDO_TEST_POSTGRES_DSN`, so the uploaded profile understates coverage the same way a local `make test-pg`-less run does, and it excludes nothing, so it counts generated protobuf. This is the one remaining awesome-go blocker fully in our control besides the 80% number itself.
 - [ ] **pkg.go.dev doc coverage** — Ensure all public types and functions have Go-style doc comments.
@@ -39,6 +39,8 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
 - [ ] **VS Code LSP** — Language server backed by `config validate`/`config compile` for live diagnostics in the editor. Optional follow-up to the VS Code extension.
 
 ## Completed (move here when done)
+
+- [x] **Config-vs-reality gaps from the third review round (#273–#276)** — Four places where a Hookaidofile said one thing and the running process enforced another. `ingress { trusted_proxies }` so `match remote_ip` sees the client rather than the reverse proxy, instead of silently matching nothing or (once widened to the proxy subnet) everything. `--watch-interval` plus a `watch_may_not_fire` startup warning, because `--watch` cannot fire at all against a single-file bind mount — the shape `docs/docker.md` itself recommended. `auth query` as a first-class variant for event sources whose entire configuration surface is a URL, replacing the `match query` workaround that reported the route as unauthenticated and could not reach `secret_ref`. And constant-time comparison in `matchHeaderValues`/`matchQueryValues`, the one secret comparison in the project that still leaked timing. One PR per issue (#277–#280), each with the docs stating the honest limitation rather than only the fix.
 
 - [x] **Single-port shared listener for ingress + pull (#183)** — `ingress` can now co-listen with `pull_api` (and transitively `admin_api`) on one prefix-muxed port when their `listen` addresses match: ingress serves its bare route paths as the default handler, the APIs serve under their prefixes. Strictly opt-in; the multi-port topology remains the default. Compile-time validation was generalized (`validateSharedListeners`) to enforce non-empty/distinct/non-overlapping API prefixes, reject ingress-route-path/API-prefix collisions, and require identical TLS across the shared address; `pull_api.grpc_listen` and `observability.metrics.listen` stay dedicated. Runtime listener construction now groups HTTP components by address and muxes shared groups via a generalized `prefixMux`. New `IngressShared` compiled flag (restart-required on toggle, surfaced as `ingress_shared` in config-summary/MCP output). 5 new config tests + a single-port e2e round-trip (`TestBinaryE2E_SinglePortIngressPull`); docs (configuration.md, DESIGN.md) + CHANGELOG updated.
 - [x] **Module path migrated to `/v2` (Go modules v2+ rule)** — `go.mod` is now `github.com/nuetzliches/hookaido/v2`. Rewrote 66 `.go` files' imports, LDFLAGS in `internal/tools/release/main.go` + `Dockerfile`, install instructions in `doc.go` + `cmd/hookaido/doc.go`, the `go_package` option in `modules/grpcworker/proto/workerapi.proto` and regenerated `workerapi.pb.go`. Repo-wide `gofmt -s` cleanup of 10 files. `go build ./...`, `go vet ./...`, full `make test-pg` all green. Root cause: `proxy.golang.org` fell back to v1.5.1 because the unsuffixed module path was incompatible with v2.x.x tags — unblocks Go Report Card / pkg.go.dev / awesome-go.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.12.0] - 2026-08-26
+
+A release about the gap between what a config file *says* and what the running
+process actually enforces. Each of the four entries below is a place where
+Hookaido was doing something defensible while an operator, reading their own
+Hookaidofile, would reasonably conclude otherwise — an IP allowlist that matched
+the proxy, a `--watch` that could never fire, an authenticated route reporting as
+open, and the one secret comparison that was not constant time. It closes
+[#273](https://github.com/nuetzliches/hookaido/issues/273)–[#276](https://github.com/nuetzliches/hookaido/issues/276).
+
+`ingress.trusted_proxies` and `auth query` are the only new configuration
+surface; both are opt-in, and nothing changes for a config that does not use
+them. The importable Go API is unchanged, so this stays on the `/v2` module path.
+
 ### Added
 
 - **`ingress { trusted_proxies "..." }`** makes `match remote_ip` usable behind a reverse proxy. `remote_ip` compared against the transport peer address only, and `X-Forwarded-For` was not consulted anywhere — a defensible default, but one that fails silently and in both directions in the topology Hookaido is most often deployed in. Behind a TLS-terminating proxy every request arrives with the proxy's address, so an allowlist of the source's published egress range matched *nothing* and the route returned `404` for legitimate traffic; widening the range to the proxy's subnet to make it work then matched *everything* the proxy forwarded, from any origin, while the config still read like an origin restriction. The new directive is opt-in and empty by default, in which case nothing changes and the header is still never read. When set, and only when the peer address falls inside one of its prefixes, the right-most `X-Forwarded-For` entry that is not itself trusted becomes the client address for `remote_ip` — so a client talking to Hookaido directly cannot spoof its way past an allowlist. Accepts IPs and CIDRs, IPv4 and IPv6; live-reloadable. Ingress rate limiting is keyed per route and globally, never per client address, so it is unaffected. `docs/ingress.md`, `docs/configuration.md` and `docs/docker.md` now state the trap and both ways out. ([#276](https://github.com/nuetzliches/hookaido/issues/276))

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,13 +1,13 @@
 # Development Status
 
-Last updated: 2026-08-18
-Current release: v2.11.0
+Last updated: 2026-08-26
+Current release: v2.12.0
 
 Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change history: `CHANGELOG.md`. Prioritized work items: `BACKLOG.md`.
 
 ## Capabilities Overview
 
-**Ingress & Routing** - HTTP ingress with optional TLS/mTLS, HMAC signature verification (replay protection, secret rotation, provider-compatible formats for GitHub/Gitea/Forgejo), Basic auth, forward auth callouts, and per-route/global rate limiting. Route matching supports path, method, host (wildcards), headers, query params, remote IP (CIDR), and named matchers. Channel types (`inbound`/`outbound`/`internal`) enforce directive constraints at compile time. Listeners default to separate ports but can opt into a single prefix-muxed port (ingress + `pull_api`/`admin_api` on the same `listen` address) for single-port deployments.
+**Ingress & Routing** - HTTP ingress with optional TLS/mTLS, HMAC signature verification (replay protection, secret rotation, provider-compatible formats for GitHub/Gitea/Forgejo), Basic auth, forward auth callouts, query-token auth for sources that can only be given a URL, and per-route/global rate limiting. Route matching supports path, method, host (wildcards), headers, query params, remote IP (CIDR, optionally resolved through `X-Forwarded-For` for configured `trusted_proxies`), and named matchers. Channel types (`inbound`/`outbound`/`internal`) enforce directive constraints at compile time. Listeners default to separate ports but can opt into a single prefix-muxed port (ingress + `pull_api`/`admin_api` on the same `listen` address) for single-port deployments.
 
 **Queue & Delivery** - SQLite/WAL and PostgreSQL durable queue backends (in-memory available for dev/tests), held to one shared `queue.Store` contract that CI exercises against all three, with lease semantics, long-poll dequeue, dead-lettering, and queue limits/retention/pruning. Push dispatcher with retry/backoff, per-route concurrency, custom outbound headers, and optional outbound HMAC signing (multi-secret rotation). Pull API (HTTP/JSON) with bearer-token auth, dequeue limits, and per-route token overrides. Optional Worker API (gRPC) mirrors Pull lease operations (`dequeue`, `ack`, `nack`, `extend`) and is intentionally scoped to pull-worker transport only.
 
@@ -15,7 +15,7 @@ Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change histo
 
 **MCP** - Stdio JSON-RPC server (`hookaido mcp serve`) with role-gated access (`read`/`operate`/`admin`). Read tools for config inspection, queue state, and health diagnostics. Mutation tools (gated) for config apply, queue operations, and endpoint management. Runtime control tools (gated) for process lifecycle. Structured JSONL audit events, principal-authoritative actor binding, and Admin-proxy mode for non-SQLite backends (memory/postgres) deployments.
 
-**Config DSL** - Caddyfile-inspired syntax with `config fmt` round-trip stability. Env/file/vars placeholders, multi-value directives, hot reload via `--watch`/`SIGHUP`, and channel-type wrappers. Defaults blocks for egress policy, deliver settings, publish policy, and trend signal tuning. Secret refs support `env:`, `file:`, `vault:`, and `raw:`.
+**Config DSL** - Caddyfile-inspired syntax with `config fmt` round-trip stability. Env/file/vars placeholders, multi-value directives, hot reload via `--watch`/`SIGHUP` (with an optional `--watch-interval` content poll for mounts that cannot deliver file events), and channel-type wrappers. Defaults blocks for egress policy, deliver settings, publish policy, and trend signal tuning. Secret refs support `env:`, `file:`, `vault:`, and `raw:`.
 
 **Observability** - Structured JSON logs (access + runtime), Prometheus metrics endpoint, OpenTelemetry tracing (OTLP/HTTP), and health diagnostics with trend signals.
 


### PR DESCRIPTION
Release prep for v2.12.0. Closes the third review round — [#273](https://github.com/nuetzliches/hookaido/issues/273)–[#276](https://github.com/nuetzliches/hookaido/issues/276), each merged as its own PR (#277–#280).

## What the release is about

Four places where a Hookaidofile said one thing and the running process enforced another:

- an IP allowlist that matched the reverse proxy rather than the client (#276)
- a `--watch` that could never fire against the mount shape the docs themselves recommended (#275)
- an authenticated route reporting as unauthenticated, because the only credential check available to a URL-only source was a matcher (#273)
- the one secret comparison in the project that was not constant time (#274)

`ingress.trusted_proxies` and `auth query` are the only new configuration surface; both are opt-in, and nothing changes for a config that does not use them. The importable Go API is unchanged, so this stays on the `/v2` module path.

## Contents

- **CHANGELOG.md** — Unreleased entries cut into a `[2.12.0] - 2026-08-26` section with a framing paragraph.
- **STATUS.md** — `Current release`, and the two capability lines that actually changed: query-token auth plus trusted-proxy-resolved `remote_ip` under Ingress & Routing, `--watch-interval` under Config DSL.
- **BACKLOG.md** — coverage refreshed against a real `make cover` run against Postgres (**76.7% → 77.1%**; `internal/config` 78.3% → 78.6%, `internal/app` 62.5% → 64.5%, `internal/ingress` 92.5%), remaining gap restated as ~690 covered statements, and the round moved to Completed.

The `internal/app` jump is worth noting in the backlog item because it is evidence for the approach that works there: `resolveClientIP` and `pollConfig` take their inputs as arguments and are testable without a server bring-up, unlike the `run.go` startup paths that make up the rest of that package's gap.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)