### PR TITLE
chore(release): prepare v2.14.0

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -4,24 +4,26 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
 
 ## P1 - Medium Priority (awesome-go readiness, target: July 2026)
 
-- [ ] **Test coverage ≥80%** — 77.2% as of v2.13.0, measured with `make cover` (needs `HOOKAIDO_TEST_POSTGRES_DSN`; see `docker-compose.test.yml`). Generated protobuf code is excluded — 292 never-hand-tested statements say nothing about the code we write.
+- [ ] **Test coverage ≥80%** — 77.3% as of v2.14.0, measured with `make cover` (needs `HOOKAIDO_TEST_POSTGRES_DSN`; see `docker-compose.test.yml`). Generated protobuf code is excluded — 292 never-hand-tested statements say nothing about the code we write.
 
-  Essentially flat against v2.12.0's 77.1%, which is the honest reading of a release that added roughly 380 production statements: the #284/#285 work came with enough tests to hold the line, not to move it. `internal/pullapi` is the one real gain (73.4% → 75.7%) — the consumer registry and the group resolution are plain functions over their arguments, so they are directly testable. `internal/mcp` went the other way (77.5% → 77.1%): `pull_consumers` is Admin-proxy-only by construction, so its handler has no local path a unit test can exercise without standing up an Admin API, and it is currently covered only through the tool-registry tests.
+  Up a tenth of a point against v2.13.0's 77.2%, and the per-package movement says more than the total does: #289 added about 130 production statements and 7 uncovered ones, so the new code landed at roughly 95% covered. That is what holding the line looks like when a release is small — it neither moves the number nor loses ground to it.
+
+  `internal/queue` is the one package that improved in both directions (84.1% → 84.6%, four *fewer* uncovered statements across twenty more total): the backlog breakdown and the top-N reduction are plain functions over their arguments, and the cross-backend contract test exercises them on all three stores at once. `internal/app` moved 64.8% → 65.4% only because the metric folding was extracted into `queueRouteDepthSeries` rather than written inline in the scrape handler — the new `run.go` wiring (`adoptRunning`, the startup `setKnownQueues`) sits in the same untested startup path as everything else there.
 
   Ranked by uncovered statements, which is what actually moves the total — a package at 64% with 1,200 uncovered statements matters far more than one at 64% with 40:
 
   | Package | Uncovered | Total | % |
   | --- | ---: | ---: | ---: |
   | `internal/config` | 1248 | 5900 | 78.8% |
-  | `internal/app` | 1202 | 3416 | 64.8% |
+  | `internal/app` | 1207 | 3491 | 65.4% |
   | `internal/mcp` | 949 | 4153 | 77.1% |
   | `internal/admin` | 543 | 2633 | 79.4% |
-  | `modules/sqlite` | 432 | 1693 | 74.5% |
-  | `modules/postgres` | 301 | 1293 | 76.7% |
-  | `internal/queue` | 213 | 1337 | 84.1% |
+  | `modules/sqlite` | 433 | 1708 | 74.6% |
+  | `modules/postgres` | 301 | 1311 | 77.0% |
+  | `internal/queue` | 209 | 1357 | 84.6% |
   | `internal/pullapi` | 183 | 754 | 75.7% |
 
-  Reaching 80% needs roughly **670 more covered statements**. `internal/config` and `internal/mcp` are the tractable bulk (parser and handler edge cases). `internal/app` is still the largest percentage gap and still the hardest: what remains uncovered there is concentrated in `run.go` startup paths that need a real server bring-up, which is where every coverage pass so far has deliberately stopped. The approach that works is still the one v2.12.0 demonstrated — extract the logic into a function that takes its inputs as arguments, as `resolveClientIP` and `pollConfig` do, rather than trying to test `run()`; v2.13.0's `identifyPullToken`, `adminPullConsumers` and `compileConsumerGroups` were written that way for the same reason.
+  Reaching 80% needs roughly **646 more covered statements**. `internal/config` and `internal/mcp` are the tractable bulk (parser and handler edge cases). `internal/app` is still the largest percentage gap and still the hardest: what remains uncovered there is concentrated in `run.go` startup paths that need a real server bring-up, which is where every coverage pass so far has deliberately stopped. The approach that works is still the one v2.12.0 demonstrated — extract the logic into a function that takes its inputs as arguments, as `resolveClientIP` and `pollConfig` do, rather than trying to test `run()`; v2.13.0's `identifyPullToken`, `adminPullConsumers` and `compileConsumerGroups` were written that way for the same reason.
 
 - [ ] **Publish a reachable coverage report** — awesome-go requires a Codecov or Coveralls link that resolves. CI computes a profile and uploads it, but only as a workflow artifact (`ci.yml`, `actions/upload-artifact` name `coverage`): that expires, needs a signed-in session, and is not a report — so there is no durable link to submit. Needs a coverage service wired into CI plus a README badge. Two things to fix while doing it: the `test` job does not set `HOOKAIDO_TEST_POSTGRES_DSN`, so the uploaded profile understates coverage the same way a local `make test-pg`-less run does, and it excludes nothing, so it counts generated protobuf. This is the one remaining awesome-go blocker fully in our control besides the 80% number itself.
 - [ ] **pkg.go.dev doc coverage** — Ensure all public types and functions have Go-style doc comments.
@@ -39,6 +41,8 @@ Prioritized work items for Hookaido. Items are grouped by priority tier and roug
 - [ ] **VS Code LSP** — Language server backed by `config validate`/`config compile` for live diagnostics in the editor. Optional follow-up to the VS Code extension.
 
 ## Completed (move here when done)
+
+- [x] **Per-queue backlog gauges (#289)** — Every queue gauge was instance-global, so a stalled route was invisible beside a busy one: a low-volume route whose consumer had gone away accumulated for ten hours while `hookaido_queue_depth` showed nothing unusual and `hookaido_queue_oldest_queued_age_seconds` could not name the route. `hookaido_queue_route_depth{route,consumer_group,state}` plus the matching `_oldest_queued_age_seconds` and `_ready_lag_seconds` families make the join against `hookaido_pull_sse_connection_active` writable, which is the alert the report was actually missing. New names rather than a `route` label on the aggregates, because labeled and unlabeled series in one family would have doubled every existing `sum()`; `consumer_group` is in the label set so a stalled group cannot hide behind a busy one on the same route. Store side, `queue.Stats` gained a complete per-`(route, target)` breakdown and `TopQueued` is now derived from it in all three backends — one query where there were two, so the two views cannot disagree across a concurrent write, and a route below the top-N cut is no longer a blind spot one level down. Shipped with the consumer's half of the keepalive story in `docs/pull-api.md`, since a half-open SSE stream is where the incident began. One PR (#290); metrics schema 1.5.0.
 
 - [x] **Pull consumer groups and consumer visibility (#284, #285)** — Both issues came out of one investigation: two consumers on a competing-consumer pull queue split the traffic, and from inside either one that is indistinguishable from delivery loss because the ingress answers `202` for every event. `pull { consumer_group ... }` makes the fan-out topology expressible — one independent queue per group, one endpoint each under the pull path, targets `pull:<group>`, and the bare path deliberately retired with a `404` so an unmigrated consumer fails visibly. `GET /admin/pull/consumers` plus `pull_sse_connected`/`pull_sse_disconnected` at INFO make the accident diagnosable, naming the credential by its configured reference and never its value. Pull metrics gained a `consumer_group` label (empty for ungrouped routes, which Prometheus treats as absent, so no existing series changed) and the metrics schema moved to 1.4.0. One PR per issue (#286, #287), each shipped with the docs stating the migration cost rather than only the feature.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [2.14.0] - 2026-09-01
+
+A release about one blind spot in the metrics. Every queue gauge was
+instance-global, which is adequate on a single-route instance and quietly
+useless on a multi-route one: when a low-volume route's consumer went away, its
+backlog was numerically invisible in `hookaido_queue_depth` beside a busy
+route's normal working set, and `hookaido_queue_oldest_queued_age_seconds` said
+an item was hours old without saying which route it belonged to. The only
+per-route evidence was an *absence* — no `ack` lines for that route in the
+access log from one point in the night onwards — and an absence is not something
+you can alert on. It closes
+[#289](https://github.com/nuetzliches/hookaido/issues/289).
+
+The queue gauges now also come in per-queue form, labeled `route` and
+`consumer_group` to match the `hookaido_pull_*` families, which makes the
+conjunction that actually matters expressible for the first time: items queued on
+a route with no consumer attached to it. The instance-global gauges are
+unchanged, deliberately — a `route` label on them would have made every existing
+`sum()` report double — so no existing dashboard moves. The Pull API docs gained
+the consumer's half of the keepalive story, which is where this failure mode
+starts: a half-open stream returns no error and no EOF, so a consumer that never
+checks for silence waits forever.
+
 ### Added
 
 - **Per-queue backlog gauges: `hookaido_queue_route_depth{route,consumer_group,state}`, `hookaido_queue_route_oldest_queued_age_seconds{route,consumer_group}` and `hookaido_queue_route_ready_lag_seconds{route,consumer_group}`.** Every queue gauge was instance-global, which made a stalled route invisible beside a busy one: when a low-volume route's consumer went away without noticing — sitting in a read on a half-open connection while the server's keepalive writes failed — items piled up on that route for hours while ingress kept answering `202`, and a second, continuously busy route drained normally the whole time. `hookaido_queue_depth{state="queued"}` could not show it, because that route's backlog is numerically invisible next to the busy route's normal working set, and `hookaido_queue_oldest_queued_age_seconds` said an item was hours old without saying *which* route it belonged to. The only per-route evidence was an absence — no `POST /<route>/ack` lines in the access log from one point in the night onwards — and an absence is not something you can alert on. With the route on both sides, the alert that matters becomes writable: `hookaido_queue_route_depth{state="queued"} > 0 and on (route, consumer_group) hookaido_pull_sse_connection_active == 0`. The label set matches the `hookaido_pull_*` families exactly, `consumer_group` included, because on a route with consumer groups a route-only label would hide a stalled group behind a busy one — the same blind spot, one level down. A series is emitted for **every configured route**, including one whose queue is empty, so `== 0` is expressible and a vanished series means the route was reconfigured away rather than "all clear"; a route that is no longer configured but still holds items keeps reporting it. The store-side breakdown they are rendered from is complete, where `Stats.TopQueued` is a top-N cut that would have left a route below the cut with no series at all; `TopQueued` is now derived from that same breakdown, so the two views cannot disagree about a route the way two separate store queries could across a concurrent write. Cardinality stays bounded by the configured routes and their groups; a deliver route that fans out to several targets is one series per route, summing depth and reporting the worst target's age and lag. ([#289](https://github.com/nuetzliches/hookaido/issues/289))
@@ -645,7 +668,10 @@ broken or already insecure; the compiler now says so instead of starting anyway.
 - Mixed queue backends rejected at compile time.
 - Hot reload now correctly rejects changes to `defaults.max_body`, `defaults.max_headers`, and `defaults.publish_policy` (previously silently ignored).
 
-[Unreleased]: https://github.com/nuetzliches/hookaido/compare/v2.11.0...HEAD
+[Unreleased]: https://github.com/nuetzliches/hookaido/compare/v2.14.0...HEAD
+[2.14.0]: https://github.com/nuetzliches/hookaido/compare/v2.13.0...v2.14.0
+[2.13.0]: https://github.com/nuetzliches/hookaido/compare/v2.12.0...v2.13.0
+[2.12.0]: https://github.com/nuetzliches/hookaido/compare/v2.11.0...v2.12.0
 [2.11.0]: https://github.com/nuetzliches/hookaido/compare/v2.10.1...v2.11.0
 [2.10.1]: https://github.com/nuetzliches/hookaido/compare/v2.10.0...v2.10.1
 [2.10.0]: https://github.com/nuetzliches/hookaido/compare/v2.9.0...v2.10.0

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,7 +1,7 @@
 # Development Status
 
-Last updated: 2026-08-31
-Current release: v2.13.0
+Last updated: 2026-09-01
+Current release: v2.14.0
 
 Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change history: `CHANGELOG.md`. Prioritized work items: `BACKLOG.md`.
 
@@ -17,7 +17,7 @@ Lightweight project snapshot. Canonical spec: `DESIGN.md`. Detailed change histo
 
 **Config DSL** - Caddyfile-inspired syntax with `config fmt` round-trip stability. Env/file/vars placeholders, multi-value directives, hot reload via `--watch`/`SIGHUP` (with an optional `--watch-interval` content poll for mounts that cannot deliver file events), and channel-type wrappers. Defaults blocks for egress policy, deliver settings, publish policy, and trend signal tuning. Secret refs support `env:`, `file:`, `vault:`, and `raw:`.
 
-**Observability** - Structured JSON logs (access + runtime), Prometheus metrics endpoint, OpenTelemetry tracing (OTLP/HTTP), and health diagnostics with trend signals. Pull consumers are identifiable rather than only countable: an Admin API listing of the SSE streams attached to each route, and connect/disconnect log lines, both naming the credential by its configured reference and never its value.
+**Observability** - Structured JSON logs (access + runtime), Prometheus metrics endpoint, OpenTelemetry tracing (OTLP/HTTP), and health diagnostics with trend signals. Queue backlog is reported per queue as well as instance-wide, labeled by `route` and `consumer_group` so a stalled route is visible beside a busy one and can be joined against the pull connection gauge; every configured route gets a series, empty queue included. Pull consumers are identifiable rather than only countable: an Admin API listing of the SSE streams attached to each route, and connect/disconnect log lines, both naming the credential by its configured reference and never its value.
 
 **Release** - Cross-platform archives, signed checksums (Ed25519), SPDX SBOM, GitHub provenance/SBOM attestations, and `hookaido verify-release` CLI.
 
@@ -42,6 +42,6 @@ Current weighted implementation grade: **~95%**.
 ## What's Missing (MVP Core)
 
 - Runtime reload intentionally keeps restart-required edges for topology/startup-bound changes (listeners, API prefixes, dispatcher-affecting settings).
-- Test coverage is 76.9% against the 80% target tracked in `BACKLOG.md` (`make cover`, generated protobuf excluded). Ranked by uncovered statements, the gaps are `internal/config`, `internal/app`, `internal/mcp` and `internal/admin`; `internal/app` is the largest percentage gap and the hardest, since what is left are `run.go` startup paths needing a real server bring-up.
+- Test coverage is 77.3% against the 80% target tracked in `BACKLOG.md` (`make cover`, generated protobuf excluded). Ranked by uncovered statements, the gaps are `internal/config`, `internal/app`, `internal/mcp` and `internal/admin`; `internal/app` is the largest percentage gap and the hardest, since what is left are `run.go` startup paths needing a real server bring-up.
 
 See `BACKLOG.md` for prioritized next steps.


### PR DESCRIPTION
Closes #289, which shipped as one PR (#290). Two housekeeping PRs ride along in the same range: #291 (stop tracking a stray `bash.exe.stackdump`) and #292 (a CI flake in `TestPollConfig_ReportsOnlyTheSettledContent`). Neither is user-visible, so neither has a CHANGELOG entry.

## CHANGELOG

Cut the Unreleased entries into a `2.14.0` section with a lead paragraph on the release's theme — one blind spot in the metrics, and the alert it made impossible to write.

Also repaired the compare links while in there: `[Unreleased]` still pointed at `v2.11.0...HEAD`, and the refs for `2.12.0` and `2.13.0` had never been added, so two releases' worth of links resolved to nothing.

## STATUS

- `Current release: v2.14.0`, `Last updated: 2026-09-01`.
- One capability line changed — **Observability**, for the per-queue backlog reporting.
- The coverage figure in "What's Missing" said 76.9%, which was two releases stale. Now 77.3%, matching BACKLOG.

## BACKLOG

Coverage refreshed against a real run (`go test -p 1 -coverprofile` with the compose Postgres on :5433, then `scripts/coverage-report.sh`), and the round moved to Completed.

| | v2.13.0 | v2.14.0 |
| --- | ---: | ---: |
| **total** | 77.2% | **77.3%** |
| `internal/queue` | 84.1% (213 uncovered / 1337) | 84.6% (209 / 1357) |
| `internal/app` | 64.8% (1202 / 3416) | 65.4% (1207 / 3491) |
| `modules/postgres` | 76.7% (301 / 1293) | 77.0% (301 / 1311) |
| `modules/sqlite` | 74.5% (432 / 1693) | 74.6% (433 / 1708) |

The total moves a tenth of a point, which is what it looks like when a release adds ~130 production statements and 7 uncovered ones — the new code landed around 95% covered. `internal/queue` is the figure worth reading: four *fewer* uncovered statements across twenty more total, because the backlog breakdown and the top-N reduction are plain functions over their arguments and one contract test exercises them on all three backends at once. `internal/app` moved only because the metric folding was extracted into `queueRouteDepthSeries` instead of being written inline in the scrape handler; the new `run.go` wiring sits in the same untested startup path as everything else there. Remaining distance to the 80% target: ~646 covered statements.

## Tag

`v2.14.0`, after this merges. Not pushed yet — the tag triggers GitHub Releases and GHCR publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
