### PR TITLE
chore(release): prepare v2.13.0

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,24 +4,24 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
 
 ## P1 - Medium Priority (awesome-go readiness, target: July 2026)
 
-- [ ] **Test coverage ≥80%** — 77.1% as of v2.12.0, measured with `make cover` (needs `HOOKAIDO_TEST_POSTGRES_DSN`; see `docker-compose.test.yml`). Generated protobuf code is excluded — 292 never-hand-tested statements say nothing about the code we write.
+- [ ] **Test coverage ≥80%** — 77.2% as of v2.13.0, measured with `make cover` (needs `HOOKAIDO_TEST_POSTGRES_DSN`; see `docker-compose.test.yml`). Generated protobuf code is excluded — 292 never-hand-tested statements say nothing about the code we write.
 
-  Up from v2.11.0's 76.7%, reversing that release's slight dip from v2.10.1's 76.9%. The #273–#276 work added more covered statements than production ones: `internal/app` moved 62.5% → 64.5% because `resolveClientIP`, `pollConfig` and the query-auth wiring are all directly testable without a server bring-up, and `internal/ingress` is at 92.5%.
+  Essentially flat against v2.12.0's 77.1%, which is the honest reading of a release that added roughly 380 production statements: the #284/#285 work came with enough tests to hold the line, not to move it. `internal/pullapi` is the one real gain (73.4% → 75.7%) — the consumer registry and the group resolution are plain functions over their arguments, so they are directly testable. `internal/mcp` went the other way (77.5% → 77.1%): `pull_consumers` is Admin-proxy-only by construction, so its handler has no local path a unit test can exercise without standing up an Admin API, and it is currently covered only through the tool-registry tests.
 
   Ranked by uncovered statements, which is what actually moves the total — a package at 64% with 1,200 uncovered statements matters far more than one at 64% with 40:
 
   | Package | Uncovered | Total | % |
   | --- | ---: | ---: | ---: |
-  | `internal/config` | 1248 | 5841 | 78.6% |
-  | `internal/app` | 1201 | 3383 | 64.5% |
-  | `internal/mcp` | 932 | 4134 | 77.5% |
-  | `internal/admin` | 543 | 2606 | 79.2% |
+  | `internal/config` | 1248 | 5900 | 78.8% |
+  | `internal/app` | 1202 | 3416 | 64.8% |
+  | `internal/mcp` | 949 | 4153 | 77.1% |
+  | `internal/admin` | 543 | 2633 | 79.4% |
   | `modules/sqlite` | 432 | 1693 | 74.5% |
   | `modules/postgres` | 301 | 1293 | 76.7% |
   | `internal/queue` | 213 | 1337 | 84.1% |
-  | `internal/pullapi` | 179 | 673 | 73.4% |
+  | `internal/pullapi` | 183 | 754 | 75.7% |
 
-  Reaching 80% needs roughly **690 more covered statements**. `internal/config` and `internal/mcp` are the tractable bulk (parser and handler edge cases). `internal/app` is still the largest percentage gap and still the hardest: what remains uncovered there is concentrated in `run.go` startup paths that need a real server bring-up, which is where every coverage pass so far has deliberately stopped. The v2.12.0 delta is the argument for the approach that works — extract the logic into a function that takes its inputs as arguments, as `resolveClientIP` and `pollConfig` do, rather than trying to test `run()`.
+  Reaching 80% needs roughly **670 more covered statements**. `internal/config` and `internal/mcp` are the tractable bulk (parser and handler edge cases). `internal/app` is still the largest percentage gap and still the hardest: what remains uncovered there is concentrated in `run.go` startup paths that need a real server bring-up, which is where every coverage pass so far has deliberately stopped. The approach that works is still the one v2.12.0 demonstrated — extract the logic into a function that takes its inputs as arguments, as `resolveClientIP` and `pollConfig` do, rather than trying to test `run()`; v2.13.0's `identifyPullToken`, `adminPullConsumers` and `compileConsumerGroups` were written that way for the same reason.
 
 - [ ] **Publish a reachable coverage report** — awesome-go requires a Codecov or Coveralls link that resolves. CI computes a profile and uploads it, but only as a workflow artifact (`ci.yml`, `actions/upload-artifact` name `coverage`): that expires, needs a signed-in session, and is not a report — so there is no durable link to submit. Needs a coverage service wired into CI plus a README badge. Two things to fix while doing it: the `test` job does not set `HOOKAIDO_TEST_POSTGRES_DSN`, so the uploaded profile understates coverage the same way a local `make test-pg`-less run does, and it excludes nothing, so it counts generated protobuf. This is the one remaining awesome-go blocker fully in our control besides the 80% number itself.
 - [ ] **pkg.go.dev doc coverage** — Ensure all public types and functions have Go-style doc comments.
@@ -39,6 +39,8 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
 - [ ] **VS Code LSP** — Language server backed by `config validate`/`config compile` for live diagnostics in the editor. Optional follow-up to the VS Code extension.
 
 ## Completed (move here when done)
+
+- [x] **Pull consumer groups and consumer visibility (#284, #285)** — Both issues came out of one investigation: two consumers on a competing-consumer pull queue split the traffic, and from inside either one that is indistinguishable from delivery loss because the ingress answers `202` for every event. `pull { consumer_group ... }` makes the fan-out topology expressible — one independent queue per group, one endpoint each under the pull path, targets `pull:<group>`, and the bare path deliberately retired with a `404` so an unmigrated consumer fails visibly. `GET /admin/pull/consumers` plus `pull_sse_connected`/`pull_sse_disconnected` at INFO make the accident diagnosable, naming the credential by its configured reference and never its value. Pull metrics gained a `consumer_group` label (empty for ungrouped routes, which Prometheus treats as absent, so no existing series changed) and the metrics schema moved to 1.4.0. One PR per issue (#286, #287), each shipped with the docs stating the migration cost rather than only the feature.
 
 - [x] **Config-vs-reality gaps from the third review round (#273–#276)** — Four places where a Hookaidofile said one thing and the running process enforced another. `ingress { trusted_proxies }` so `match remote_ip` sees the client rather than the reverse proxy, instead of silently matching nothing or (once widened to the proxy subnet) everything. `--watch-interval` plus a `watch_may_not_fire` startup warning, because `--watch` cannot fire at all against a single-file bind mount — the shape `docs/docker.md` itself recommended. `auth query` as a first-class variant for event sources whose entire configuration surface is a URL, replacing the `match query` workaround that reported the route as unauthenticated and could not reach `secret_ref`. And constant-time comparison in `matchHeaderValues`/`matchQueryValues`, the one secret comparison in the project that still leaked timing. One PR per issue (#277–#280), each with the docs stating the honest limitation rather than only the fix.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.13.0] - 2026-08-31
+
+A release about one accident and the two things missing to deal with it. The
+Pull API is a competing-consumer queue, so two consumers on one route split the
+traffic — and from inside either one that is indistinguishable from delivery
+loss, because the ingress keeps answering `202` for every event. It closes
+[#284](https://github.com/nuetzliches/hookaido/issues/284) and
+[#285](https://github.com/nuetzliches/hookaido/issues/285), both reported from
+the same investigation.
+
+`pull { consumer_group ... }` makes the topology expressible where competing was
+never the intent, and `GET /admin/pull/consumers` plus the SSE lifecycle log
+lines make the accident diagnosable where it was not. `consumer_group` is the
+only new configuration surface and it is opt-in: a route without it is unchanged
+down to its queue target, which matters for messages already queued in a durable
+backend. The importable Go API is unchanged, so this stays on the `/v2` module
+path.
+
 ### Added
 
 - **`pull { consumer_group "<name>" }` fans one route out to several independent consumers.** The Pull API is a competing-consumer work queue — each message is leased to exactly one consumer — which is right for scaling workers and makes one topology impossible to express: one inbound source, several consumers that each need every message. That is not exotic; it is what you get whenever the source cannot be configured to deliver more than once, which covers appliances and telephony systems that hold exactly one webhook URL, older ERP systems, and anything whose URL is set in a vendor portal. Two environments attached to such a queue silently split the traffic, and from inside either one that is indistinguishable from delivery loss: the ingress answers `202` for every event and each side sees a fluctuating fraction arrive. Declaring consumer groups gives the route one independent queue per group — every inbound event is enqueued once per group — with its own endpoint at `pull_api.prefix + pull.path + "/" + name`. Semantics inside a group are unchanged, so workers still compete within a group while groups fan out. **The bare pull path stops resolving once groups exist** and answers `404 route_not_found`: silently keeping it would leave an unmigrated consumer taking a share of a queue it was meant to receive in full, which is the exact failure the feature exists to prevent, so it has to fail visibly instead. Group names must match `^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$`, be unique per route, and not collide with a Pull API operation name. Groups are a fan-out of one route, not an authorization boundary — they share the route's pull credentials and can settle each other's leases, and the docs say so. A route without groups is unchanged down to its queue target, so nothing moves for existing configs or for messages already queued in a durable backend. One consequence worth knowing before you add groups to a live route: `POST /admin/messages/publish` auto-selects a target only for a single-target route, so publishing to a grouped route now requires an explicit `target` of `pull:<group>` and is rejected with `target_unresolvable` otherwise. Covered by the MCP config tools (`consumer_group_count` in the config-compile summary). ([#284](https://github.com/nuetzliches/hookaido/issues/284))

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Development Status
 
-Last updated: 2026-08-26
-Current release: v2.12.0
+Last updated: 2026-08-31
+Current release: v2.13.0
 
 Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change history: `CHANGELOG.md`. Prioritized work items: `BACKLOG.md`.
 
@@ -17,7 +17,7 @@ Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change histo
 
 **Config DSL** - Caddyfile-inspired syntax with `config fmt` round-trip stability. Env/file/vars placeholders, multi-value directives, hot reload via `--watch`/`SIGHUP` (with an optional `--watch-interval` content poll for mounts that cannot deliver file events), and channel-type wrappers. Defaults blocks for egress policy, deliver settings, publish policy, and trend signal tuning. Secret refs support `env:`, `file:`, `vault:`, and `raw:`.
 
-**Observability** - Structured JSON logs (access + runtime), Prometheus metrics endpoint, OpenTelemetry tracing (OTLP/HTTP), and health diagnostics with trend signals.
+**Observability** - Structured JSON logs (access + runtime), Prometheus metrics endpoint, OpenTelemetry tracing (OTLP/HTTP), and health diagnostics with trend signals. Pull consumers are identifiable rather than only countable: an Admin API listing of the SSE streams attached to each route, and connect/disconnect log lines, both naming the credential by its configured reference and never its value.
 
 **Release** - Cross-platform archives, signed checksums (Ed25519), SPDX SBOM, GitHub provenance/SBOM attestations, and `hookaido verify-release` CLI.
 


### PR DESCRIPTION
## Summary

Release prep for **v2.13.0**. Closes #284 and #285, which came out of one investigation and shipped as one PR each (#286, #287).

- **CHANGELOG** — `Unreleased` cut into a `2.13.0` section with a lead paragraph naming the shared cause: the Pull API is a competing-consumer queue, so two consumers on one route split the traffic, and from inside either one that is indistinguishable from delivery loss.
- **STATUS** — `Current release: v2.13.0`, `Last updated: 2026-08-31`, plus the two capability lines that actually changed: consumer groups under Queue & Delivery, consumer identification under Observability.
- **BACKLOG** — coverage refreshed against a real `make cover` run (compose Postgres up, full profile, torn down again), and the round moved to Completed.

**Version choice:** minor. Everything is additive and no existing deployment changes behavior — the retired bare pull path only applies to a route that opts into `consumer_group`, and the new `consumer_group` metric label is empty for ungrouped routes, which Prometheus treats as an absent label. The `hookaido_metrics_schema_info` bump to `1.4.0` is a metrics-schema version, not a SemVer statement. The importable Go API is unchanged, so this stays on the `/v2` module path.

## Related Issues

Closes #284
Closes #285

## Scope

- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [x] Documentation only
- [ ] CI / release pipeline

## Coverage

77.1% → **77.2%**, measured with the compose Postgres DSN so the Postgres integration tests actually run.

Essentially flat, which is the honest reading of a release that added roughly 380 production statements: the #284/#285 work came with enough tests to hold the line, not to move it. Two movements worth naming rather than averaging away:

- `internal/pullapi` **73.4% → 75.7%** — the consumer registry, `BearerTokenIdentifier` and the group resolution are plain functions over their arguments, so they are directly testable. This is the approach the backlog item has been recommending for three releases.
- `internal/mcp` **77.5% → 77.1%** — a real dip, recorded rather than smoothed over. `pull_consumers` is Admin-proxy-only by construction (an SSE connection is not durable queue state, so there is no local SQLite path to fall back to), which means its handler has no branch a unit test reaches without standing up an Admin API. It is currently covered only through the tool-registry tests.

Remaining to 80%: ~670 statements.

## Validation

- [x] `go test ./...` passed locally, including Postgres integration tests via `docker-compose.test.yml`
- [ ] Added or updated tests for behavioral changes — n/a, docs only
- [x] Updated docs for user-visible changes — done in #286/#287; this PR is the release cut
- [x] Updated `CHANGELOG.md`
- [x] Updated `BACKLOG.md` / `STATUS.md`

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed — n/a
- [x] Backward compatibility considered — see the version-choice note above

## Notes for Reviewers

After merge the tag `v2.13.0` goes on the merged `origin/main` state, which triggers GitHub Releases and GHCR publishing.
