### PR TITLE
fix(app): never report a truncated config file as a config change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Fixed
+
+- **`--watch-interval` no longer reports a truncated config file as a config change.** A plain overwrite truncates before writing, so a poll can read a zero-byte file that nobody meant as a config. The settle re-read made that unlikely rather than impossible: two reads a settle window apart can both land in a truncation window, at which point an empty file has demonstrably "held still" and was reported as settled content. The reload that followed was rejected by the parser as `empty config`, so the visible effect was a `config_reload_failed` at ERROR against a config the operator never wrote — misleading precisely when someone is looking at the log to find out why a deploy did not take. An empty read is now sat out until there is content to parse; the running config stays in place either way, including for a genuinely emptied Hookaidofile, which could not have been loaded in the first place. The same window is what made `TestPollConfig_RepeatedIdenticalRewritesAreNotChanges` fail about one run in twenty under load.
+
 ## [2.14.0] - 2026-09-01
 
 A release about one blind spot in the metrics. Every queue gauge was

--- a/internal/app/watch_poll.go
+++ b/internal/app/watch_poll.go
@@ -85,6 +85,22 @@ func readSettledConfigHash(ctx context.Context, path string, logger *slog.Logger
 		logger.Warn("poll_config_failed", slog.Any("err", err))
 		return "", false
 	}
+	// A plain overwrite truncates before writing, so a read can land on a
+	// zero-byte file that nobody meant as a config. The settle re-read makes
+	// that unlikely rather than impossible: with enough rewrites, both reads
+	// eventually land in a truncation window, and an empty file that "held
+	// still" was then reported as a settled change. The parser rejects it as
+	// `empty config`, so the only trace was a spurious config_reload_failed
+	// against a config the operator never wrote.
+	//
+	// Waiting for content is the honest reading of an empty file here: it is an
+	// artifact of someone else's write, and a genuinely emptied Hookaidofile
+	// could not be loaded either -- the running config stays in place in both
+	// cases, so nothing actionable is lost by staying quiet until there is
+	// something to parse.
+	if len(first) == 0 {
+		return "", false
+	}
 
 	timer := time.NewTimer(pollSettleDelay)
 	defer timer.Stop()

--- a/internal/app/watch_poll_test.go
+++ b/internal/app/watch_poll_test.go
@@ -246,11 +246,72 @@ func TestRun_WatchIntervalBelowMinimumIsRejected(t *testing.T) {
 	}
 }
 
+// An empty read is an artifact of someone else's truncate, never a config. The
+// settle re-read alone could not establish that: two reads a settle window
+// apart can both land in a truncation window, which is how the hammering case
+// below came to fail roughly one run in twenty under load. This pins the part
+// that makes that case an absolute rather than a probability -- the file is
+// held empty across several settle windows, which the poller must sit out
+// entirely, and the real content that follows must still be reported.
+func TestPollConfig_IgnoresAnEmptyRead(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "Hookaidofile")
+	initial := []byte("# v1\nroute \"/x\" {}\n")
+	if err := os.WriteFile(path, initial, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	seen := make(chan string, 64)
+	go pollConfig(ctx, path, 20*time.Millisecond, initial, discardLogger(), func() {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			seen <- "read-error"
+			return
+		}
+		seen <- string(data)
+	})
+
+	if err := os.WriteFile(path, nil, 0o644); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	// Long enough that the poller has taken several settled reads of the empty
+	// file, so a report here is the guard failing rather than a lucky timing.
+	time.Sleep(3 * pollSettleDelay)
+	select {
+	case got := <-seen:
+		t.Fatalf("an empty config file was reported as a change: %q", got)
+	default:
+	}
+
+	want := "# v2\nroute \"/y\" {}\n"
+	if err := os.WriteFile(path, []byte(want), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	deadline := time.After(5 * time.Second)
+	for {
+		select {
+		case got := <-seen:
+			if got == want {
+				return
+			}
+			t.Fatalf("reported %q, want the content written after the empty window", got)
+		case <-deadline:
+			t.Fatal("the config written after the empty window was never reported")
+		}
+	}
+}
+
 // A plain overwrite truncates and then writes, so the file is briefly empty.
 // Without the settle re-read that showed up as a change -- and for a config
 // being rewritten with content that differs, as two: a rejected reload of the
 // half-written file followed by the real one. Hammering identical rewrites is
-// what reliably catches a regression of that.
+// what reliably catches a regression of that, and the empty-read guard covered
+// by TestPollConfig_IgnoresAnEmptyRead is what makes this assertion hold every
+// time rather than most of the time.
 func TestPollConfig_RepeatedIdenticalRewritesAreNotChanges(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "Hookaidofile")


### PR DESCRIPTION
The follow-up flagged in #292: the latent flake in `TestPollConfig_RepeatedIdenticalRewritesAreNotChanges` was a real, if rare, defect in the poller rather than a bad assertion.

## Mechanism

A plain overwrite (`os.WriteFile`, `> file`, most config deployers) truncates before writing, so a poll can read a zero-byte file. `readSettledConfigHash` re-reads after `pollSettleDelay` to reject content that is still moving, which makes that *unlikely* — but with enough rewrites both reads eventually land in a truncation window, and at that point the empty file has demonstrably held still and is reported as settled content.

What the operator saw was a `config_reload_failed` at ERROR, because `config.Parse` rejects an empty file with `empty config`:

```
ERROR config_reload_failed err="empty config" trigger=watch_interval
```

An error against a config nobody wrote, surfacing exactly when someone is reading the log to find out why a deploy did not take. Same window, same cause as the test failing about one run in twenty under load — the test asserted an absolute over a property that was only probable.

## Fix

Sit out an empty read until there is content to parse. That is the honest reading of an empty file in this position: it is an artifact of someone else's write, and a genuinely emptied Hookaidofile could not be loaded either — `Parse` rejects it — so the running config stays in place in both cases and nothing actionable is lost by staying quiet. The guard is deliberately on zero bytes only, not on whitespace- or comment-only content: those are something the operator wrote, and a rejected reload with a clear parse error is the right answer there.

Only the `--watch-interval` poll path is affected. The fsnotify `--watch` path debounces 200ms past the last event and re-reads at reload time, so it does not observe the window.

## Tests

`TestPollConfig_IgnoresAnEmptyRead` holds the file empty across three settle windows and asserts nothing is reported, then that the content written afterwards still is — so the guard cannot be satisfied by simply going deaf. Against the previous behaviour it fails with:

```
watch_poll_test.go:285: an empty config file was reported as a change: ""
```

`TestPollConfig_RepeatedIdenticalRewritesAreNotChanges` keeps its hammering, now with a comment pointing at what makes its assertion hold every time rather than most of the time. All nine `TestPollConfig` cases pass at `-count=15` (90s), where the pair previously reproduced a failure at `-count=20`.

CHANGELOG entry under Unreleased, since v2.14.0 is already tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
