### PR TITLE
test(app): judge a partial poll report against the writer's timeline

### DIFF
--- a/internal/app/watch_poll_test.go
+++ b/internal/app/watch_poll_test.go
@@ -376,17 +376,20 @@ func TestPollConfig_ReportsOnlyTheSettledContent(t *testing.T) {
 	// (the gap exceeds the poll interval) but fast enough that the file is still
 	// changing across a settle window.
 	//
-	// The gap is a fraction of pollSettleDelay rather than a bare duration,
-	// because the relationship is the whole assumption of the test: at a flat
-	// 120ms against a 200ms settle the margin was thin enough that a loaded
-	// `-race` runner could stretch one sleep past the window, at which point the
-	// poller correctly reported settled partial content and the test blamed it
-	// for a stall in the writer.
+	// The gap is a fraction of pollSettleDelay rather than a bare duration, but
+	// the gap alone cannot carry the test: a loaded `-race` runner can stretch
+	// one of these sleeps past the settle window whatever it is set to, and then
+	// a prefix really did hold still. So record when each chunk hit the disk and
+	// judge a partial report against that timeline below, instead of assuming
+	// the sleeps were timely.
 	const chunkGap = pollSettleDelay / 5
 	f, err := os.Create(path)
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
+	var prefixes []string
+	var writtenAt []time.Time
+	content := ""
 	for _, chunk := range []string{"# v2\n", "route \"/a\" {}\n", "route \"/b\" {}\n"} {
 		if _, err := f.WriteString(chunk); err != nil {
 			t.Fatalf("write chunk: %v", err)
@@ -394,13 +397,19 @@ func TestPollConfig_ReportsOnlyTheSettledContent(t *testing.T) {
 		if err := f.Sync(); err != nil {
 			t.Fatalf("sync: %v", err)
 		}
+		content += chunk
+		prefixes = append(prefixes, content)
+		writtenAt = append(writtenAt, time.Now())
 		time.Sleep(chunkGap)
 	}
 	if err := f.Close(); err != nil {
 		t.Fatalf("close: %v", err)
 	}
 
-	want := "# v2\nroute \"/a\" {}\nroute \"/b\" {}\n"
+	// The reports arrive through a buffered channel and are read only now that
+	// the writing goroutine is done with the timeline, so no synchronisation is
+	// needed around it.
+	want := prefixes[len(prefixes)-1]
 	deadline := time.After(5 * time.Second)
 	for {
 		select {
@@ -408,11 +417,31 @@ func TestPollConfig_ReportsOnlyTheSettledContent(t *testing.T) {
 			if got == want {
 				return
 			}
-			// Anything else means a partial state was reported as a config
-			// change, which is exactly what the settle exists to prevent.
+			// A partial state reported as a config change is exactly what the
+			// settle exists to prevent -- but only when the file demonstrably
+			// changed again inside the settle window, which is what makes the
+			// poller's two reads differ and the report premature. If the writer
+			// stalled longer than that after this prefix, the prefix genuinely
+			// settled: reporting it is correct, and the full config is still
+			// reported once it settles too.
+			if i := indexOfString(prefixes, got); i >= 0 && i+1 < len(writtenAt) {
+				if stall := writtenAt[i+1].Sub(writtenAt[i]); stall >= pollSettleDelay {
+					t.Logf("writer stalled %v after chunk %d, so %q had settled; still waiting for the full config", stall, i+1, got)
+					continue
+				}
+			}
 			t.Fatalf("reload observed a partial config: %q", got)
 		case <-deadline:
 			t.Fatal("the settled config was never reported")
 		}
 	}
+}
+
+func indexOfString(values []string, want string) int {
+	for i, v := range values {
+		if v == want {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
## Summary

`TestPollConfig_ReportsOnlyTheSettledContent` failed the `test (ubuntu-latest)` job on `main` for the v2.15.0 release commit ([run 33641652407](https://github.com/nuetzliches/hookaido/actions/runs/33641652407)) with `reload observed a partial config: "# v2\n"` — the first of three chunks. Nothing is wrong with `pollConfig`: when the runner stretches one of the test's inter-chunk sleeps past the 200 ms settle window, that prefix genuinely held still across two reads, so `readSettledConfigHash` is correct to report it, and the full config is still reported once it settles too. The test's assertion was absolute, so it could not tell that apart from a premature report and blamed the poller for a stall in its own writer.

The test now records when each chunk hit the disk and judges a reported prefix against that timeline: a prefix is a failure only when the *next* chunk followed it within `pollSettleDelay` — that is what makes the poller's two reads differ and the report premature. A longer gap means the writer stalled, the prefix legitimately settled, and the test logs that and keeps waiting for the settled content.

The timeline is appended by the test goroutine and read only after the writing loop finishes (reports queue in the 64-slot `seen` channel), so it needs no locking.

### Why not just widen the margin again

#292 already did exactly that, from a flat 120 ms to `pollSettleDelay / 5`, and left a comment at `internal/app/watch_poll_test.go:379` naming this hazard. A wider margin lowers the probability without removing the class — any margin can be eaten by a loaded `-race` runner — and the release commit hit it again. Making the test check what actually happened removes the class instead. The 40 ms gap stays as-is: it is still what puts a poll inside a partial write in the normal case.

## Related Issues

Closes #299

## Scope

- [x] CI / release pipeline
- [ ] DSL / config behavior
- [ ] Runtime behavior
- [ ] Admin or Pull API behavior
- [ ] MCP behavior
- [ ] Documentation only

## Validation

- [x] `go test ./...` passed locally
- [x] Added or updated tests for behavioral changes
- [ ] Updated docs for user-visible changes — test-only change, no user-visible behavior
- [ ] Updated `CHANGELOG.md` — same, matching #292 which was also test-file-only
- [ ] Updated `BACKLOG.md` / `STATUS.md` when applicable

Both directions were verified with a throwaway probe (not committed) that forces the stall the CI runner produced, writing chunk 2 a full `3 * pollSettleDelay` after chunk 1:

- With the old unconditional assertion it fails with the exact CI message, `reload observed a partial config: "# v2\n"`.
- With the new check it logs `writer stalled 601.9935ms after chunk 1, so "# v2\n" had settled; still waiting for the full config` and passes, three runs out of three.

And the guard still bites: against a `readSettledConfigHash` patched to return the first read's hash immediately — no settle at all — the fixed test fails on every one of three runs.

`TestPollConfig*` also ran 20× in a row clean, and the full package and `go test ./...` are green. `-race` could not run locally (no cgo toolchain on this machine); CI covers it.

## Security and Operations

- [x] No secrets or credentials committed
- [x] Auth/policy implications reviewed (if applicable) — none, test-only
- [x] Backward compatibility considered — no production code touched

## Notes for Reviewers

One thing this test does not pin, before and after this change: a `pollConfig` that keeps the 200 ms wait but drops the hash *comparison* still passes it, because the wait alone defers the read past the end of the write. The scenario is aimed at the wait, and `TestPollConfig_IgnoresAnEmptyRead` covers the read-comparison side; worth knowing if the settle logic is ever refactored.
