### PR TITLE
test(app): stop racing pollConfig's settle window

### DIFF
--- a/internal/app/watch_poll_test.go
+++ b/internal/app/watch_poll_test.go
@@ -311,7 +311,17 @@ func TestPollConfig_ReportsOnlyTheSettledContent(t *testing.T) {
 		seen <- string(data)
 	})
 
-	// Write the new config in pieces, slowly enough that a poll lands inside it.
+	// Write the new config in pieces, slowly enough that a poll lands inside it
+	// (the gap exceeds the poll interval) but fast enough that the file is still
+	// changing across a settle window.
+	//
+	// The gap is a fraction of pollSettleDelay rather than a bare duration,
+	// because the relationship is the whole assumption of the test: at a flat
+	// 120ms against a 200ms settle the margin was thin enough that a loaded
+	// `-race` runner could stretch one sleep past the window, at which point the
+	// poller correctly reported settled partial content and the test blamed it
+	// for a stall in the writer.
+	const chunkGap = pollSettleDelay / 5
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("create: %v", err)
@@ -323,7 +333,7 @@ func TestPollConfig_ReportsOnlyTheSettledContent(t *testing.T) {
 		if err := f.Sync(); err != nil {
 			t.Fatalf("sync: %v", err)
 		}
-		time.Sleep(120 * time.Millisecond)
+		time.Sleep(chunkGap)
 	}
 	if err := f.Close(); err != nil {
 		t.Fatalf("close: %v", err)


### PR DESCRIPTION
`TestPollConfig_ReportsOnlyTheSettledContent` failed on CI in the run for #291 — a PR that only deletes a stray crash dump — so the failure is the test, not the change.

## Diagnosis

The test writes the config in three chunks 120ms apart and asserts the poller never reports a partial file. `pollSettleDelay` is 200ms, so the assertion holds only while the writer stays faster than the settle window: an 80ms margin. A loaded `-race` runner can eat that. One stretched `time.Sleep(120ms)` and the file genuinely does hold still across a settle window, so `readSettledConfigHash` correctly reports settled partial content — and the test blames the poller for a stall in its own writer.

## Fix

Express the inter-chunk gap as `pollSettleDelay / 5` rather than a bare 120ms. The relationship between the two is the entire assumption of the test, so it should be visible in the source and should track the constant instead of drifting from it. At 40ms the gap still exceeds the 20ms poll interval, so a poll still lands inside a partial write — the case under test — now with a 5x margin instead of 1.7x.

Verified with `-count=30` on the case.

Test-only, so no CHANGELOG entry.

## Related finding, not fixed here

`TestPollConfig_RepeatedIdenticalRewritesAreNotChanges` in the same file is a latent flake of a different kind: it hammers 40 in-place `os.WriteFile` rewrites, each of which truncates before writing, and asserts that no reload is ever reported. The settle re-read makes a spurious reload *unlikely* — both reads, 200ms apart, would have to land in a truncation window — but not impossible, so the test asserts an absolute over a probabilistic property. It reproduced once locally at `-count=20` with the other poll tests running alongside, and not at all at `-count=30` in isolation, so it is load-dependent.

The clean fix is in production code rather than the test: have `readSettledConfigHash` ignore an empty read, since a truncation window is an artifact of someone else's write and an empty Hookaidofile is never a config worth reloading (a reload would be rejected by validation anyway, so only a spurious log line is at stake). Left out of this PR deliberately — that is a behavior change and this one is test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
