### PR TITLE
feat(pullapi): name the pull consumers attached to a route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+
+- **`GET /admin/pull/consumers` and `pull_sse_connected` / `pull_sse_disconnected` log lines name the pull consumers attached to a route.** `hookaido_pull_sse_connection_active{route}` already said *how many* consumers a route has, which is the decisive signal — an unexpected second consumer on a competing-consumer queue is not a visible failure, because the two split the traffic while ingress keeps answering `202` for every event, so from inside either one it is indistinguishable from delivery loss. What was missing was *which*: with the gauge reading `2` and one expected, the only way to name the second was to correlate raw container logs by `remote_addr` and resolve the addresses on the host, which needs shell access and only works while the offender is still connected. The Admin API endpoint now reports each open SSE stream with its remote address, connected-since, messages sent, and the configured token reference it authenticated with — the reference (`env.PULL_TOKEN`), never the token, and for a route with its own `pull { auth token ... }` only from that route's set. The gauge stays unlabeled by consumer on purpose: a remote-address label is unbounded cardinality for a diagnostic needed occasionally. Establish and teardown are also logged at INFO, because a stream logs one access-log line when it opens and then stays open for hours, so the access log alone can reconstruct neither who is attached nor when anyone left. Covered by the read-role MCP tool `pull_consumers`. Both surfaces cover SSE streams only — a consumer polling `POST {endpoint}/dequeue` holds no connection between calls and is counted by neither. ([#285](https://github.com/nuetzliches/hookaido/issues/285))
+
 ## [2.12.0] - 2026-08-26
 
 A release about the gap between what a config file *says* and what the running

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -247,6 +247,7 @@ Endpoints:
 - `POST {endpoint}/ack`
 - `POST {endpoint}/nack`
 - `POST {endpoint}/extend`
+- `GET {endpoint}/stream` (SSE; each event creates a lease with the same semantics as `dequeue`). Streams are registered in a per-process consumer registry surfaced by Admin `GET /pull/consumers` and logged at INFO as `pull_sse_connected` / `pull_sse_disconnected` with `consumer_id`, `route`, `endpoint`, `remote_addr` and `token_ref` (the configured secret reference, never the token value). Multiple streams on one route remain competing consumers.
 
 `ack` request forms:
 ```json
@@ -313,6 +314,7 @@ Endpoints:
 - For global route-selector `POST /messages/publish` and route-selector/unscoped `POST /messages/*_by_filter`, when `defaults.publish_policy.fail_closed on` is enabled and managed-route context cannot be evaluated, requests fail closed with `503` and `code=managed_resolver_missing`.
 - For global route-selector `POST /messages/*_by_filter`, ownership-source drift between `ManagementModel` and route-policy ownership callbacks for the selected route fails closed with `503` and `code=managed_target_mismatch`.
 - `GET /attempts` (query params: `route` or `application` + `endpoint_name`, `target`, `event_id`, `outcome` (`acked|retry|dead`), `limit` (default 100, max 1000), `before` (RFC3339); when selector mode is `route`, it must be an absolute Hookaido route path starting with `/`; managed selectors return `404` with `code=managed_endpoint_not_found` when selector labels do not resolve, `503` with `code=managed_resolver_missing` when resolver wiring is unavailable, and `503` with `code=managed_target_mismatch` when selector-resolved route ownership is out of sync with route ownership policy mapping)
+- `GET /pull/consumers` (returns the pull consumers holding an SSE stream right now; query param: `route`, which when provided must be an absolute Hookaido route path starting with `/`; each entry carries `id`, `route`, `endpoint`, `remote_addr`, `user_agent`, `token_ref`, `connected_at`, `connected_for_seconds`, `messages_sent` and `last_message_at`; `token_ref` is the configured secret reference the consumer authenticated with and never the token value, resolved from a route's own `pull { auth token ... }` set when it has one; SSE streams only, so a consumer polling `{endpoint}/dequeue` is not listed; the registry is per process and in memory, so a restart empties it; returns `503` with `code=pull_consumers_unavailable` when registry wiring is unavailable)
 - `GET /management/model` (returns runtime management projection with `route_count`, `application_count`, `endpoint_count`, and `applications[]` entries carrying `name`, `endpoint_count` and nested `endpoints[]` (`name`, `route`, `mode`, `targets`, `publish_policy` with `enabled` / `direct_enabled` / `managed_enabled`))
 - `GET /applications` (returns management application list with per-application endpoint counts)
 - `GET /applications/{application}/endpoints` (returns endpoint entries for one application; entries include `publish_policy`; `application` is path-escaped and matched exactly)
@@ -469,6 +471,7 @@ Queue/Admin tools:
 - `management_model` (application/endpoint projection from compiled config)
 - `management_endpoint_upsert`, `management_endpoint_delete` (application/endpoint mapping CUD in config source-of-truth)
 - `attempts_list`
+- `pull_consumers` (live SSE consumer registry; Admin-proxy only, since an SSE connection is not durable queue state)
 
 Backend note:
 - For `queue.backend sqlite`, MCP queue tools can read/mutate via direct SQLite access.

--- a/docs/admin-api.md
+++ b/docs/admin-api.md
@@ -374,6 +374,47 @@ Endpoint-scoped publish:
 
 > Target, route, and scope are resolved from the endpoint mapping — do not include selector fields in items.
 
+## Pull Consumers
+
+### `GET /pull/consumers`
+
+Lists the pull consumers that currently hold an SSE stream.
+
+`hookaido_pull_sse_connection_active{route}` already reports how many consumers are attached to a route, which is the decisive signal — an unexpected second consumer on a competing-consumer queue looks, from inside either one, exactly like delivery loss. This endpoint answers which ones they are, so the count turns into a fix.
+
+**Query parameters:**
+
+| Parameter | Default | Description                        |
+| --------- | ------- | ---------------------------------- |
+| `route`   | all     | Restrict to one route path         |
+
+```json
+{
+  "consumers": [
+    {
+      "id": "con_9f2c4a1b7d3e5068",
+      "route": "/webhooks/appliance",
+      "endpoint": "/appliance",
+      "remote_addr": "10.0.0.5:41234",
+      "user_agent": "hookaido-worker/1.0",
+      "token_ref": "env.PULL_TOKEN",
+      "connected_at": "2026-08-31T14:02:11Z",
+      "connected_for_seconds": 3612.4,
+      "messages_sent": 81,
+      "last_message_at": "2026-08-31T15:01:48Z"
+    }
+  ],
+  "count": 1
+}
+```
+
+- `token_ref` is the configured secret reference the consumer authenticated with (`env.PULL_TOKEN`, `file./run/secrets/pull`), never the token value. It is omitted when the Pull API runs without tokens. For a route with its own `pull { auth token ... }`, it names a reference from that route's set — the global `pull_api` tokens do not authorize that route, so they are never reported for it.
+- `messages_sent` counts messages written to this stream since it opened. It is not a lease count: acks arrive on separate requests that are not tied to the connection, so how many of those messages are still outstanding is not something this endpoint can answer. Use `hookaido_pull_lease_active` for that.
+- Only SSE streams appear. A consumer polling `POST {endpoint}/dequeue` holds no connection between calls, so it is listed here and counted by the gauge alike: not at all.
+- The registry is per process and in memory. A restart empties it, and in a multi-instance deployment each instance reports its own consumers.
+
+The same lifecycle is logged at INFO as `pull_sse_connected` / `pull_sse_disconnected`; see [Pull API — Who Is Attached](pull-api.md#who-is-attached).
+
 ## Management Model
 
 ### `GET /management/model`

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -79,6 +79,7 @@ Runtime control tools (`instance_start`, `instance_stop`, `instance_reload`) req
 | `dlq_list`              | `read` | List dead-letter queue items                    |
 | `messages_list`         | `read` | List queue messages (all states)                |
 | `attempts_list`         | `read` | List delivery attempts                          |
+| `pull_consumers`        | `read` | Pull consumers with an open SSE stream          |
 | `backlog_top_queued`    | `read` | Top queued route/target buckets                 |
 | `backlog_oldest_queued` | `read` | Oldest queued messages                          |
 | `backlog_aging_summary` | `read` | Aging distribution with percentiles             |

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -84,6 +84,8 @@ observability {
 }
 ```
 
+**Pull consumer lifecycle:** an SSE stream logs `pull_sse_connected` when it is established and `pull_sse_disconnected` when it ends, both at INFO, carrying `consumer_id`, `route`, `endpoint`, `remote_addr` and `token_ref` (the configured secret reference, never the token). The teardown line also carries `status_code`, `messages_sent` and `duration_seconds`. The access log cannot substitute for these: a stream logs one `http_request` line when it opens and then stays open for hours, so it records neither who is still attached nor when anyone left. See [Pull API — Who Is Attached](pull-api.md#who-is-attached).
+
 ### Log Sinks
 
 | Sink     | Description                   |
@@ -168,6 +170,8 @@ Set `enabled off` to disable the metrics listener while keeping config in place.
 | `hookaido_pull_sse_connections_total`      | counter | SSE connections established, by `route`                |
 | `hookaido_pull_sse_messages_sent_total`    | counter | Messages sent over SSE, by `route`                     |
 | `hookaido_pull_sse_connection_active`      | gauge   | Currently active SSE connections, by `route`           |
+
+`hookaido_pull_sse_connection_active` is deliberately unlabeled by consumer: a remote-address label would be unbounded cardinality for a diagnostic that is only needed occasionally. When the gauge is higher than you expect, name the consumers with [`GET /pull/consumers`](admin-api.md#get-pullconsumers) or from the `pull_sse_connected` / `pull_sse_disconnected` runtime log lines.
 
 **Secret and publish-policy metrics:**
 

--- a/docs/pull-api.md
+++ b/docs/pull-api.md
@@ -333,6 +333,26 @@ event: error
 data: dequeue is temporarily unavailable
 ```
 
+### Who Is Attached
+
+An unexpected second consumer on a route is the failure mode worth planning for, because from inside either consumer it does not look like a second consumer — it looks like delivery loss. The queue is competing-consumer, so the two split the traffic: ingress answers `202 {"status":"queued"}` for every event, and each side sees a fluctuating fraction of them arrive. It is easy to end up there by accident, with a shared token or a second environment pointed at the same host.
+
+Two surfaces answer it:
+
+- `hookaido_pull_sse_connection_active{route}` — **how many** consumers are attached. If this says `2` and you expect `1`, that is the problem, and it is the fastest signal.
+- [`GET /pull/consumers`](admin-api.md#get-pullconsumers) on the Admin API — **which** ones: remote address, connected-since, messages sent, and the configured token reference each authenticated with.
+
+Both cover SSE streams only. A consumer polling `POST {endpoint}/dequeue` holds no connection between calls, so it is counted by neither.
+
+The runtime log carries the same lifecycle at INFO, which is what you need after the fact:
+
+```json
+{"level":"INFO","msg":"pull_sse_connected","consumer_id":"con_9f2c...","route":"/webhooks/appliance","endpoint":"/appliance","remote_addr":"10.0.0.5:41234","user_agent":"hookaido-worker/1.0","token_ref":"env.PULL_TOKEN"}
+{"level":"INFO","msg":"pull_sse_disconnected","consumer_id":"con_9f2c...","route":"/webhooks/appliance","remote_addr":"10.0.0.5:41234","token_ref":"env.PULL_TOKEN","status_code":200,"messages_sent":81,"duration_seconds":3612.4}
+```
+
+The teardown line matters as much as the establish: a stream logs its HTTP request once, when it opens, and then stays open for hours, so the access log alone cannot tell you who is still attached.
+
 ## Dequeue Controls
 
 Fine-tune Pull API behavior in the config:

--- a/internal/admin/handle_pull.go
+++ b/internal/admin/handle_pull.go
@@ -1,0 +1,77 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// PullConsumer is one pull consumer with an open SSE stream, as reported by
+// GET /pull/consumers.
+//
+// TokenRef is the configured secret reference the consumer authenticated with
+// (`env.PULL_TOKEN`), never the token value.
+type PullConsumer struct {
+	ID            string    `json:"id"`
+	Route         string    `json:"route"`
+	Endpoint      string    `json:"endpoint"`
+	RemoteAddr    string    `json:"remote_addr"`
+	UserAgent     string    `json:"user_agent,omitempty"`
+	TokenRef      string    `json:"token_ref,omitempty"`
+	ConnectedAt   time.Time `json:"connected_at"`
+	MessagesSent  int64     `json:"messages_sent"`
+	LastMessageAt time.Time `json:"last_message_at,omitzero"`
+}
+
+type pullConsumerView struct {
+	PullConsumer
+	ConnectedForSeconds float64 `json:"connected_for_seconds"`
+}
+
+type pullConsumersResponse struct {
+	Consumers []pullConsumerView `json:"consumers"`
+	Count     int                `json:"count"`
+}
+
+// handlePullConsumers answers which pull consumers are attached right now.
+//
+// `hookaido_pull_sse_connection_active` already says how many, and that is the
+// decisive signal — but an unexpected second consumer on a competing-consumer
+// queue looks, from inside either consumer, exactly like delivery loss: the
+// ingress answers 202 for every event and each side sees a fluctuating
+// fraction arrive. Without this the only way to name the second consumer was to
+// correlate raw container logs by remote address on the host, which needs shell
+// access and only works while it is still connected.
+//
+// Only SSE streams are listed. A consumer polling `POST .../dequeue` holds no
+// connection between calls, so there is nothing to report — and nothing the
+// gauge counts either, which keeps the two surfaces consistent.
+func (s *Server) handlePullConsumers(w http.ResponseWriter, r *http.Request) {
+	if s.PullConsumers == nil {
+		writeManagementError(w, http.StatusServiceUnavailable, readCodePullUnavailable, "pull consumer registry is unavailable")
+		return
+	}
+
+	routeFilter, ok := parseOptionalRoutePath(r.URL.Query().Get("route"))
+	if !ok {
+		writeManagementError(w, http.StatusBadRequest, readCodeInvalidQuery, "route must start with '/'")
+		return
+	}
+
+	now := time.Now()
+	consumers := s.PullConsumers()
+	out := pullConsumersResponse{Consumers: make([]pullConsumerView, 0, len(consumers))}
+	for _, c := range consumers {
+		if routeFilter != "" && c.Route != routeFilter {
+			continue
+		}
+		out.Consumers = append(out.Consumers, pullConsumerView{
+			PullConsumer:        c,
+			ConnectedForSeconds: now.Sub(c.ConnectedAt).Seconds(),
+		})
+	}
+	out.Count = len(out.Consumers)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/internal/admin/handle_pull_test.go
+++ b/internal/admin/handle_pull_test.go
@@ -1,0 +1,199 @@
+package admin
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/v2/internal/queue"
+)
+
+func decodePullConsumers(t *testing.T, body []byte) map[string]any {
+	t.Helper()
+	var out map[string]any
+	if err := json.Unmarshal(body, &out); err != nil {
+		t.Fatalf("unmarshal response: %v (%s)", err, body)
+	}
+	return out
+}
+
+func TestServer_PullConsumers(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	connectedAt := time.Now().Add(-90 * time.Second)
+	srv.PullConsumers = func() []PullConsumer {
+		return []PullConsumer{
+			{
+				ID:            "con_a",
+				Route:         "/webhooks/appliance",
+				Endpoint:      "/appliance",
+				RemoteAddr:    "10.0.0.5:41234",
+				UserAgent:     "hookaido-worker/1.0",
+				TokenRef:      "env.PULL_TOKEN",
+				ConnectedAt:   connectedAt,
+				MessagesSent:  81,
+				LastMessageAt: connectedAt.Add(time.Minute),
+			},
+			{
+				ID:          "con_b",
+				Route:       "/webhooks/other",
+				Endpoint:    "/other",
+				RemoteAddr:  "10.0.0.9:52001",
+				ConnectedAt: connectedAt,
+			},
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/consumers", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	out := decodePullConsumers(t, rr.Body.Bytes())
+	if count, _ := out["count"].(float64); count != 2 {
+		t.Fatalf("expected count 2, got %v", out["count"])
+	}
+	consumers, ok := out["consumers"].([]any)
+	if !ok || len(consumers) != 2 {
+		t.Fatalf("expected two consumers, got %#v", out["consumers"])
+	}
+
+	first, _ := consumers[0].(map[string]any)
+	if first["id"] != "con_a" {
+		t.Fatalf("expected con_a first, got %v", first["id"])
+	}
+	if first["token_ref"] != "env.PULL_TOKEN" {
+		t.Fatalf("expected the token reference, got %v", first["token_ref"])
+	}
+	if sent, _ := first["messages_sent"].(float64); sent != 81 {
+		t.Fatalf("expected messages_sent 81, got %v", first["messages_sent"])
+	}
+	if secs, _ := first["connected_for_seconds"].(float64); secs < 60 {
+		t.Fatalf("expected connected_for_seconds to reflect a 90s connection, got %v", secs)
+	}
+
+	// A consumer that has received nothing yet must not report a zero-value
+	// timestamp as if it had.
+	second, _ := consumers[1].(map[string]any)
+	if _, present := second["last_message_at"]; present {
+		t.Fatalf("expected last_message_at to be omitted when nothing was sent, got %v", second["last_message_at"])
+	}
+	if _, present := second["token_ref"]; present {
+		t.Fatalf("expected token_ref to be omitted without a matched token, got %v", second["token_ref"])
+	}
+}
+
+func TestServer_PullConsumersRouteFilter(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.PullConsumers = func() []PullConsumer {
+		return []PullConsumer{
+			{ID: "con_a", Route: "/webhooks/appliance", ConnectedAt: time.Now()},
+			{ID: "con_b", Route: "/webhooks/other", ConnectedAt: time.Now()},
+		}
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/consumers?route=/webhooks/appliance", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	out := decodePullConsumers(t, rr.Body.Bytes())
+	consumers, _ := out["consumers"].([]any)
+	if len(consumers) != 1 {
+		t.Fatalf("expected one consumer after filtering, got %#v", consumers)
+	}
+	first, _ := consumers[0].(map[string]any)
+	if first["id"] != "con_a" {
+		t.Fatalf("expected con_a, got %v", first["id"])
+	}
+}
+
+func TestServer_PullConsumersRejectsRelativeRouteFilter(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.PullConsumers = func() []PullConsumer { return nil }
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/consumers?route=webhooks", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d (%s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServer_PullConsumersEmptyList(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.PullConsumers = func() []PullConsumer { return nil }
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/consumers", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	// An empty registry must serialize as [], not null: a client iterating the
+	// list should not have to special-case "nobody is attached".
+	if body := rr.Body.String(); !jsonHasEmptyConsumers(body) {
+		t.Fatalf("expected an empty consumers array, got %s", body)
+	}
+}
+
+func jsonHasEmptyConsumers(body string) bool {
+	var out struct {
+		Consumers []PullConsumer `json:"consumers"`
+		Count     int            `json:"count"`
+	}
+	if err := json.Unmarshal([]byte(body), &out); err != nil {
+		return false
+	}
+	return out.Consumers != nil && len(out.Consumers) == 0 && out.Count == 0
+}
+
+func TestServer_PullConsumersUnavailable(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/consumers", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d (%s)", rr.Code, rr.Body.String())
+	}
+	out := decodePullConsumers(t, rr.Body.Bytes())
+	if out["code"] != "pull_consumers_unavailable" {
+		t.Fatalf("expected pull_consumers_unavailable, got %v", out["code"])
+	}
+}
+
+func TestServer_PullConsumersMethodNotAllowed(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.PullConsumers = func() []PullConsumer { return nil }
+
+	req := httptest.NewRequest(http.MethodPost, "http://example/pull/consumers", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d (%s)", rr.Code, rr.Body.String())
+	}
+}
+
+func TestServer_PullConsumersRequiresAuth(t *testing.T) {
+	srv := NewServer(queue.NewMemoryStore())
+	srv.Authorize = BearerTokenAuthorizer([][]byte{[]byte("admin-token")})
+	srv.PullConsumers = func() []PullConsumer { return nil }
+
+	req := httptest.NewRequest(http.MethodGet, "http://example/pull/consumers", nil)
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d (%s)", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/admin/http.go
+++ b/internal/admin/http.go
@@ -85,6 +85,7 @@ const (
 	readCodeInvalidQuery          = "invalid_query"
 	readCodeNotFound              = "not_found"
 	readCodeBacklogUnavailable    = "backlog_unavailable"
+	readCodePullUnavailable       = "pull_consumers_unavailable"
 	readCodeManagementUnavailable = "management_model_unavailable"
 )
 
@@ -154,6 +155,7 @@ type Server struct {
 	PublishManagedEnabledForRoute      func(route string) bool
 	LimitsForRoute                     func(route string) (maxBodyBytes int64, maxHeaderBytes int)
 	ManagementModel                    func() ManagementModel
+	PullConsumers                      func() []PullConsumer
 	RequireManagementAuditReason       bool
 	MaxBodyBytes                       int64
 	MaxHeaderBytes                     int
@@ -356,6 +358,13 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		s.handleAttempts(w, r)
+		return
+	case "/pull/consumers":
+		if r.Method != http.MethodGet {
+			writeMethodNotAllowed(w, http.MethodGet)
+			return
+		}
+		s.handlePullConsumers(w, r)
 		return
 	case "/management/model":
 		if r.Method != http.MethodGet {

--- a/internal/app/pull_consumers_test.go
+++ b/internal/app/pull_consumers_test.go
@@ -1,0 +1,126 @@
+package app
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/nuetzliches/hookaido/v2/internal/admin"
+	"github.com/nuetzliches/hookaido/v2/internal/pullapi"
+)
+
+const pullIdentityConfig = `
+pull_api { auth token "raw:globaltoken" }
+
+"/webhooks/global" {
+  pull { path "/global" }
+}
+
+"/webhooks/scoped" {
+  pull { path "/scoped" auth token "raw:scopedtoken" }
+}
+`
+
+func newPullIdentityState(t *testing.T) *runtimeState {
+	t.Helper()
+	compiled := compileForReloadTest(t, pullIdentityConfig)
+	state := newRuntimeState(compiled)
+	if err := state.loadAuth(compiled); err != nil {
+		t.Fatalf("loadAuth: %v", err)
+	}
+	return state
+}
+
+func pullStreamRequest(path, token string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "http://workers.example"+path, nil)
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return req
+}
+
+func TestIdentifyPullToken_NamesTheGlobalTokenReference(t *testing.T) {
+	state := newPullIdentityState(t)
+
+	got := state.identifyPullToken(pullStreamRequest("/global/stream", "globaltoken"))
+	if got != "raw:globaltoken" {
+		t.Fatalf("expected the configured pull_api token reference, got %q", got)
+	}
+}
+
+// A route with its own `pull { auth token }` is authorized against that set
+// alone, so identification has to follow the same scoping — otherwise an
+// unexpected consumer would be reported under a credential it could not have
+// used to reach that route.
+func TestIdentifyPullToken_UsesRouteScopedTokensForScopedRoutes(t *testing.T) {
+	state := newPullIdentityState(t)
+
+	if got := state.identifyPullToken(pullStreamRequest("/scoped/stream", "scopedtoken")); got != "raw:scopedtoken" {
+		t.Fatalf("expected the route-scoped token reference, got %q", got)
+	}
+
+	// The global token authorizes nothing on this route, so it must not be
+	// reported as the credential in use either.
+	if got := state.identifyPullToken(pullStreamRequest("/scoped/stream", "globaltoken")); got != "" {
+		t.Fatalf("expected no identity for a token the route does not accept, got %q", got)
+	}
+	if state.authorizePull(pullStreamRequest("/scoped/stream", "globaltoken")) {
+		t.Fatal("expected the global token to be rejected on a route-scoped endpoint")
+	}
+}
+
+func TestIdentifyPullToken_UnknownTokenAndEndpoint(t *testing.T) {
+	state := newPullIdentityState(t)
+
+	if got := state.identifyPullToken(pullStreamRequest("/global/stream", "nope")); got != "" {
+		t.Fatalf("expected no identity for an unknown token, got %q", got)
+	}
+	if got := state.identifyPullToken(pullStreamRequest("/global/stream", "")); got != "" {
+		t.Fatalf("expected no identity without an Authorization header, got %q", got)
+	}
+	// An endpoint that resolves to no route falls back to the global set,
+	// which is what authorizePull does too.
+	if got := state.identifyPullToken(pullStreamRequest("/unknown/stream", "globaltoken")); got != "raw:globaltoken" {
+		t.Fatalf("expected the global reference for an unresolved endpoint, got %q", got)
+	}
+	if got := state.identifyPullToken(nil); got != "" {
+		t.Fatalf("expected no identity for a nil request, got %q", got)
+	}
+}
+
+func TestAdminPullConsumers_TranslatesEveryField(t *testing.T) {
+	connectedAt := time.Date(2026, 8, 31, 12, 0, 0, 0, time.UTC)
+	lastMessage := connectedAt.Add(90 * time.Second)
+
+	got := adminPullConsumers([]pullapi.ConsumerConnection{{
+		ID:            "con_a",
+		Route:         "/webhooks/appliance",
+		Endpoint:      "/appliance",
+		RemoteAddr:    "10.0.0.5:41234",
+		UserAgent:     "hookaido-worker/1.0",
+		TokenRef:      "env.PULL_TOKEN",
+		ConnectedAt:   connectedAt,
+		MessagesSent:  81,
+		LastMessageAt: lastMessage,
+	}})
+
+	want := admin.PullConsumer{
+		ID:            "con_a",
+		Route:         "/webhooks/appliance",
+		Endpoint:      "/appliance",
+		RemoteAddr:    "10.0.0.5:41234",
+		UserAgent:     "hookaido-worker/1.0",
+		TokenRef:      "env.PULL_TOKEN",
+		ConnectedAt:   connectedAt,
+		MessagesSent:  81,
+		LastMessageAt: lastMessage,
+	}
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+
+	if got := adminPullConsumers(nil); got == nil || len(got) != 0 {
+		t.Fatalf("expected an empty non-nil slice, got %#v", got)
+	}
+}

--- a/internal/app/run.go
+++ b/internal/app/run.go
@@ -464,6 +464,8 @@ type runtimeState struct {
 	configGeneration     int
 	configLoadedAt       time.Time
 	pullByRoute          map[string]pullapi.Authorizer
+	pullIdentify         pullapi.TokenIdentifier
+	pullIdentifyByRoute  map[string]pullapi.TokenIdentifier
 	workerByRoute        map[string]workerapi.Authorizer
 	basicByRoute         map[string]*ingress.BasicAuth
 	forwardByRoute       map[string]*ingress.ForwardAuth
@@ -488,6 +490,7 @@ func newRuntimeState(compiled config.Compiled) *runtimeState {
 		trendSignals:         compiled.Defaults.TrendSignals,
 		adaptiveBackpressure: compiled.Defaults.AdaptiveBackpressure,
 		pullByRoute:          make(map[string]pullapi.Authorizer),
+		pullIdentifyByRoute:  make(map[string]pullapi.TokenIdentifier),
 		workerByRoute:        make(map[string]workerapi.Authorizer),
 		basicByRoute:         make(map[string]*ingress.BasicAuth),
 		forwardByRoute:       make(map[string]*ingress.ForwardAuth),
@@ -986,6 +989,33 @@ func (s *runtimeState) authorizePull(r *http.Request) bool {
 	return auth(r)
 }
 
+// identifyPullToken names the configured token reference a pull request
+// authenticated with, so an SSE consumer can be reported by credential rather
+// than only by remote address.
+//
+// It mirrors authorizePull's route-scoped lookup deliberately: a route with its
+// own `pull { auth_token ... }` is authorized against that set alone, so
+// reporting a match from the global set would name a credential the request
+// could not have used.
+func (s *runtimeState) identifyPullToken(r *http.Request) string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	identify := s.pullIdentify
+	if r != nil && len(s.pullIdentifyByRoute) > 0 {
+		if endpoint := pullEndpointFromRequest(r); endpoint != "" {
+			if route, ok := s.pathToRoute[endpoint]; ok {
+				if ri, ok := s.pullIdentifyByRoute[route]; ok && ri != nil {
+					identify = ri
+				}
+			}
+		}
+	}
+	if identify == nil {
+		return ""
+	}
+	return identify(r)
+}
+
 func (s *runtimeState) authorizeWorker(ctx context.Context, endpoint string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -1442,6 +1472,7 @@ func (s *runtimeState) loadAuth(compiled config.Compiled) error {
 	}
 
 	pullByRoute := make(map[string]pullapi.Authorizer)
+	pullIdentifyByRoute := make(map[string]pullapi.TokenIdentifier)
 	workerByRoute := make(map[string]workerapi.Authorizer)
 	for _, rt := range compiled.Routes {
 		if rt.Pull == nil || len(rt.Pull.AuthTokens) == 0 {
@@ -1452,6 +1483,7 @@ func (s *runtimeState) loadAuth(compiled config.Compiled) error {
 			return err
 		}
 		pullByRoute[rt.Path] = pullapi.BearerTokenAuthorizer(routeTokens)
+		pullIdentifyByRoute[rt.Path] = pullapi.BearerTokenIdentifier(rt.Pull.AuthTokens, routeTokens)
 		workerByRoute[rt.Path] = workerapi.BearerTokenAuthorizer(routeTokens)
 	}
 
@@ -1604,9 +1636,11 @@ func (s *runtimeState) loadAuth(compiled config.Compiled) error {
 	s.mu.Lock()
 	s.runtimePools = nextRuntimePools
 	s.pullAuthorize = pullapi.BearerTokenAuthorizer(tokens)
+	s.pullIdentify = pullapi.BearerTokenIdentifier(compiled.PullAPI.AuthTokens, tokens)
 	s.workerAuthorize = workerapi.BearerTokenAuthorizer(tokens)
 	s.adminAuthorize = admin.BearerTokenAuthorizer(adminTokens)
 	s.pullByRoute = pullByRoute
+	s.pullIdentifyByRoute = pullIdentifyByRoute
 	s.workerByRoute = workerByRoute
 	s.basicByRoute = basicByRoute
 	s.forwardByRoute = forwardByRoute
@@ -2625,6 +2659,38 @@ func startServers(
 	pullHandler.ObserveExtend = func(route string, statusCode int, leaseID string, extendBy time.Duration, leaseExpired bool) {
 		appMetrics.observePullExtend(route, statusCode, leaseID, extendBy, leaseExpired)
 	}
+	pullHandler.IdentifyToken = state.identifyPullToken
+
+	// One INFO line per stream establish and one per teardown.
+	//
+	// The establish was already visible as an `http_request` access-log line
+	// among thousands, and the teardown was not visible at all — an SSE stream
+	// logs its request once, when it opens, and stays open for hours. So "who
+	// is attached right now" was not reconstructable from the log even with the
+	// access log on, which is what left `remote_addr` correlation across raw
+	// container logs as the only answer.
+	pullHandler.ObserveConsumerConnect = func(c pullapi.ConsumerConnection) {
+		runtimeLogger.Info("pull_sse_connected",
+			slog.String("consumer_id", c.ID),
+			slog.String("route", c.Route),
+			slog.String("endpoint", c.Endpoint),
+			slog.String("remote_addr", c.RemoteAddr),
+			slog.String("user_agent", c.UserAgent),
+			slog.String("token_ref", c.TokenRef),
+		)
+	}
+	pullHandler.ObserveConsumerDisconnect = func(c pullapi.ConsumerConnection, statusCode int, duration time.Duration) {
+		runtimeLogger.Info("pull_sse_disconnected",
+			slog.String("consumer_id", c.ID),
+			slog.String("route", c.Route),
+			slog.String("endpoint", c.Endpoint),
+			slog.String("remote_addr", c.RemoteAddr),
+			slog.String("token_ref", c.TokenRef),
+			slog.Int("status_code", statusCode),
+			slog.Int64("messages_sent", c.MessagesSent),
+			slog.Float64("duration_seconds", duration.Seconds()),
+		)
+	}
 
 	adminH := admin.NewServer(store)
 	adminH.Authorize = state.authorizeAdmin
@@ -2636,6 +2702,9 @@ func startServers(
 	adminH.ManagedRouteSet = state.managedRouteSetForPolicy
 	adminH.TargetsForRoute = state.targetsForRoute
 	adminH.ModeForRoute = state.modeForRoute
+	adminH.PullConsumers = func() []admin.PullConsumer {
+		return adminPullConsumers(pullHandler.Consumers())
+	}
 	adminH.PublishEnabledForRoute = state.publishEnabledForRoute
 	adminH.PublishDirectEnabledForRoute = state.publishDirectEnabledForRoute
 	adminH.PublishManagedEnabledForRoute = state.publishManagedEnabledForRoute
@@ -3162,6 +3231,30 @@ func mapEgressRules(rules []config.EgressRule) []dispatcher.EgressRule {
 			Subdomains: r.Subdomains,
 			CIDR:       r.CIDR,
 			IsCIDR:     r.IsCIDR,
+		})
+	}
+	return out
+}
+
+// adminPullConsumers translates the Pull API's live consumer registry into the
+// Admin API's wire shape.
+//
+// The conversion exists so `internal/admin` does not import `internal/pullapi`:
+// the two are separate surfaces by design (see the Admin/Pull separation in
+// AGENTS.md), and the runtime is the one place that already knows both.
+func adminPullConsumers(in []pullapi.ConsumerConnection) []admin.PullConsumer {
+	out := make([]admin.PullConsumer, 0, len(in))
+	for _, c := range in {
+		out = append(out, admin.PullConsumer{
+			ID:            c.ID,
+			Route:         c.Route,
+			Endpoint:      c.Endpoint,
+			RemoteAddr:    c.RemoteAddr,
+			UserAgent:     c.UserAgent,
+			TokenRef:      c.TokenRef,
+			ConnectedAt:   c.ConnectedAt,
+			MessagesSent:  c.MessagesSent,
+			LastMessageAt: c.LastMessageAt,
 		})
 	}
 	return out

--- a/internal/mcp/protocol.go
+++ b/internal/mcp/protocol.go
@@ -534,7 +534,7 @@ func requiredRoleForTool(name string) (Role, bool) {
 	switch name {
 	case "config_parse", "config_validate", "config_compile", "config_fmt_preview", "config_diff", "admin_health", "management_model",
 		"backlog_top_queued", "backlog_oldest_queued", "backlog_aging_summary", "backlog_trends",
-		"messages_list", "attempts_list", "dlq_list":
+		"messages_list", "attempts_list", "dlq_list", "pull_consumers":
 		return RoleRead, true
 	case "dlq_requeue", "dlq_delete", "messages_cancel", "messages_requeue", "messages_resume",
 		"messages_publish", "messages_cancel_by_filter", "messages_requeue_by_filter", "messages_resume_by_filter",
@@ -684,6 +684,8 @@ func (s *Server) callTool(name string, args map[string]any) toolsCallResult {
 		out, err = s.toolAttemptsList(args)
 	case "dlq_list":
 		out, err = s.toolDLQList(args)
+	case "pull_consumers":
+		out, err = s.toolPullConsumers(args)
 	case "dlq_requeue":
 		out, err = s.toolDLQRequeue(args)
 	case "dlq_delete":
@@ -1350,6 +1352,17 @@ func (s *Server) toolDescriptors() []toolDescriptor {
 					"outcome":       map[string]any{"type": "string", "enum": []string{"acked", "retry", "dead"}},
 					"limit":         map[string]any{"type": "integer", "minimum": 1, "maximum": backlog.MaxListLimit},
 					"before":        map[string]any{"type": "string", "description": "RFC3339 timestamp"},
+				},
+				"additionalProperties": false,
+			},
+		},
+		{
+			Name:        "pull_consumers",
+			Description: "Read which pull consumers currently hold an SSE stream, with remote address, connected-since, messages sent, and the token reference they authenticated with (never the token). Requires a running instance reachable over the Admin API",
+			InputSchema: map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"route": routePathSchema(),
 				},
 				"additionalProperties": false,
 			},

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -59,6 +59,7 @@ func TestHandleRequest_ToolsList(t *testing.T) {
 		"messages_list":         false,
 		"attempts_list":         false,
 		"dlq_list":              false,
+		"pull_consumers":        false,
 	}
 	for _, tool := range result.Tools {
 		if _, ok := want[tool.Name]; ok {
@@ -130,6 +131,7 @@ func TestHandleRequest_ToolsListWithMutations(t *testing.T) {
 		"messages_list",
 		"attempts_list",
 		"dlq_list",
+		"pull_consumers",
 		"messages_cancel_by_filter",
 		"messages_requeue_by_filter",
 		"messages_resume_by_filter",

--- a/internal/mcp/spec.md
+++ b/internal/mcp/spec.md
@@ -438,6 +438,22 @@ Arguments:
 Notes:
 - `route` (when provided) must be an absolute Hookaido route path (starts with `/`).
 
+### `pull_consumers`
+List the pull consumers that currently hold an SSE stream.
+
+Arguments:
+```json
+{
+  "route": "/webhooks/appliance"
+}
+```
+
+Notes:
+- `route` (when provided) must be an absolute Hookaido route path (starts with `/`).
+- Always served through the Admin proxy (`GET /pull/consumers`), with no local fallback: an SSE connection is not durable queue state, it exists only in the memory of the process serving it. Fails with a clear error when no config path is configured or the config does not compile.
+- `token_ref` is the configured secret reference the consumer authenticated with, never the token value.
+- SSE streams only. A consumer polling `{endpoint}/dequeue` holds no connection between calls and is not listed.
+
 ### `dlq_requeue` (requires `--enable-mutations`)
 Requeue dead-letter items by ID.
 

--- a/internal/mcp/tools_pull.go
+++ b/internal/mcp/tools_pull.go
@@ -1,0 +1,42 @@
+package mcp
+
+import (
+	"errors"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// toolPullConsumers lists the pull consumers currently attached to a route.
+//
+// Unlike the backlog and message tools it has no local fallback. Those read
+// durable queue state and can open the SQLite file directly when the MCP server
+// runs beside it; an SSE connection is not durable state — it exists only in
+// the memory of the process serving it. So the running instance is the only
+// possible source, and the Admin API is the only way to ask it.
+func (s *Server) toolPullConsumers(args map[string]any) (any, error) {
+	route, err := parseString(args, "route")
+	if err != nil {
+		return nil, err
+	}
+	if err := validateOptionalRoutePath(route); err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(s.ConfigPath) == "" {
+		return nil, errors.New("pull_consumers needs a config path: live consumer state is only available from a running instance via the Admin API")
+	}
+	compiled, res, err := s.loadCompiledConfig()
+	if err != nil {
+		return nil, err
+	}
+	if !res.OK {
+		return nil, errors.New("pull_consumers is unavailable: " + s.ConfigPath + " does not compile")
+	}
+
+	query := url.Values{}
+	if route != "" {
+		query.Set("route", route)
+	}
+	return s.callAdminJSON(compiled, http.MethodGet, "/pull/consumers", query, nil, nil, defaultAdminProxyTimeout)
+}

--- a/internal/pullapi/auth.go
+++ b/internal/pullapi/auth.go
@@ -3,11 +3,16 @@ package pullapi
 import (
 	"crypto/subtle"
 	"net/http"
+	"strings"
 
 	"github.com/nuetzliches/hookaido/v2/internal/httpheader"
 )
 
 type Authorizer func(r *http.Request) bool
+
+// TokenIdentifier names the configured token reference a request
+// authenticated with — never the token value. See BearerTokenIdentifier.
+type TokenIdentifier func(r *http.Request) string
 
 func BearerTokenAuthorizer(tokens [][]byte) Authorizer {
 	allowed := make([][]byte, 0, len(tokens))
@@ -36,5 +41,56 @@ func BearerTokenAuthorizer(tokens [][]byte) Authorizer {
 			}
 		}
 		return false
+	}
+}
+
+// BearerTokenIdentifier names which configured token reference a request
+// authenticated with, for the consumer registry.
+//
+// refs and tokens are index-aligned as the config resolves them; a ref without
+// a token, or a token past the end of refs, is skipped rather than reported
+// under the wrong name. The return value is the reference (`env.PULL_TOKEN`),
+// never the secret — an operator needs to map an unexpected consumer back to a
+// Hookaidofile line, and a token value in an Admin API response or a log line
+// would be a credential leak by way of a diagnostic.
+//
+// It returns "" when nothing matches, including when the Pull API runs without
+// tokens at all. That is not an authorization decision: the authorizer above
+// has already made it by the time this is consulted.
+func BearerTokenIdentifier(refs []string, tokens [][]byte) TokenIdentifier {
+	type labeled struct {
+		ref   string
+		token []byte
+	}
+
+	allowed := make([]labeled, 0, len(tokens))
+	for i, t := range tokens {
+		if len(t) == 0 || i >= len(refs) {
+			continue
+		}
+		ref := strings.TrimSpace(refs[i])
+		if ref == "" {
+			continue
+		}
+		cp := make([]byte, len(t))
+		copy(cp, t)
+		allowed = append(allowed, labeled{ref: ref, token: cp})
+	}
+
+	return func(r *http.Request) string {
+		if len(allowed) == 0 || r == nil {
+			return ""
+		}
+		got, ok := httpheader.ParseBearerToken(r.Header.Get("Authorization"))
+		if !ok {
+			return ""
+		}
+		gb := []byte(got)
+		for _, want := range allowed {
+			if subtle.ConstantTimeCompare(gb, want.token) == 1 {
+				return want.ref
+			}
+		}
+		return ""
 	}
 }

--- a/internal/pullapi/consumers.go
+++ b/internal/pullapi/consumers.go
@@ -1,0 +1,179 @@
+package pullapi
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"sort"
+	"time"
+)
+
+// ConsumerConnection describes one pull consumer that currently holds an open
+// SSE stream.
+//
+// The connection gauge (`hookaido_pull_sse_connection_active`) answers how many
+// consumers are attached; this answers which. That distinction matters because
+// an unexpected second consumer on a route is not a visible failure: the queue
+// is competing-consumer, so the two split the traffic and each of them observes
+// a fluctuating fraction of the events arriving, which is indistinguishable
+// from delivery loss from the inside. The count says there is a problem; the
+// identity is what turns it into a fix.
+//
+// TokenRef names the configured secret reference the request authenticated
+// with (`env.PULL_TOKEN`, `file./run/secrets/pull`), never the token value. It
+// is empty when the Pull API runs without tokens, and it is deliberately the
+// reference rather than a hash: an operator can map it back to a Hookaidofile
+// line, which is what they need in order to decide whose credential is in use.
+type ConsumerConnection struct {
+	ID            string
+	Route         string
+	Endpoint      string
+	RemoteAddr    string
+	UserAgent     string
+	TokenRef      string
+	ConnectedAt   time.Time
+	MessagesSent  int64
+	LastMessageAt time.Time
+}
+
+// consumerConn is the mutable registry entry behind a ConsumerConnection.
+//
+// Only the two counters change over the life of a stream, and they are written
+// by the stream's own goroutine while Consumers() reads them from an Admin API
+// request. The registry mutex covers both, so a snapshot never observes a torn
+// message count.
+type consumerConn struct {
+	id          string
+	route       string
+	endpoint    string
+	remoteAddr  string
+	userAgent   string
+	tokenRef    string
+	connectedAt time.Time
+
+	messagesSent  int64
+	lastMessageAt time.Time
+}
+
+func (s *Server) registerConsumer(r *http.Request, route string) *consumerConn {
+	now := s.nowTime()
+	c := &consumerConn{
+		id:          newConsumerID(),
+		route:       route,
+		connectedAt: now,
+	}
+	if r != nil {
+		c.remoteAddr = r.RemoteAddr
+		c.userAgent = r.Header.Get("User-Agent")
+		if r.URL != nil {
+			c.endpoint = endpointFromPath(r.URL.Path)
+		}
+	}
+	if s.IdentifyToken != nil {
+		c.tokenRef = s.IdentifyToken(r)
+	}
+
+	s.consumersMu.Lock()
+	if s.consumers == nil {
+		s.consumers = make(map[string]*consumerConn)
+	}
+	s.consumers[c.id] = c
+	snap := c.snapshotLocked()
+	s.consumersMu.Unlock()
+
+	s.observeSSEConnect(route)
+	if s.ObserveConsumerConnect != nil {
+		s.ObserveConsumerConnect(snap)
+	}
+	return c
+}
+
+// recordMessagesSent accounts for a batch that has been written to the stream.
+func (s *Server) recordMessagesSent(c *consumerConn, n int) {
+	if c == nil || n <= 0 {
+		return
+	}
+	now := s.nowTime()
+	s.consumersMu.Lock()
+	c.messagesSent += int64(n)
+	c.lastMessageAt = now
+	s.consumersMu.Unlock()
+}
+
+// unregisterConsumer removes the stream from the registry and reports it.
+//
+// It is idempotent so callers can defer it without tracking whether an earlier
+// return path already ran it.
+func (s *Server) unregisterConsumer(c *consumerConn, statusCode int) {
+	if c == nil {
+		return
+	}
+
+	s.consumersMu.Lock()
+	if _, ok := s.consumers[c.id]; !ok {
+		s.consumersMu.Unlock()
+		return
+	}
+	delete(s.consumers, c.id)
+	snap := c.snapshotLocked()
+	s.consumersMu.Unlock()
+
+	duration := s.nowTime().Sub(snap.ConnectedAt)
+	s.observeSSEDisconnect(snap.Route, statusCode, int(snap.MessagesSent), duration)
+	if s.ObserveConsumerDisconnect != nil {
+		s.ObserveConsumerDisconnect(snap, statusCode, duration)
+	}
+}
+
+// Consumers returns the pull consumers with an open SSE stream right now,
+// ordered by route and then by how long they have been connected.
+//
+// Only SSE streams appear here. A consumer that polls `POST .../dequeue` holds
+// no connection between calls, so there is nothing to list and nothing the
+// connection gauge counts either.
+func (s *Server) Consumers() []ConsumerConnection {
+	if s == nil {
+		return nil
+	}
+
+	s.consumersMu.Lock()
+	out := make([]ConsumerConnection, 0, len(s.consumers))
+	for _, c := range s.consumers {
+		out = append(out, c.snapshotLocked())
+	}
+	s.consumersMu.Unlock()
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Route != out[j].Route {
+			return out[i].Route < out[j].Route
+		}
+		if !out[i].ConnectedAt.Equal(out[j].ConnectedAt) {
+			return out[i].ConnectedAt.Before(out[j].ConnectedAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// snapshotLocked copies the entry. The caller must hold the registry mutex:
+// the two counters are written by the stream's own goroutine, so an unlocked
+// read here would race a concurrent send.
+func (c *consumerConn) snapshotLocked() ConsumerConnection {
+	return ConsumerConnection{
+		ID:            c.id,
+		Route:         c.route,
+		Endpoint:      c.endpoint,
+		RemoteAddr:    c.remoteAddr,
+		UserAgent:     c.userAgent,
+		TokenRef:      c.tokenRef,
+		ConnectedAt:   c.connectedAt,
+		MessagesSent:  c.messagesSent,
+		LastMessageAt: c.lastMessageAt,
+	}
+}
+
+func newConsumerID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return "con_" + hex.EncodeToString(b[:])
+}

--- a/internal/pullapi/consumers_test.go
+++ b/internal/pullapi/consumers_test.go
@@ -1,0 +1,304 @@
+package pullapi
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitForConsumers blocks until the registry reports want entries.
+//
+// Registration happens on the server goroutine after the response head is
+// flushed, so a test that has read the head has not necessarily observed the
+// registration yet.
+func waitForConsumers(t *testing.T, srv *Server, want int) []ConsumerConnection {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		got := srv.Consumers()
+		if len(got) == want {
+			return got
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected %d consumers, got %d after 2s", want, len(got))
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func TestConsumers_ListsAttachedSSEStreams(t *testing.T) {
+	srv, store := newSSETestServer(t)
+	srv.IdentifyToken = func(r *http.Request) string {
+		if r.Header.Get("Authorization") == "Bearer integration-token" {
+			return "env.INTEGRATION_TOKEN"
+		}
+		return "env.WORKSTATION_TOKEN"
+	}
+	enqueueTestMsg(t, store, "evt_1")
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	if got := srv.Consumers(); len(got) != 0 {
+		t.Fatalf("expected no consumers before any stream, got %d", len(got))
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream", nil)
+	req.Header.Set("Authorization", "Bearer integration-token")
+	req.Header.Set("User-Agent", "hookaido-worker/1.0")
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("SSE request: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Read the queued message so messages_sent is non-zero by the time the
+	// registry is inspected.
+	scanner := bufio.NewScanner(resp.Body)
+	if _, isComment, eof := readSSEEvent(scanner); eof || isComment {
+		t.Fatalf("expected SSE message event, got eof=%v comment=%v", eof, isComment)
+	}
+
+	got := waitForConsumers(t, srv, 1)
+	c := got[0]
+	if c.Route != "/webhooks/github" {
+		t.Fatalf("expected route /webhooks/github, got %q", c.Route)
+	}
+	if c.Endpoint != "/pull/github" {
+		t.Fatalf("expected endpoint /pull/github, got %q", c.Endpoint)
+	}
+	if c.ID == "" {
+		t.Fatal("expected a consumer id")
+	}
+	if c.RemoteAddr == "" {
+		t.Fatal("expected a remote address")
+	}
+	if c.UserAgent != "hookaido-worker/1.0" {
+		t.Fatalf("expected the request User-Agent, got %q", c.UserAgent)
+	}
+	if c.TokenRef != "env.INTEGRATION_TOKEN" {
+		t.Fatalf("expected the matched token reference, got %q", c.TokenRef)
+	}
+	if c.ConnectedAt.IsZero() {
+		t.Fatal("expected a connect timestamp")
+	}
+
+	// messages_sent is written by the stream goroutine; give it the same grace
+	// as registration itself.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		snap := srv.Consumers()
+		if len(snap) == 1 && snap[0].MessagesSent == 1 {
+			if snap[0].LastMessageAt.IsZero() {
+				t.Fatal("expected last_message_at once a message was sent")
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected messages_sent 1, got %#v", snap)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestConsumers_TwoConsumersOnOneRouteAreDistinguishable is the case from the
+// issue: two consumers attach to the same competing-consumer queue, split the
+// traffic, and each of them sees only a fraction arrive. The connection gauge
+// says "two"; this is what says which two.
+func TestConsumers_TwoConsumersOnOneRouteAreDistinguishable(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+	srv.IdentifyToken = func(r *http.Request) string {
+		return "env." + r.Header.Get("X-Test-Token-Name")
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var wg sync.WaitGroup
+	for _, name := range []string{"INTEGRATION", "WORKSTATION"} {
+		wg.Add(1)
+		go func(name string) {
+			defer wg.Done()
+			req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream", nil)
+			req.Header.Set("X-Test-Token-Name", name)
+			resp, err := ts.Client().Do(req)
+			if err != nil {
+				return
+			}
+			defer resp.Body.Close()
+			<-ctx.Done()
+		}(name)
+	}
+
+	got := waitForConsumers(t, srv, 2)
+	refs := map[string]bool{}
+	ids := map[string]bool{}
+	for _, c := range got {
+		if c.Route != "/webhooks/github" {
+			t.Fatalf("expected both on /webhooks/github, got %q", c.Route)
+		}
+		refs[c.TokenRef] = true
+		ids[c.ID] = true
+	}
+	if !refs["env.INTEGRATION"] || !refs["env.WORKSTATION"] {
+		t.Fatalf("expected both token references to be distinguishable, got %v", refs)
+	}
+	if len(ids) != 2 {
+		t.Fatalf("expected two distinct consumer ids, got %v", ids)
+	}
+
+	cancel()
+	wg.Wait()
+	waitForConsumers(t, srv, 0)
+}
+
+func TestConsumers_DisconnectRemovesTheEntryAndReportsIt(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+
+	var mu sync.Mutex
+	var connected, disconnected []ConsumerConnection
+	var disconnectStatus int
+	srv.ObserveConsumerConnect = func(c ConsumerConnection) {
+		mu.Lock()
+		defer mu.Unlock()
+		connected = append(connected, c)
+	}
+	srv.ObserveConsumerDisconnect = func(c ConsumerConnection, statusCode int, _ time.Duration) {
+		mu.Lock()
+		defer mu.Unlock()
+		disconnected = append(disconnected, c)
+		disconnectStatus = statusCode
+	}
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/pull/github/stream", nil)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("SSE request: %v", err)
+	}
+
+	waitForConsumers(t, srv, 1)
+
+	cancel()
+	_ = resp.Body.Close()
+
+	waitForConsumers(t, srv, 0)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		mu.Lock()
+		nConnected, nDisconnected, status := len(connected), len(disconnected), disconnectStatus
+		mu.Unlock()
+		if nConnected == 1 && nDisconnected == 1 {
+			if status != http.StatusOK {
+				t.Fatalf("expected status 200 for a clean teardown, got %d", status)
+			}
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expected one connect and one disconnect, got %d/%d", nConnected, nDisconnected)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+// TestConsumers_RejectedStreamIsNotRegistered pins that the registry lists the
+// same thing the connection gauge counts: a request that never became a stream
+// must not appear as one.
+func TestConsumers_RejectedStreamIsNotRegistered(t *testing.T) {
+	srv, _ := newSSETestServer(t)
+	srv.Authorize = func(r *http.Request) bool { return false }
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/pull/github/stream")
+	if err != nil {
+		t.Fatalf("SSE request: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", resp.StatusCode)
+	}
+	if got := srv.Consumers(); len(got) != 0 {
+		t.Fatalf("expected no registered consumer for a rejected request, got %#v", got)
+	}
+
+	// Same for an unknown endpoint.
+	resp2, err := ts.Client().Get(ts.URL + "/pull/unknown/stream")
+	if err != nil {
+		t.Fatalf("SSE request: %v", err)
+	}
+	defer resp2.Body.Close()
+	if got := srv.Consumers(); len(got) != 0 {
+		t.Fatalf("expected no registered consumer for an unknown endpoint, got %#v", got)
+	}
+}
+
+func TestConsumers_NilServerReturnsNothing(t *testing.T) {
+	var srv *Server
+	if got := srv.Consumers(); got != nil {
+		t.Fatalf("expected nil from a nil server, got %#v", got)
+	}
+}
+
+func TestBearerTokenIdentifier(t *testing.T) {
+	refs := []string{"env.A", "env.B"}
+	tokens := [][]byte{[]byte("token-a"), []byte("token-b")}
+	identify := BearerTokenIdentifier(refs, tokens)
+
+	cases := []struct {
+		name   string
+		header string
+		want   string
+	}{
+		{name: "first token", header: "Bearer token-a", want: "env.A"},
+		{name: "second token", header: "Bearer token-b", want: "env.B"},
+		{name: "unknown token", header: "Bearer nope", want: ""},
+		{name: "no header", header: "", want: ""},
+		{name: "not bearer", header: "Basic token-a", want: ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := httptest.NewRequest(http.MethodGet, "/pull/github/stream", nil)
+			if tc.header != "" {
+				r.Header.Set("Authorization", tc.header)
+			}
+			if got := identify(r); got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+
+	t.Run("no tokens configured", func(t *testing.T) {
+		r := httptest.NewRequest(http.MethodGet, "/pull/github/stream", nil)
+		r.Header.Set("Authorization", "Bearer token-a")
+		if got := BearerTokenIdentifier(nil, nil)(r); got != "" {
+			t.Fatalf("expected empty identity without tokens, got %q", got)
+		}
+	})
+
+	// A token without a matching ref must not be reported under a neighbour's
+	// name. Index alignment is the whole contract here.
+	t.Run("token beyond the ref list", func(t *testing.T) {
+		identify := BearerTokenIdentifier([]string{"env.A"}, [][]byte{[]byte("token-a"), []byte("token-b")})
+		r := httptest.NewRequest(http.MethodGet, "/pull/github/stream", nil)
+		r.Header.Set("Authorization", "Bearer token-b")
+		if got := identify(r); got != "" {
+			t.Fatalf("expected no identity for an unlabelled token, got %q", got)
+		}
+	})
+}

--- a/internal/pullapi/http.go
+++ b/internal/pullapi/http.go
@@ -49,6 +49,21 @@ type Server struct {
 	ObserveSSEConnect    func(route string)
 	ObserveSSEDisconnect func(route string, statusCode int, messagesSent int, duration time.Duration)
 
+	// IdentifyToken names the configured secret reference a request
+	// authenticated with, for the consumer registry below. It never returns the
+	// token value. Optional: without it consumers are listed without a
+	// credential.
+	IdentifyToken TokenIdentifier
+
+	// ObserveConsumerConnect and ObserveConsumerDisconnect report SSE stream
+	// lifecycle so the runtime can log it. They exist next to the SSE metric
+	// observers because a counter and an identity answer different questions:
+	// the gauge says two consumers are attached, these say which two, and the
+	// disconnect is the half that a plain `http_request` access-log line for
+	// the establishing GET can never provide.
+	ObserveConsumerConnect    func(c ConsumerConnection)
+	ObserveConsumerDisconnect func(c ConsumerConnection, statusCode int, duration time.Duration)
+
 	// LeaseRouteScoped reports whether the running config uses per-route pull
 	// credentials. When it does, lease operations are checked against the route
 	// they were issued for; when it does not, every client is authorized for
@@ -62,6 +77,9 @@ type Server struct {
 	recentLeaseOps   map[recentLeaseOpKey]*list.Element
 	recentLeaseOrder list.List
 	now              func() time.Time
+
+	consumersMu sync.Mutex
+	consumers   map[string]*consumerConn
 }
 
 func NewServer(store queue.Store) *Server {
@@ -88,13 +106,22 @@ type recentLeaseOpEntry struct {
 	expiresAt time.Time
 }
 
-func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	cleanPath := path.Clean(r.URL.Path)
+// endpointFromPath splits a Pull API request path into the endpoint it
+// addresses, dropping the trailing operation segment.
+func endpointFromPath(requestPath string) string {
+	cleanPath := path.Clean(requestPath)
 	op := path.Base(cleanPath)
 	endpoint := strings.TrimSuffix(cleanPath, "/"+op)
 	if endpoint == "" {
 		endpoint = "/"
 	}
+	return endpoint
+}
+
+func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	cleanPath := path.Clean(r.URL.Path)
+	op := path.Base(cleanPath)
+	endpoint := endpointFromPath(cleanPath)
 
 	if r.Method == http.MethodGet {
 		if op != "stream" {

--- a/internal/pullapi/sse.go
+++ b/internal/pullapi/sse.go
@@ -75,9 +75,20 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 		notifyCh = sn.NotifyCh
 	}
 
-	s.observeSSEConnect(route)
-	start := time.Now()
-	messagesSent := 0
+	// The stream enters the registry only once the response head is out, so
+	// what /admin/pull/consumers lists is exactly what
+	// hookaido_pull_sse_connection_active counts: streams a consumer is
+	// attached to, not requests that failed validation above and never became
+	// one.
+	//
+	// Teardown is a single defer rather than a call on each return path. There
+	// are seven of those, each previously repeating the same observe line, and
+	// one of them was missed for long enough that the gauge only ever counted
+	// up (see the cancellation comment below).
+	consumer := s.registerConsumer(r, route)
+	status := http.StatusOK
+	defer func() { s.unregisterConsumer(consumer, status) }()
+
 	keepaliveTicker := time.NewTicker(keepalive)
 	defer keepaliveTicker.Stop()
 
@@ -93,7 +104,6 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 		// observeSSEDisconnect never ran either, so
 		// hookaido_pull_sse_connection_active only ever counted up.
 		if ctx.Err() != nil {
-			s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
 			return
 		}
 
@@ -129,7 +139,7 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 			// Store unavailable — write an SSE error event and close.
 			fmt.Fprintf(w, "event: error\ndata: %s\n\n", opErr.Detail)
 			flusher.Flush()
-			s.observeSSEDisconnect(route, opErr.StatusCode, messagesSent, time.Since(start))
+			status = opErr.StatusCode
 			return
 		}
 
@@ -152,10 +162,9 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 				// error, so on a busy stream a disconnect went unnoticed until
 				// the next idle moment -- which may never come.
 				if _, err := fmt.Fprintf(w, "id: %s\nevent: message\ndata: %s\n\n", it.LeaseID, data); err != nil {
-					s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
 					return
 				}
-				messagesSent++
+				s.recordMessagesSent(consumer, 1)
 			}
 			flusher.Flush()
 			// Reset keepalive timer after activity.
@@ -170,12 +179,10 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 				continue
 			case <-keepaliveTicker.C:
 				if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
-					s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
 					return
 				}
 				flusher.Flush()
 			case <-ctx.Done():
-				s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
 				return
 			}
 		} else {
@@ -189,7 +196,6 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 					<-fallback.C
 				}
 				if _, err := fmt.Fprint(w, ": keepalive\n\n"); err != nil {
-					s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
 					return
 				}
 				flusher.Flush()
@@ -197,7 +203,6 @@ func (s *Server) handleSSE(w http.ResponseWriter, r *http.Request, route string)
 				if !fallback.Stop() {
 					<-fallback.C
 				}
-				s.observeSSEDisconnect(route, http.StatusOK, messagesSent, time.Since(start))
 				return
 			}
 		}


### PR DESCRIPTION
## Summary

`hookaido_pull_sse_connection_active{route}` already answers **how many** pull consumers are attached to a route, which is the decisive half of the signal. This adds the other half: **which**.

The failure mode this exists for is worth restating, because it is the reason the count alone is not enough. The Pull API is a competing-consumer queue, so two consumers on one route split the traffic — the ingress answers `202 {"status":"queued"}` for every event, and each consumer sees a fluctuating fraction arrive. From inside either one that is indistinguishable from delivery loss, and both would report it as such. Once the gauge says `2` where you expect `1`, naming the second consumer previously meant correlating raw container logs by `remote_addr` and resolving those addresses by ARP/DNS on the host: needs shell access, and only works while the offender is still connected.

Three surfaces, all fed by one per-process registry of open SSE streams:

1. **`GET /admin/pull/consumers`** — `id`, `route`, `endpoint`, `remote_addr`, `user_agent`, `token_ref`, `connected_at`, `connected_for_seconds`, `messages_sent`, `last_message_at`. Optional `?route=` filter.
2. **`pull_sse_connected` / `pull_sse_disconnected` at INFO** on the runtime log.
3. **MCP read tool `pull_consumers`**, proxying the Admin endpoint.

The issue offered a third option — a low-cardinality label on the existing gauge — which I did not take. The endpoint supersedes it, and a per-consumer label on a gauge is the wrong shape for something needed occasionally during an investigation.

## Related Issues

Closes #285

## Scope

- [ ] DSL / config behavior
- [x] Runtime behavior
- [x] Admin or Pull API behavior
- [x] MCP behavior
- [ ] Documentation only
- [ ] CI / release pipeline

## Per-finding rationale

**`token_ref` is the configured secret reference, never a hash and never the token.** `env.PULL_TOKEN` maps back to a Hookaidofile line, which is what an operator needs in order to decide whose credential is in use; a fingerprint would identify without explaining. `BearerTokenIdentifier` takes refs and tokens index-aligned and skips any token without a matching ref rather than reporting it under a neighbour's name — there is a test for exactly that. Route-scoped identification mirrors `authorizePull`'s scoping deliberately: a route with its own `pull { auth token ... }` is authorized against that set alone, so reporting a match from the global set would name a credential the request could not have used.

**Registration happens after the response head is flushed.** That keeps the registry listing exactly what the gauge counts — a request rejected by auth or an unknown endpoint never became a stream and must not appear as one. Tested both ways.

**`messages_sent`, not active leases.** The issue asked for active leases per consumer. I could not give an honest number: acks arrive on separate HTTP requests that carry no connection identity, so the registry cannot know how many of a stream's messages are still outstanding. `messages_sent` is what the connection actually knows, and `docs/admin-api.md` says so explicitly and points at `hookaido_pull_lease_active` instead.

**Teardown collapsed to one `defer`.** `handleSSE` had seven return paths, each repeating the same `observeSSEDisconnect(...)` line — and the in-tree comment records that one of them was missed for long enough that the gauge only ever counted up. `registerConsumer` / `unregisterConsumer` now bracket the whole handler, with a `status` variable for the one path that is not 200. `unregisterConsumer` is idempotent so the defer is safe regardless of path.

**MCP coverage: covered, Admin-proxy only.** Unlike the backlog and message tools, `pull_consumers` has no local-SQLite fallback. Those read durable queue state; an SSE connection exists only in the memory of the process serving it, so the running instance is the only possible source. The tool fails with an explicit message when there is no config path or the config does not compile, rather than silently reporting an empty list.

## Deviation from the issue's suggested fix direction

The issue ranked its options 1 (admin endpoint) > 3 (INFO logs) > 2 (gauge label), and said option 3 alone would have sufficed. This implements 1 **and** 3, and deliberately skips 2. The reason for doing both rather than just the smallest change: the endpoint answers "who is attached *right now*", the log answers "who was attached *then*", and the original investigation needed the second one after the fact. Option 2 is skipped because a per-consumer label on `hookaido_pull_sse_connection_active` is unbounded cardinality in the remote-address form and redundant with the endpoint in the token form; `docs/observability.md` now states that choice and points at the two surfaces that replace it.

## Validation

- [x] `go test ./...` passed locally (`go build`, `go vet` clean)
- [x] Added or updated tests for behavioral changes
- [x] Updated docs for user-visible changes
- [x] Updated `CHANGELOG.md` for user-visible behavior changes
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable — not applicable: MCP coverage is delivered rather than deferred, so `STATUS.md` needs no follow-up entry, and this is not a milestone-level capability shift.

New tests: `internal/pullapi/consumers_test.go` (registry lifecycle, two distinguishable consumers on one route, rejected requests not registered, `BearerTokenIdentifier` including the index-alignment case), `internal/admin/handle_pull_test.go` (response shape, route filter, empty-list serializes as an empty array, 503/405/401/400 paths), `internal/app/pull_consumers_test.go` (route-scoped vs global token identification, `adminPullConsumers` translation).

**On "verified to fail against the old code":** these are additive-surface tests — they exercise API that does not exist on `main` (`Server.Consumers`, `BearerTokenIdentifier`, `admin.PullConsumers`, `identifyPullToken`), so against the old tree they fail to compile rather than failing behaviorally. Worth stating plainly rather than implying a stronger check than was possible.

CI runs `go test -race`; this machine has no cgo toolchain, so the race detector ran only in CI. The registry guards both mutable counters and the map under one mutex, and `snapshotLocked` is only called with it held.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed — the endpoint sits behind the normal Admin API auth guard (tested). `token_ref` exposes a *reference*, never a value, on the Admin API and in the runtime log alike. `BearerTokenIdentifier` keeps `crypto/subtle` comparison, and it is consulted only after the authorizer has already decided.
- [x] Backward compatibility considered — purely additive. No existing endpoint, metric, log line, or config key changes. The registry is per process and in memory: a restart empties it, and in a multi-instance deployment each instance reports its own consumers. Documented.

## Notes for Reviewers

Riskiest area is the `handleSSE` restructure — behavior should be identical, but it touches every return path in the stream loop. The existing SSE tests (including `TestSSE_BusyStreamObservesDisconnect`, which pins the bug that motivated the old duplicated lines) pass unchanged.

Follow-up: #284 (consumer groups / fan-out) is the other half of this operator story — the same accident is what led there.
